### PR TITLE
fix(core): Add support for multiple attribute types for id

### DIFF
--- a/examples/first-demo/controllers/comments.ts
+++ b/examples/first-demo/controllers/comments.ts
@@ -15,7 +15,7 @@ export const CommentsController = Controller(({db}) => ({
       data: {
         ...newData,
         post: {
-          connect: {id: parseInt(params.query.postId)},
+          connect: {id: params.query.postId},
         },
       },
     })

--- a/packages/core/src/controller.ts
+++ b/packages/core/src/controller.ts
@@ -45,7 +45,7 @@ export const harnessController = (Controller: ControllerInstance) => async (
 
   const stringId = req.query && (Array.isArray(req.query.id) ? req.query.id[0] : req.query.id)
   delete req.query.id
-  const id = isNaN(parseInt(stringId)) ? null : parseInt(stringId)
+  const id = stringId ? (isNaN(Number(stringId)) ? stringId : parseInt(stringId)) : null
 
   const params = {id, query: req.query}
   const data = req.body || {}

--- a/packages/core/src/controller.ts
+++ b/packages/core/src/controller.ts
@@ -50,6 +50,9 @@ export const harnessController = (Controller: ControllerInstance) => async (
 
   const stringId = req.query && (Array.isArray(req.query.id) ? req.query.id[0] : req.query.id)
   delete req.query.id
+
+  // We need to check which attribute type for ID is used (cuid, uuid, autoincrement)
+  // It could be a string, number of null
   const id = stringId ? (isNaN(Number(stringId)) ? stringId : parseInt(stringId)) : null
 
   const params = {id, query: req.query}

--- a/packages/core/test/controller-fixtures.ts
+++ b/packages/core/test/controller-fixtures.ts
@@ -45,6 +45,16 @@ const RedirectController = Controller(() => ({
   },
 }))
 
+export const SpyController = Controller(() => ({
+  name: 'SpyController',
+  index: jest.fn(),
+  show: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+}))
+
 export const unstable_getSimpleServerProps = harnessServerProps(SimpleController)
 export const unstable_getEmptyServerProps = harnessServerProps(EmptyController)
 export const unstable_getRedirectServerProps = harnessServerProps(RedirectController)
+export const unstable_getSpyServerProps = harnessServerProps(SpyController)

--- a/packages/core/test/controller.test.ts
+++ b/packages/core/test/controller.test.ts
@@ -5,9 +5,10 @@ describe('controller', () => {
     query: {},
     ...opts,
     req: {method: 'GET', url: '/', socket: {remoteAddress: 'testAddress'}, ...opts.req},
-    res: {status: jest.fn(), ...opts.res},
+    res: {status: jest.fn(), end: jest.fn(), ...opts.res},
   })
 
+  const createSpyRequest = (ctx: any) => fixtures.unstable_getSpyServerProps(ctx)
   const createSimpleRequest = (ctx: any) => fixtures.unstable_getSimpleServerProps(ctx)
   const createRedirectRequest = (ctx: any) => fixtures.unstable_getRedirectServerProps(ctx)
 
@@ -23,6 +24,24 @@ describe('controller', () => {
     const returning = (await createSimpleRequest(ctx)) as {props: any}
     expect(returning.props).toMatchObject({message: 'shown'})
     expect(ctx.res.status).toBeCalledWith(200)
+  })
+
+  it('simple show response with autoincrement', async () => {
+    const ctx = createContext({query: {id: 123}})
+    await createSpyRequest(ctx)
+    expect(fixtures.SpyController.show).toBeCalledWith({id: 123, query: {}}, {})
+  })
+
+  it('simple show response with cuid', async () => {
+    const ctx = createContext({query: {id: 'cjld2cjxh0000qzrmn831i7rn'}})
+    await createSpyRequest(ctx)
+    expect(fixtures.SpyController.show).toBeCalledWith({id: 'cjld2cjxh0000qzrmn831i7rn', query: {}}, {})
+  })
+
+  it('simple show response with uuid', async () => {
+    const ctx = createContext({query: {id: '786d378b-9296-4d32-9379-7d4dedd9c7fc'}})
+    await createSpyRequest(ctx)
+    expect(fixtures.SpyController.show).toBeCalledWith({id: '786d378b-9296-4d32-9379-7d4dedd9c7fc', query: {}}, {})
   })
 
   it('simple create response', async () => {

--- a/packages/core/types/controller.ts
+++ b/packages/core/types/controller.ts
@@ -1,7 +1,7 @@
 import {PrismaClient} from '@prisma/client'
 
 export interface ControllerParams extends Record<any, any> {
-  id: number | null
+  id: number | string | null
   query: Record<any, any>
 }
 


### PR DESCRIPTION
Support all default values for IDs:


- `String`:
  - `cuid`: Prisma will generate a globally unqiue identifier based on the [`cuid`](https://github.com/ericelliott/cuid) spec and set it as the record's ID value
  - `uuid`: Prisma will generate a globally unqiue identifier based on the [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) spec and set it as the record's ID value
- `Int`: 
  - `autoincrement`: Prisma will create a sequence of integers in the underlying database and assign the incremented values to the ID values of the created records based on the sequence. This corresponds to e.g. using [`SERIAL`](https://www.postgresql.org/docs/9.1/datatype-numeric.html#DATATYPE-SERIAL) in PostgreSQL.

Here are examples for using default values for the model:

```prisma
model User {
  id    String  @id @default(cuid())
  name  String
}
```

or

```prisma
model User {
  id    String  @id @default(uuid())
  name  String
}
```

or

```prisma
model User {
  id    Int     @id @default(autoincrement())
  name  String
}
```