### PR TITLE
feat(core): Return 404 if controller action is not defined

### DIFF
--- a/packages/core/src/controller.ts
+++ b/packages/core/src/controller.ts
@@ -16,16 +16,21 @@ if (isServer) {
   db.connect()
 }
 
+const actionNotFound = () => ({
+  status: 404,
+  data: {},
+})
+
 export function Controller(getController: ControllerInput) {
   const controller = getController({db})
   return {
     name: controller.name,
     permit: controller.permit || [],
-    index: controller.index,
-    show: controller.show,
-    create: controller.create,
-    update: controller.update,
-    delete: controller.delete,
+    index: controller.index || actionNotFound,
+    show: controller.show || actionNotFound,
+    create: controller.create || actionNotFound,
+    update: controller.update || actionNotFound,
+    delete: controller.delete || actionNotFound,
   } as ControllerInstance
 }
 

--- a/packages/core/test/controller-fixtures.ts
+++ b/packages/core/test/controller-fixtures.ts
@@ -33,6 +33,10 @@ const SimpleController = Controller(() => ({
   },
 }))
 
+const EmptyController = Controller(() => ({
+  name: 'EmptyController',
+}))
+
 const RedirectController = Controller(() => ({
   name: 'RedirectController',
 
@@ -42,4 +46,5 @@ const RedirectController = Controller(() => ({
 }))
 
 export const unstable_getSimpleServerProps = harnessServerProps(SimpleController)
+export const unstable_getEmptyServerProps = harnessServerProps(EmptyController)
 export const unstable_getRedirectServerProps = harnessServerProps(RedirectController)

--- a/packages/core/test/controller.test.ts
+++ b/packages/core/test/controller.test.ts
@@ -73,4 +73,38 @@ describe('controller', () => {
     expect(ctx.res.setHeader).toBeCalledWith('Location', 'href')
     expect(ctx.res.setHeader).toBeCalledWith('x-as', 'as')
   })
+
+  describe('actions not defined', () => {
+    const createEmptyRequest = (ctx: any) => fixtures.unstable_getEmptyServerProps(ctx)
+
+    it('index returns 404', async () => {
+      const ctx = createContext()
+      await createEmptyRequest(ctx)
+      expect(ctx.res.status).toBeCalledWith(404)
+    })
+
+    it('show returns 404', async () => {
+      const ctx = createContext({query: {id: 123}})
+      await createEmptyRequest(ctx)
+      expect(ctx.res.status).toBeCalledWith(404)
+    })
+
+    it('create returns 404', async () => {
+      const ctx = createContext({req: {method: 'POST'}})
+      await createEmptyRequest(ctx)
+      expect(ctx.res.status).toBeCalledWith(404)
+    })
+
+    it('update returns 404', async () => {
+      const ctx = createContext({req: {method: 'PATCH'}})
+      await createEmptyRequest(ctx)
+      expect(ctx.res.status).toBeCalledWith(404)
+    })
+
+    it('delete returns 404', async () => {
+      const ctx = createContext({req: {method: 'DELETE'}})
+      await createEmptyRequest(ctx)
+      expect(ctx.res.status).toBeCalledWith(404)
+    })
+  })
 })


### PR DESCRIPTION
Closes #33 

This PR makes all the main actions (`index`, `show`, `create`, `update`, `delete`) have a [default implementation](https://github.com/camilo86/blitz/blob/camilo/404-controller-action/packages/core/src/controller.ts#L29-L33) that returns 404, so that unimplemented actions return 404.

Also adds tests to check that the default behavior in each of the controller actions return 404