### PR TITLE
fix(examples): Fix Yarn link blitz cli failing

### DIFF
--- a/examples/store/package.json
+++ b/examples/store/package.json
@@ -1,11 +1,12 @@
 {
   "name": "store",
+  "version": "0.0.1-canary.1",
   "private": true,
   "scripts": {},
   "dependencies": {
-    "@blitzjs/cli": "0.0.1-canary.0",
-    "@blitzjs/core": "0.0.1-canary.0",
-    "@blitzjs/server": "0.0.1-canary.0",
+    "@blitzjs/cli": "0.0.1-canary.1",
+    "@blitzjs/core": "0.0.1-canary.1",
+    "@blitzjs/server": "0.0.1-canary.1",
     "@prisma/cli": "2.0.0-beta.2",
     "@prisma/client": "2.0.0-beta.2",
     "final-form": "4.19.1",

--- a/examples/store/package.json
+++ b/examples/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "store",
-  "version": "0.0.1-canary.1",
+  "version": "0.0.0",
   "private": true,
   "scripts": {},
   "dependencies": {


### PR DESCRIPTION
Closes #101  

So for yarn workspaces dependencies to install properly it looks like you need package version.
