### PR TITLE
Automatically run `blitz db migrate` on every `blitz start`

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,6 +1,8 @@
 import {Command, flags} from '@oclif/command'
 import {dev, prod} from '@blitzjs/server'
 
+import {runMigrate, schemaArg} from './db'
+
 export default class Start extends Command {
   static description = 'Start a development server'
   static aliases = ['s']
@@ -12,8 +14,11 @@ export default class Start extends Command {
     }),
   }
 
+  static args = [{name: 'noMigrate', description: 'Disable automatic database migration'}]
+
   async run() {
     const {flags} = this.parse(Start)
+    const {args} = this.parse(Start)
 
     const config = {
       rootFolder: process.cwd(),
@@ -22,6 +27,9 @@ export default class Start extends Command {
     if (flags.production) {
       await prod(config)
     } else {
+      if (!args.noMigrate) {
+        runMigrate(schemaArg)
+      }
       await dev(config)
     }
   }

--- a/packages/cli/test/commands/start.test.ts
+++ b/packages/cli/test/commands/start.test.ts
@@ -16,7 +16,7 @@ describe('Start command', () => {
   }
 
   it('runs the dev script', async () => {
-    await StartCmd.run([])
+    await StartCmd.run(['--no-migrate'])
     expect(dev).toBeCalledWith(options)
   })
 


### PR DESCRIPTION
Closes everything in #145 

