### PR TITLE
Fix server for deployment to Zeit

### DIFF
--- a/examples/store/blitz.config.js
+++ b/examples/store/blitz.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  webpack: (config, {buildId, dev, isServer, defaultLoaders, webpack}) => {
+    // Note: we provide webpack above so you should not `require` it
+    // Perform customizations to webpack config
+    // Important: return the modified config
+    return config
+  },
+  webpackDevMiddleware: (config) => {
+    // Perform customizations to webpack dev middleware config
+    // Important: return the modified config
+    return config
+  },
+}

--- a/examples/store/package.json
+++ b/examples/store/package.json
@@ -6,9 +6,9 @@
     "build": "blitz db migrate && blitz build"
   },
   "dependencies": {
-    "@blitzjs/cli": "0.0.2-canary.1",
+    "@blitzjs/cli": "0.0.2-canary.1.2",
     "@blitzjs/core": "0.0.2-canary.1",
-    "@blitzjs/server": "0.0.2-canary.1",
+    "@blitzjs/server": "0.0.2-canary.1.4",
     "@prisma/cli": "2.0.0-beta.2",
     "@prisma/client": "2.0.0-beta.2",
     "final-form": "4.19.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blitzjs/cli",
   "description": "Blitz CLI",
-  "version": "0.0.2-canary.1",
+  "version": "0.0.2-canary.1.2",
   "license": "MIT",
   "scripts": {
     "b": "./bin/run",
@@ -23,7 +23,6 @@
     "/lib"
   ],
   "dependencies": {
-    "@blitzjs/server": "0.0.2-canary.1",
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.14.0",
     "@oclif/plugin-help": "^2.2.3",
@@ -44,6 +43,7 @@
     "vinyl": "^2.2.0"
   },
   "devDependencies": {
+    "@blitzjs/server": "0.0.2-canary.1.4",
     "@oclif/dev-cli": "^1.22.2",
     "@oclif/test": "^1.2.5",
     "@types/cross-spawn": "^6.0.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2-canary.1",
+  "version": "0.0.2-canary.1.4",
   "license": "MIT",
   "main": "dist/index.js",
   "bin": {

--- a/packages/server/src/synchronizer/rules/config.ts
+++ b/packages/server/src/synchronizer/rules/config.ts
@@ -1,4 +1,4 @@
-import {readFile, writeFile, rename} from 'fs-extra'
+import {readFile, writeFile, copyFile} from 'fs-extra'
 import {resolve} from 'path'
 import File from 'vinyl'
 import {Rule} from '../types'
@@ -28,7 +28,7 @@ export async function copyConfig(entries: string[], srcPath: string, destPath: s
   // Zeit now adds configuration needed for Now, like serverless target,
   // so we need to keep and use that
   if (process.env.NOW_BUILDER) {
-    rename(resolve(srcPath, 'next.config.js'), resolve(destPath, 'next-zeit.config.js'))
+    await copyFile(resolve(srcPath, 'next.config.js'), resolve(destPath, 'next-zeit.config.js'))
   }
 
   const nextConfigShellTpl = process.env.NOW_BUILDER

--- a/packages/server/test/rules.test.ts
+++ b/packages/server/test/rules.test.ts
@@ -36,7 +36,7 @@ describe('Dev command', () => {
     if (await pathExists(devFolder)) {
       await remove(devFolder)
     }
-    watcher.close()
+    watcher?.close()
   })
 
   it('should copy the correct files to the dev folder', async () => {
@@ -108,6 +108,8 @@ describe('Build command ZEIT', () => {
     if (await pathExists(buildFolder)) {
       await remove(buildFolder)
     }
+
+    await remove(resolve(rootFolder, 'next.config.js'))
   })
 
   it('should copy the correct files to the build folder', async () => {
@@ -134,7 +136,7 @@ describe('Build command ZEIT', () => {
           extension: '.js',
           name: 'next.config.js',
           path: `${buildFolder}/next.config.js`,
-          size: 203,
+          size: 61,
           type: 'file',
         },
         {
@@ -160,7 +162,7 @@ describe('Build command ZEIT', () => {
           type: 'directory',
         },
       ],
-      size: 404,
+      size: 262,
       type: 'directory',
     })
   })

--- a/packages/server/test/rules.test.ts
+++ b/packages/server/test/rules.test.ts
@@ -2,6 +2,7 @@
 
 const nextUtilsMock = {
   nextStartDev: jest.fn().mockReturnValue(Promise.resolve()),
+  nextBuild: jest.fn().mockReturnValue(Promise.resolve()),
 }
 // Quieten reporter
 jest.doMock('../src/reporter', () => ({
@@ -13,9 +14,10 @@ jest.doMock('../src/next-utils', () => nextUtilsMock)
 
 // Import with mocks applied
 import {dev} from '../src/dev'
+import {build} from '../src/build'
 import {resolve} from 'path'
 import {FSWatcher} from 'chokidar'
-import {remove, pathExists} from 'fs-extra'
+import {remove, pathExists, writeFile} from 'fs-extra'
 import directoryTree from 'directory-tree'
 
 describe('Dev command', () => {
@@ -81,6 +83,84 @@ describe('Dev command', () => {
         },
       ],
       size: 270,
+      type: 'directory',
+    })
+  })
+})
+
+describe('Build command ZEIT', () => {
+  const rootFolder = resolve(__dirname, './fixtures/rules')
+  const buildFolder = resolve(rootFolder, '.blitz')
+  const devFolder = resolve(rootFolder, '.blitz-rules')
+
+  beforeEach(async () => {
+    process.env.NOW_BUILDER = '1'
+    jest.clearAllMocks()
+
+    const defaultZeitConfig = "module.exports = { target: 'experimental-serverless-trace' };"
+    await writeFile(resolve(rootFolder, 'next.config.js'), Buffer.from(defaultZeitConfig))
+
+    await build({rootFolder, buildFolder, devFolder, writeManifestFile: false})
+  })
+
+  afterEach(async () => {
+    delete process.env.NOW_BUILDER
+    if (await pathExists(buildFolder)) {
+      await remove(buildFolder)
+    }
+  })
+
+  it('should copy the correct files to the build folder', async () => {
+    const tree = directoryTree(buildFolder)
+    expect(tree).toEqual({
+      path: `${buildFolder}`,
+      name: '.blitz',
+      children: [
+        {
+          extension: '.js',
+          name: 'blitz.config.js',
+          path: `${buildFolder}/blitz.config.js`,
+          size: 20,
+          type: 'file',
+        },
+        {
+          extension: '.js',
+          name: 'next-zeit.config.js',
+          path: `${buildFolder}/next-zeit.config.js`,
+          size: 61,
+          type: 'file',
+        },
+        {
+          extension: '.js',
+          name: 'next.config.js',
+          path: `${buildFolder}/next.config.js`,
+          size: 203,
+          type: 'file',
+        },
+        {
+          path: `${buildFolder}/pages`,
+          name: 'pages',
+          children: [
+            {
+              path: `${buildFolder}/pages/bar.tsx`,
+              name: 'bar.tsx',
+              size: 60,
+              extension: '.tsx',
+              type: 'file',
+            },
+            {
+              path: `${buildFolder}/pages/foo.tsx`,
+              name: 'foo.tsx',
+              size: 60,
+              extension: '.tsx',
+              type: 'file',
+            },
+          ],
+          size: 120,
+          type: 'directory',
+        },
+      ],
+      size: 404,
       type: 'directory',
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1102,6 +1102,53 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@blitzjs/cli@0.0.2-canary.1":
+  version "0.0.2-canary.1"
+  resolved "https://registry.yarnpkg.com/@blitzjs/cli/-/cli-0.0.2-canary.1.tgz#63de9cf5280dc9f7b9ebddaeff73f61968a65053"
+  integrity sha512-nSl0rcYLf1/fbFXe4n6/TpPNSnmV+EmBE4eWFk8M5QKQ1mRAovPWofip3y1sRttwuP3p+xjk5uup4eM9rRkkLw==
+  dependencies:
+    "@blitzjs/server" "0.0.2-canary.1"
+    "@oclif/command" "^1.5.19"
+    "@oclif/config" "^1.14.0"
+    "@oclif/plugin-help" "^2.2.3"
+    "@oclif/plugin-not-found" "^1.2.3"
+    chalk "^4.0.0"
+    chokidar "^3.3.1"
+    cross-spawn "^7.0.2"
+    diff "^4.0.2"
+    dotenv "8.2.0"
+    enquirer "^2.3.4"
+    fs-extra "^9.0.0"
+    fs-readdir-recursive "1.1.0"
+    has-yarn "^2.1.0"
+    hasbin "1.2.3"
+    mem-fs "^1.1.3"
+    mem-fs-editor "^6.0.0"
+    username "5.1.0"
+    vinyl "^2.2.0"
+
+"@blitzjs/server@0.0.2-canary.1":
+  version "0.0.2-canary.1"
+  resolved "https://registry.yarnpkg.com/@blitzjs/server/-/server-0.0.2-canary.1.tgz#1ecd805e95b20650c339012ccb7fcef433e5b23e"
+  integrity sha512-zf/CDNwu3puxDHesZElAGVcmwrgV0N8dSzDEMmL/ZXd1gNtO82UbLbVO6Z9W924mC9AfczeSMgfwsQzakRsvHA==
+  dependencies:
+    cross-spawn "^7.0.2"
+    fast-glob "^3.2.2"
+    gulp-if "^3.0.0"
+    next "9.3.4"
+    next-compose-plugins "2.2.0"
+    next-transpile-modules "3.2.0"
+    node-pty "^0.9.0"
+    null-loader "^3.0.0"
+    path-is-absolute "^2.0.0"
+    pirates "^4.0.1"
+    readable-stream "^3.6.0"
+    resolve-bin "^0.4.0"
+    through2 "^3.0.1"
+    vinyl "^2.2.0"
+    vinyl-file "^3.0.0"
+    vinyl-fs "^3.0.3"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"


### PR DESCRIPTION
Zeit automatically adds the serverless target to next.config.js, so it's always present during Zeit build time. Blitz build was yelling because that file shouldn't be there.

And we do actually need that config that Zeit sets, so this will preserve any config Zeit sets.

This is done except the test is failing and I can't figure out why. @ryardley could you take a look at it?