### PR TITLE
Implement Initial Continuous Integration Workflow Using GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,33 +1,33 @@
-name: Github Stars to Slack
+name: Continuous Integration
 
-on: 
-  watch:
-    types: [started]
+on: [push]
 
 jobs:
-  celebrate:
-    name: Celebrate
-    runs-on: [ubuntu-latest]
-    steps: 
-    - uses: 8398a7/action-slack@v2
-      with:
-        status: custom
-        payload: | 
-           {
-            text: "GitHub Stargazer",
-            blocks: [{
-               "type": "section", 
-               "text": {
-                 "type": "mrkdwn",
-                 "text": "✨New Star from *<${{github.event.sender.url}}|${{ github.actor }}>*!✨\n\n Hot dog! You now have *${{ github.event.repository.stargazers_count }}* stargazers! Keep up the good work!!" 
-                 },
-               "accessory": {
-                 "type": "image",
-                 "image_url": "${{ github.event.sender.avatar_url }}",
-                 "alt_text": "${{ github.actor }} avatar"
-               } 
-               }]
-           }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }} # required
-      if: always() # P
+  build_and_test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.16.1'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache Node.js modules
+        id: yarn-cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --silent
+        env:
+          CI: true
+      - name: Test Blitz Packages
+        run: yarn test
+        env:
+          CI: true

--- a/.github/workflows/stars_to_slack.yml
+++ b/.github/workflows/stars_to_slack.yml
@@ -1,0 +1,33 @@
+name: Github Stars to Slack
+
+on: 
+  watch:
+    types: [started]
+
+jobs:
+  celebrate:
+    name: Celebrate
+    runs-on: [ubuntu-latest]
+    steps: 
+    - uses: 8398a7/action-slack@v2
+      with:
+        status: custom
+        payload: | 
+           {
+            text: "GitHub Stargazer",
+            blocks: [{
+               "type": "section", 
+               "text": {
+                 "type": "mrkdwn",
+                 "text": "✨New Star from *<${{github.event.sender.url}}|${{ github.actor }}>*!✨\n\n Hot dog! You now have *${{ github.event.repository.stargazers_count }}* stargazers! Keep up the good work!!" 
+                 },
+               "accessory": {
+                 "type": "image",
+                 "image_url": "${{ github.event.sender.avatar_url }}",
+                 "alt_text": "${{ github.actor }} avatar"
+               } 
+               }]
+           }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }} # required
+      if: always() # P

--- a/package.json
+++ b/package.json
@@ -15,10 +15,7 @@
     "lerna": "lerna",
     "lerna-prepare": "lerna run prepare",
     "start": "lerna exec --parallel -- yarn start",
-    "test": "npm-run-all -s lint jest test:peril",
-    "test:coverage": "jest --coverage",
-    "test:update": "jest --updateSnapshot",
-    "test:watch": "jest --watch"
+    "test": "lerna exec --parallel -- yarn test"
   },
   "devDependencies": {
     "cross-env": "^7.0.0",


### PR DESCRIPTION
This PR implements basic CI using GitHub actions. As it is presently configured, the service will use `yarn`, cache dependencies for faster execution times, and run any/all tests in lerna-enabled packages. This will occur on all `push` events. 

Eventually, once we come with a release workflow, formalize our GitFlow, etc., we'll want to tweak this service to be more nuanced. For now, this should do nicely. 