### PR TITLE
bug(server): CI pathname errors for readable-stream 

### DIFF
--- a/packages/server/test/build.test.ts
+++ b/packages/server/test/build.test.ts
@@ -44,7 +44,7 @@ describe('Build command', () => {
   })
 
   it('should copy the correct files to the build folder', async () => {
-    const tree = directoryTree(rootFolder, {normalizePath: true})
+    const tree = directoryTree(rootFolder)
     expect(tree).toEqual({
       children: [
         {

--- a/packages/server/test/build.test.ts
+++ b/packages/server/test/build.test.ts
@@ -21,11 +21,7 @@ describe('Build command', () => {
   const rootFolder = resolve(__dirname, './fixtures/build')
   const buildFolder = resolve(rootFolder, '.blitz-build')
   const devFolder = resolve(rootFolder, '.blitz')
-  console.log('Debugging CI failures:', {
-    rootFolder,
-    buildFolder,
-    devFolder,
-  })
+
   beforeEach(async () => {
     jest.clearAllMocks()
     await build({rootFolder, buildFolder, devFolder, writeManifestFile: false})

--- a/packages/server/test/dev.test.ts
+++ b/packages/server/test/dev.test.ts
@@ -38,7 +38,7 @@ describe('Dev command', () => {
   })
 
   it('should copy the correct files to the dev folder', async () => {
-    const tree = directoryTree(rootFolder, {normalizePath: true})
+    const tree = directoryTree(rootFolder)
     expect(tree).toEqual({
       children: [
         {


### PR DESCRIPTION
Closes https://github.com/blitz-js/blitz/issues/70

This appears to fix the CI bug found when merging to master. One thing that is odd is why the test passed for the last PR? Hopefully this sticks.