### PR TITLE
Fix launchEditor bug

### DIFF
--- a/examples/vanilla-next/pages/posts/[...id].tsx
+++ b/examples/vanilla-next/pages/posts/[...id].tsx
@@ -1,8 +1,4 @@
 import {greet} from 'app/posts/controller'
-import {Form} from '@blitzjs/core'
-
-// TEST: Importing and using a thing from core should not spit the dummy
-console.log(Form.name)
 
 // TEST: Typical server rendering from params example
 export const getServerSideProps = (ctx: any) => {

--- a/packages/server/register/index.js
+++ b/packages/server/register/index.js
@@ -3,8 +3,8 @@ const addHook = require('pirates').addHook
 addHook(
   function(code) {
     const wrapCode =
-      '\n;module.exports = require("@blitzjs/server/register/launch-editor").enhance(_launchEditorFn);'
-    return code.replace('module.exports =', 'const _launchEditorFn =') + wrapCode
+      '\n;if(_launchEditorFn) { module.exports = require("@blitzjs/server/register/launch-editor").enhance(_launchEditorFn); }'
+    return code.replace(/module\.exports\s?=/, 'const _launchEditorFn =') + wrapCode
   },
   {
     exts: ['.js'],


### PR DESCRIPTION
Related: #91  

So I don't like this very much but it looks like launchEditor changed it's bundling output which tripped up the monkeypatch. I have made it more lenient and less likely to break. If it does it should not error and simply not do the error redirect instead. Be nice to have all the examples under a cypress test perhaps? 