### PR TITLE
feat(cli): use custom REPL in console command

### DIFF
--- a/packages/cli/src/commands/console.ts
+++ b/packages/cli/src/commands/console.ts
@@ -1,11 +1,19 @@
-import {Command} from '@oclif/command'
-import {spawn} from 'child_process'
+import { Command } from '@oclif/command'
+import { start } from 'repl'
 
 export default class Console extends Command {
   static description = 'Run project REPL'
   static aliases = ['c']
 
-  async run() {
-    spawn('node', {stdio: 'inherit'})
+  static replOptions = {
+    prompt: '⚡️>',
+    useColors: true
+  }
+
+  async run () {
+    this.log(`Welcome to Blitz.js v0.0.1
+Type ".help" for more information.`)
+
+    start(Console.replOptions)
   }
 }

--- a/packages/cli/test/commands/console.test.ts
+++ b/packages/cli/test/commands/console.test.ts
@@ -1,16 +1,20 @@
-import childProcess from 'child_process'
+import * as repl from 'repl'
 import ConsoleCmd from '../../src/commands/console'
 
-jest.mock('child_process')
+jest.mock('repl')
 
 describe('Console command', () => {
   beforeEach(() => {
     jest.resetAllMocks()
   })
 
-  it('runs node', async () => {
+  it('runs REPL', async () => {
+    jest.spyOn(ConsoleCmd.prototype, 'log')
+
     await ConsoleCmd.prototype.run()
 
-    expect(childProcess.spawn).toBeCalledWith('node', {stdio: 'inherit'})
+    expect(repl.start).toBeCalledWith(ConsoleCmd.replOptions)
+    expect(ConsoleCmd.prototype.log).toHaveBeenCalledWith(`Welcome to Blitz.js v0.0.1
+Type ".help" for more information.`)
   })
 })


### PR DESCRIPTION
I did some more digging and it seems that this would be a better solution for the REPL - it allows for more customization (custom prompt, additional helper commands) and it will be much simpler to autoload modules. 

What do you think @flybayer 