### PR TITLE
fix(cli): leverage cross-spawn for cross-platform compatibility

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
     "@oclif/plugin-not-found": "^1.2.3",
     "chalk": "^4.0.0",
     "chokidar": "^3.3.1",
+    "cross-spawn": "^7.0.2",
     "diff": "^4.0.2",
     "enquirer": "^2.3.4",
     "fs-extra": "^9.0.0",
@@ -43,7 +44,7 @@
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.2",
     "@oclif/test": "^1.2.5",
-    "@types/cross-spawn": "6.0.1",
+    "@types/cross-spawn": "^6.0.1",
     "@types/diff": "^4.0.2",
     "@types/fs-extra": "^8.1.0",
     "@types/fs-readdir-recursive": "1.0.0",

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -1,10 +1,9 @@
-import {platform} from 'os'
-import {spawn} from 'child_process'
+import {spawn} from 'cross-spawn'
 import {Command} from '@oclif/command'
 import * as path from 'path'
 
 export default class Db extends Command {
-  static description = 'Run project database commands'
+  static description = 'Run database commands'
 
   static args = [
     {
@@ -18,29 +17,26 @@ export default class Db extends Command {
     const {args} = this.parse(Db)
     const command = args['command']
 
-    const prismaBinaryName = platform() === 'win32' ? 'prisma.cmd' : 'prisma'
-    const prismaBinary = path.join(process.cwd(), 'node_modules/.bin', prismaBinaryName)
-
     const schemaArg = `--schema=${path.join(process.cwd(), 'db', 'schema.prisma')}`
 
     if (command === 'migrate' || command === 'm') {
-      const cp = spawn(prismaBinary, ['migrate', 'save', schemaArg, '--create-db', '--experimental'], {
+      const cp = spawn('prisma', ['migrate', 'save', schemaArg, '--create-db', '--experimental'], {
         stdio: 'inherit',
       })
       cp.on('exit', (code: number) => {
         if (code == 0) {
-          const cp = spawn(prismaBinary, ['migrate', 'up', schemaArg, '--create-db', '--experimental'], {
+          const cp = spawn('prisma', ['migrate', 'up', schemaArg, '--create-db', '--experimental'], {
             stdio: 'inherit',
           })
           cp.on('exit', (code: number) => {
             if (code == 0) {
-              spawn(prismaBinary, ['generate', schemaArg], {stdio: 'inherit'})
+              spawn('prisma', ['generate', schemaArg], {stdio: 'inherit'})
             }
           })
         }
       })
     } else if (command === 'init' || command === 'i') {
-      spawn(prismaBinary, ['init'], {stdio: 'inherit'})
+      spawn('prisma', ['init'], {stdio: 'inherit'})
     } else {
       this.log('Missing command')
     }

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,5 +1,4 @@
-import {platform} from 'os'
-import {spawn} from 'child_process'
+import {spawn} from 'cross-spawn'
 import {Command} from '@oclif/command'
 import hasYarn from 'has-yarn'
 
@@ -21,9 +20,7 @@ export default class Test extends Command {
     if (watch) {
       watchMode = watch === 'watch' || watch === 'w'
     }
-    const yarnBinary = platform() === 'win32' ? 'yarn.cmd' : 'yarn'
-    const npmBinary = platform() === 'win32' ? 'npm.cmd' : 'npm'
-    const packageManager = hasYarn() ? yarnBinary : npmBinary
+    const packageManager = hasYarn() ? 'yarn' : 'npm'
 
     if (watchMode) spawn(packageManager, ['test:watch'], {stdio: 'inherit'})
     else spawn(packageManager, ['test'], {stdio: 'inherit'})

--- a/packages/cli/test/commands/db.test.ts
+++ b/packages/cli/test/commands/db.test.ts
@@ -1,5 +1,4 @@
 import * as path from 'path'
-import {platform} from 'os'
 
 let onSpy: jest.Mock
 const spawn = jest.fn(() => {
@@ -9,22 +8,20 @@ const spawn = jest.fn(() => {
   return {on: onSpy}
 })
 
-jest.doMock('child_process', () => ({spawn}))
+jest.doMock('cross-spawn', () => ({spawn}))
 
 import DbCmd from '../../src/commands/db'
 
-const prismaBinaryName = platform() === 'win32' ? 'prisma.cmd' : 'prisma'
-const prismaBinary = path.join(process.cwd(), 'node_modules/.bin', prismaBinaryName)
 const schemaArg = `--schema=${path.join(process.cwd(), 'db', 'schema.prisma')}`
 
-const initParams = [prismaBinary, ['init'], {stdio: 'inherit'}]
+const initParams = ['prisma', ['init'], {stdio: 'inherit'}]
 const migrateSaveParams = [
-  prismaBinary,
+  'prisma',
   ['migrate', 'save', schemaArg, '--create-db', '--experimental'],
   {stdio: 'inherit'},
 ]
 const migrateUpParams = [
-  prismaBinary,
+  'prisma',
   ['migrate', 'up', schemaArg, '--create-db', '--experimental'],
   {stdio: 'inherit'},
 ]

--- a/packages/cli/test/commands/test.test.ts
+++ b/packages/cli/test/commands/test.test.ts
@@ -1,8 +1,8 @@
-import childProcess from 'child_process'
+import crossSpawn from 'cross-spawn'
 import hasYarn from 'has-yarn'
 import TestCmd from '../../src/commands/test'
 
-jest.mock('child_process')
+jest.mock('cross-spawn')
 jest.mock('has-yarn')
 
 const testParams = [['test'], {stdio: 'inherit'}]
@@ -18,7 +18,7 @@ describe('Test command', () => {
 
     await TestCmd.run([])
 
-    expect(childProcess.spawn).toBeCalledWith('yarn', ...testParams)
+    expect(crossSpawn.spawn).toBeCalledWith('yarn', ...testParams)
   })
 
   it('runs npm test script', async () => {
@@ -26,7 +26,7 @@ describe('Test command', () => {
 
     await TestCmd.run([])
 
-    expect(childProcess.spawn).toBeCalledWith('npm', ...testParams)
+    expect(crossSpawn.spawn).toBeCalledWith('npm', ...testParams)
   })
 
   it('runs yarn test:watch script', async () => {
@@ -34,7 +34,7 @@ describe('Test command', () => {
 
     await TestCmd.run(['watch'])
 
-    expect(childProcess.spawn).toBeCalledWith('yarn', ...testWatchParams)
+    expect(crossSpawn.spawn).toBeCalledWith('yarn', ...testWatchParams)
   })
 
   it('runs yarn test:watch script with alias', async () => {
@@ -42,7 +42,7 @@ describe('Test command', () => {
 
     await TestCmd.run(['w'])
 
-    expect(childProcess.spawn).toBeCalledWith('yarn', ...testWatchParams)
+    expect(crossSpawn.spawn).toBeCalledWith('yarn', ...testWatchParams)
   })
 
   it('runs yarn test and ignores invalid argument', async () => {
@@ -50,6 +50,6 @@ describe('Test command', () => {
 
     await TestCmd.run(['invalid'])
 
-    expect(childProcess.spawn).toBeCalledWith('yarn', ...testParams)
+    expect(crossSpawn.spawn).toBeCalledWith('yarn', ...testParams)
   })
 })

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,6 +28,7 @@
   "module": "dist/webpack.esm.js",
   "types": "dist/packages/server/src/index.d.ts",
   "devDependencies": {
+    "@types/cross-spawn": "^6.0.1",
     "@types/gulp-if": "^0.0.33",
     "@types/jest": "^25.1.3",
     "@types/path-is-absolute": "^1.0.0",
@@ -41,6 +42,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "cross-spawn": "^7.0.2",
     "fast-glob": "^3.2.2",
     "gulp-if": "^3.0.0",
     "next": "9.3.4",

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -1,4 +1,4 @@
-import {spawn} from 'child_process'
+import {spawn} from 'cross-spawn'
 import * as pty from 'node-pty'
 import {Manifest} from 'synchronizer/manifest'
 // import chalk from 'chalk'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2418,7 +2418,7 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/cross-spawn@6.0.1":
+"@types/cross-spawn@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.1.tgz#60fa0c87046347c17d9735e5289e72b804ca9b63"
   integrity sha512-MtN1pDYdI6D6QFDzy39Q+6c9rl2o/xN7aWGe6oZuzqq5N6+YuwFsWiEAv3dNzvzN9YzU+itpN8lBzFpphQKLAw==
@@ -4669,7 +4669,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.1:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.2.tgz#d0d7dcfa74e89115c7619f4f721a94e1fdb716d6"
   integrity sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==


### PR DESCRIPTION
I ran into problems with `yarn blitz start` and tracked it down to the same root cause as #108. Rather than duplicate logic similar to #109, I figured we should just let [`cross-spawn`](https://www.npmjs.com/package/cross-spawn) resolve the appropriate executable for us. This effectively reverts #109 and replaces it with a more comprehensive solution (IMHO).

Caveat: going forward, if we need to spawn processes, we need to remember to import from `cross-spawn` rather than `child_process`.