### PR TITLE
Back out the auto db migrate, and instead only auto generate prisma client

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -9,6 +9,8 @@ const schemaPath = path.join(process.cwd(), 'db', 'schema.prisma')
 const schemaArg = `--schema=${schemaPath}`
 const getPrismaBin = () => resolveBinAsync('@prisma/cli', 'prisma')
 
+// Prisma client generation will fail if no model is defined in the schema.
+// So the silent option is here to ignore that failure
 export const runPrismaGeneration = async ({silent = false} = {}) => {
   const prismaBin = await getPrismaBin()
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,7 +1,7 @@
 import {Command, flags} from '@oclif/command'
 import {dev, prod} from '@blitzjs/server'
 
-import {runMigrate} from './db'
+import {runPrismaGeneration} from './db'
 
 export default class Start extends Command {
   static description = 'Start a development server'
@@ -14,11 +14,8 @@ export default class Start extends Command {
     }),
   }
 
-  static args = [{name: 'noMigrate', description: 'Disable automatic database migration'}]
-
   async run() {
     const {flags} = this.parse(Start)
-    const {args} = this.parse(Start)
 
     const config = {
       rootFolder: process.cwd(),
@@ -27,9 +24,7 @@ export default class Start extends Command {
     if (flags.production) {
       await prod(config)
     } else {
-      if (!args.noMigrate) {
-        await runMigrate()
-      }
+      await runPrismaGeneration({silent: true})
       await dev(config)
     }
   }

--- a/packages/cli/test/commands/start.test.ts
+++ b/packages/cli/test/commands/start.test.ts
@@ -1,7 +1,17 @@
 const dev = jest.fn(() => {})
 const prod = jest.fn(() => {})
 
-jest.mock('@blitzjs/server', () => ({dev, prod}))
+jest.mock('@blitzjs/server', () => ({dev, prod, resolveBinAsync: jest.fn()}))
+
+let onSpy: jest.Mock
+const spawn = jest.fn(() => {
+  onSpy = jest.fn(function on(_: string, callback: (_: number) => {}) {
+    callback(0)
+  })
+  return {on: onSpy}
+})
+
+jest.doMock('cross-spawn', () => ({spawn}))
 
 import StartCmd from '../../src/commands/start'
 import {resolve} from 'path'
@@ -16,7 +26,7 @@ describe('Start command', () => {
   }
 
   it('runs the dev script', async () => {
-    await StartCmd.run(['--no-migrate'])
+    await StartCmd.run([])
     expect(dev).toBeCalledWith(options)
   })
 


### PR DESCRIPTION
- It turns out automatically running db migrate isn't a good idea, because if you need to migrate, Prisma prompts you to input the migration name. This is very bad in the middle of Next dev logs. So the solution is to only generate the client on blitz start
- This also fixes a bug where the `runMigrate()` and `runPrismaGeneration()` async functions would return before the process was finished.