### PR TITLE
feat(server): Errors respect file path redirection

### DIFF
--- a/packages/server/bin/next-patched
+++ b/packages/server/bin/next-patched
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('Hello')

--- a/packages/server/bin/next-patched
+++ b/packages/server/bin/next-patched
@@ -1,2 +1,5 @@
 #!/usr/bin/env node
-console.log('Hello')
+'use strict'
+
+require('@blitzjs/server/register')
+require('next/dist/bin/next')

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,8 +12,7 @@
     "start": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test",
-    "lint": "tsdx lint",
-    "prepare": "tsdx build"
+    "lint": "tsdx lint"
   },
   "peerDependencies": {},
   "husky": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -2,6 +2,9 @@
   "version": "0.0.1",
   "license": "MIT",
   "main": "dist/index.js",
+  "bin": {
+    "next-patched": "./bin/next-patched"
+  },
   "files": [
     "dist"
   ],

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -39,6 +39,8 @@
   "dependencies": {
     "next-compose-plugins": "2.2.0",
     "next-transpile-modules": "3.0.2",
+    "node-pty": "^0.9.0",
+    "pirates": "^4.0.1",
     "tsconfig-paths-webpack-plugin": "^3.2.0"
   }
 }

--- a/packages/server/register/index.js
+++ b/packages/server/register/index.js
@@ -1,0 +1,16 @@
+const addHook = require('pirates').addHook
+
+addHook(
+  function(code) {
+    const wrapCode =
+      '\n;module.exports = require("@blitzjs/server/register/launch-editor").enhance(_launchEditorFn);'
+    return code.replace('module.exports =', 'const _launchEditorFn =') + wrapCode
+  },
+  {
+    exts: ['.js'],
+    matcher: function(filename) {
+      return filename.match(/launch-editor\/index/)
+    },
+    ignoreNodeModules: false,
+  },
+)

--- a/packages/server/register/launch-editor.js
+++ b/packages/server/register/launch-editor.js
@@ -1,0 +1,15 @@
+// NOTE: This is here temporarily to support deep linking into this package
+// TODO: Incorporate this deep linked file into our TS build
+
+module.exports = {
+  enhance: function(launchEditor) {
+    return function(file, specifiedEditor, onErrorCallback) {
+      // TODO: Implement the following:
+      //       1. Load the compilation transform map from JSON
+      //       2. Run a reverse lookup of the compiled file to the original URL
+      // NOTE: Currently the following is hard coded as POC until we implement transformation rules
+      const tmpReplacementPoc = file.replace(/\/\.blitz\/caches\/dev/, '')
+      return launchEditor(tmpReplacementPoc, specifiedEditor, onErrorCallback)
+    }
+  },
+}

--- a/packages/server/register/launch-editor.js
+++ b/packages/server/register/launch-editor.js
@@ -1,4 +1,5 @@
-// NOTE: This is here temporarily to support deep linking into this package
+// NOTE: This is here to support deep linking into this package
+//       It would be nice to be able to write this code in typescript
 // TODO: Incorporate this deep linked file into our TS build
 
 module.exports = {
@@ -7,7 +8,7 @@ module.exports = {
       // TODO: Implement the following:
       //       1. Load the compilation transform map from JSON
       //       2. Run a reverse lookup of the compiled file to the original URL
-      // NOTE: Currently the following is hard coded as POC until we implement transformation rules
+      // HACK: Currently the following is hard coded as POC until we have a build manifest to lookup
       const tmpReplacementPoc = file.replace(/\/\.blitz\/caches\/dev/, '')
       return launchEditor(tmpReplacementPoc, specifiedEditor, onErrorCallback)
     }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -3,12 +3,17 @@ export type Config = {
   rootFolder: string
   devFolder: string
   buildFolder: string
+  interceptNextErrors?: boolean
 }
 
 export function enhance(config: Config) {
-  const nextBin = resolve(config.rootFolder, './node_modules/.bin/next')
   const devFolder = resolve(config.rootFolder, config.devFolder)
   const buildFolder = resolve(config.rootFolder, config.buildFolder)
+  const pathToNext = config.interceptNextErrors
+    ? './node_modules/.bin/next-patched'
+    : './node_modules/.bin/next'
+  const nextBin = resolve(config.rootFolder, pathToNext)
+
   return {
     ...config,
     nextBin,

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -4,7 +4,7 @@ import {Config, enhance} from './config'
 import {nextStartDev} from './next-utils'
 
 export async function dev(config: Config) {
-  const {rootFolder, nextBin, devFolder} = enhance(config)
+  const {rootFolder, nextBin, devFolder} = enhance({...config, interceptNextErrors: true})
   const src = resolve(rootFolder)
   const dest = resolve(rootFolder, devFolder)
 

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -1,14 +1,19 @@
 import {spawn} from 'child_process'
+import pty from 'node-pty'
 
 export async function nextStartDev(nextBin: string, cwd: string) {
-  return Promise.resolve(
-    spawn(nextBin, ['dev'], {
+  const cp = pty
+    .spawn(nextBin, ['dev'], {
+      name: 'xterm-color',
       cwd,
-      stdio: 'inherit',
-    }).on('error', err => {
-      console.error(err)
-    }),
-  )
+    })
+    .on('data', data => {
+      // HACK: The following is temporary until we have a build
+      //       manifest to lookup on a per file basis
+      process.stdout.write(data.toString().replace('.blitz/caches/dev/', ''))
+    })
+
+  return Promise.resolve(cp)
 }
 
 export async function nextBuild(nextBin: string, cwd: string) {

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -7,27 +7,12 @@ function transformOutput(data: any) {
   process.stdout.write(data.toString().replace('.blitz/caches/dev/', ''))
 }
 
-function getSpawnFn(nextBin: string, cwd: string, transformer: (data: any) => void) {
-  // tty was causing CI to stall
-  if (process.env.CI) {
-    return spawn(nextBin, ['dev'], {
-      cwd,
-    })
-      .on('error', err => {
-        console.error(err)
-      })
-      .on('data', transformer)
-  }
-
-  return pty
+export async function nextStartDev(nextBin: string, cwd: string) {
+  const cb = pty
     .spawn(nextBin, ['dev'], {
       cwd,
     })
-    .on('data', transformer)
-}
-
-export async function nextStartDev(nextBin: string, cwd: string) {
-  const cb = getSpawnFn(nextBin, cwd, transformOutput)
+    .on('data', transformOutput)
 
   return Promise.resolve(cb)
 }

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -1,5 +1,4 @@
 import {spawn} from 'child_process'
-import pty from 'node-pty'
 
 function transformOutput(data: any) {
   // HACK: The following is temporary until we have a build
@@ -19,7 +18,7 @@ function getSpawnFn(nextBin: string, cwd: string, transformer: (data: any) => vo
       .on('data', transformer)
   }
 
-  return pty
+  return require('node-pty')
     .spawn(nextBin, ['dev'], {
       cwd,
     })

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -1,4 +1,5 @@
 import {spawn} from 'child_process'
+import * as pty from 'node-pty'
 
 function transformOutput(data: any) {
   // HACK: The following is temporary until we have a build
@@ -18,7 +19,7 @@ function getSpawnFn(nextBin: string, cwd: string, transformer: (data: any) => vo
       .on('data', transformer)
   }
 
-  return require('node-pty')
+  return pty
     .spawn(nextBin, ['dev'], {
       cwd,
     })

--- a/packages/server/test/dev.test.ts
+++ b/packages/server/test/dev.test.ts
@@ -1,8 +1,4 @@
 // Setup mocks
-const childProcessMock = {
-  spawn: jest.fn().mockReturnValue({on: () => {}}),
-}
-
 const fsExtraMock = {
   copy: jest.fn(),
   unlink: jest.fn(),
@@ -13,8 +9,12 @@ const reporterMock = {
   reporter: {copy: jest.fn(), remove: jest.fn()},
 }
 
-jest.doMock('child_process', () => childProcessMock)
+const nextUtilsMock = {
+  nextStartDev: jest.fn().mockReturnValue(Promise.resolve()),
+}
+
 jest.doMock('fs-extra', () => fsExtraMock)
+jest.doMock('../src/next-utils', () => nextUtilsMock)
 jest.doMock('../src/reporter', () => reporterMock)
 
 // Import with mocks applied
@@ -53,13 +53,9 @@ describe('Start command', () => {
   })
 
   it('calls spawn with the patched next cli bin', () => {
-    expect(childProcessMock.spawn).toHaveBeenCalledWith(
+    expect(nextUtilsMock.nextStartDev).toHaveBeenCalledWith(
       resolve(rootFolder, './node_modules/.bin/next-patched'),
-      ['dev'],
-      {
-        cwd: devFolder,
-        stdio: 'inherit',
-      },
+      devFolder,
     )
   })
 })

--- a/packages/server/test/dev.test.ts
+++ b/packages/server/test/dev.test.ts
@@ -52,9 +52,9 @@ describe('Start command', () => {
     expect(fsExtraMock.unlink.mock.calls).toEqual([[resolve(rootFolder, '.blitz/.now')]])
   })
 
-  it('calls spawn with the next cli bin', () => {
+  it('calls spawn with the patched next cli bin', () => {
     expect(childProcessMock.spawn).toHaveBeenCalledWith(
-      resolve(rootFolder, './node_modules/.bin/next'),
+      resolve(rootFolder, './node_modules/.bin/next-patched'),
       ['dev'],
       {
         cwd: devFolder,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9850,7 +9850,7 @@ mz@^2.5.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.12.1:
+nan@^2.12.1, nan@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
@@ -10133,6 +10133,13 @@ node-notifier@^5.4.2:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
+
+node-pty@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.9.0.tgz#8f9bcc0d1c5b970a3184ffd533d862c7eb6590a6"
+  integrity sha512-MBnCQl83FTYOu7B4xWw10AW77AAh7ThCE1VXEv+JeWj8mSpGo+0bwgsV+b23ljBFwEM9OmsOv3kM27iUPPm84g==
+  dependencies:
+    nan "^2.14.0"
 
 node-releases@^1.1.44, node-releases@^1.1.50:
   version "1.1.50"


### PR DESCRIPTION
This fixes #53 

* Enables browser errors to be clicked so they redirect to the original files instead of the build cache.
* Hijacks the console output to show correct page paths in console when there is a typescript error and you click through to view the error. 

Considerations
* This aught to work for the base case or first release and we can tighten it up later as edge case issues come in
* Currently the transformations are hardcoded but marked clearly as hacks until we have the final system in place
* It would be nice at a later point to move the patch code to typescript but it is a nice to have and not essential for now. It is clearly marked as a todo.
* This uses a tincy wincy pirate hook to override some functionality provided by `launch-editor` so we can redirect to the correct file when the browser is launched. It is done pretty cleanly but unfortunately I could not work out a better way. Suggestions welcome.