### PR TITLE
fix(cli): console crashing when importing ts files

### DIFF
--- a/packages/cli/src/commands/console.ts
+++ b/packages/cli/src/commands/console.ts
@@ -8,7 +8,7 @@ import {log} from '@blitzjs/server'
 import chalk from 'chalk'
 
 // import {loadDependencies} from '../utils/load-dependencies'
-import {BLITZ_MODULE_PATHS, loadBlitz} from '../utils/load-blitz'
+import {setupTsnode, BLITZ_MODULE_PATHS, loadBlitz} from '../utils/load-blitz'
 import {runPrismaGeneration} from './db'
 
 const projectRoot = pkgDir.sync() || process.cwd()
@@ -40,6 +40,7 @@ export default class Console extends Command {
     console.log(chalk.yellow('      - Use your db like this: await db.user.findMany()'))
     console.log(chalk.yellow('      - Use your queries/mutations like this: await getUsers()'))
 
+    setupTsnode()
     await runPrismaGeneration({silent: true})
 
     const repl = Console.initializeRepl()

--- a/packages/cli/src/commands/console.ts
+++ b/packages/cli/src/commands/console.ts
@@ -40,9 +40,6 @@ export default class Console extends Command {
     console.log(chalk.yellow('      - Use your db like this: await db.user.findMany()'))
     console.log(chalk.yellow('      - Use your queries/mutations like this: await getUsers()'))
 
-    // Make the REPL work with `baseUrl`
-    require('tsconfig-paths/register')
-
     await runPrismaGeneration({silent: true})
 
     const repl = Console.initializeRepl()

--- a/packages/cli/src/utils/load-blitz.ts
+++ b/packages/cli/src/utils/load-blitz.ts
@@ -2,11 +2,18 @@ import {forceRequire} from './module'
 import path from 'path'
 import globby from 'globby'
 import pkgDir from 'pkg-dir'
+import {REGISTER_INSTANCE} from 'ts-node'
 
 const projectRoot = pkgDir.sync() || process.cwd()
 
-require('tsconfig-paths/register')
-require('ts-node').register({compilerOptions: {module: 'commonjs'}})
+export const setupTsnode = () => {
+  if (!process[REGISTER_INSTANCE]) {
+    // During blitz interal dev, oclif automaticaly sets up ts-node so we have to check
+    // require('ts-node').register({compilerOptions: {module: 'commonjs'}})
+    require('ts-node').register()
+  }
+  require('tsconfig-paths/register')
+}
 
 export const BLITZ_MODULE_PATHS = [
   ...globby.sync(

--- a/packages/cli/src/utils/load-blitz.ts
+++ b/packages/cli/src/utils/load-blitz.ts
@@ -5,6 +5,9 @@ import pkgDir from 'pkg-dir'
 
 const projectRoot = pkgDir.sync() || process.cwd()
 
+require('tsconfig-paths/register')
+require('ts-node').register({compilerOptions: {module: 'commonjs'}})
+
 export const BLITZ_MODULE_PATHS = [
   ...globby.sync(
     [
@@ -27,11 +30,16 @@ export const loadBlitz = () => {
         const dirs = path.dirname(modulePath).split(path.sep)
         name = dirs[dirs.length - 1]
       }
-      const module = forceRequire(modulePath)
-      const contextObj = module.default || module
-      //TODO: include all exports here, not just default
-      return {
-        [name]: contextObj,
+
+      try {
+        const module = forceRequire(modulePath)
+        const contextObj = module.default || module
+        //TODO: include all exports here, not just default
+        return {
+          [name]: contextObj,
+        }
+      } catch (e) {
+        return {}
       }
     }),
   )


### PR DESCRIPTION
### Pull Request Type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Tests related changes
- [ ] Other (please describe): Dependency updates

### Checklist

<!-- Please ensure your PR fulfills the following: -->

- [x] Tests added for changes (or N/A)
- [ ] Any added terminal logging uses `packages/server/src/log.ts` (or N/A)
- [ ] Code Coverage stayed the same or increased

### What's the reason for the change? :question:

<!-- Closes: ISSUE_NUMBER -->
Closes: #180 

### What are the changes and their implications? :gear:
- require `ts-node` for loading modules inside REPL
- ignore any errors when loading modules in REPL (helps when `prisma generate` cannot run because the schema is empty - in that case requiring `db` results in an error)

### Does this introduce a breaking change? :warning:

- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path for existing apps-->

### Other information

<!-- Before/after screenshots, etc. -->
