### PR TITLE
Fix `yarn test` by also running the build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,10 +35,6 @@ jobs:
         run: yarn install --frozen-lockfile --silent
         env:
           CI: true
-      - name: Build Blitz Packages
-        run: yarn build
-        env:
-          CI: true
       - name: Test Blitz Packages
         run: yarn test
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,12 @@ yarn
 yarn dev
 ```
 
+**4.** Run tests
+
+```
+yarn test
+```
+
 #### Link the Blitz CLI (Optional)
 
 The following will link the development CLI as a local binary so you can use it anywhere for testing.

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "link-cli": "yarn workspace blitz link",
     "unlink-cli": "yarn workspace blitz unlink",
     "build": "lerna run build --no-private --stream",
-    "test": "lerna run test --parallel",
-    "prepublishOnly": "yarn run build && yarn run test",
+    "test": "yarn run build && lerna run test --parallel",
+    "prepublishOnly": "yarn run test",
     "prepack": "cpy README.md packages/blitz/",
     "postpack": "rimraf packages/blitz/README.md",
     "publish-canary": "lerna publish --preid canary --pre-dist-tag canary",
@@ -81,7 +81,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged",
-      "pre-push": "yarn build && yarn test"
+      "pre-push": "yarn test"
     }
   },
   "resolutions": {


### PR DESCRIPTION
### Pull Request Type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Tests related changes
- [ ] Other (please describe): Dependency updates


### What's the reason for the change? :question:

`yarn test` fails for a clean repo because `yarn build` must first be run

### What are the changes and their implications? :gear:

This changes `yarn test` to also run `yarn build`.
