### PR TITLE
fix(server): make synchronizer pages rule cross-platform

### DIFF
--- a/packages/server/src/synchronizer/pipeline/rules/pages/api.test.ts
+++ b/packages/server/src/synchronizer/pipeline/rules/pages/api.test.ts
@@ -1,31 +1,32 @@
+import {normalize} from 'path'
 import {apiPathTransformer} from '.'
 
 describe('createPagesPathTransformer', () => {
   const tests = [
     {
       name: 'extracts paths folder to the root in a basic transformation',
-      input: 'app/users/api/one/two/three.tsx',
-      expected: 'pages/api/one/two/three.tsx',
+      input: normalize('app/users/api/one/two/three.tsx'),
+      expected: normalize('pages/api/one/two/three.tsx'),
     },
     {
       name: 'handles leading /',
-      input: '/app/users/api/one/two/three.tsx',
-      expected: 'pages/api/one/two/three.tsx',
+      input: normalize('/app/users/api/one/two/three.tsx'),
+      expected: normalize('pages/api/one/two/three.tsx'),
     },
     {
       name: 'handles nested api folders',
-      input: 'app/users/api/one/two/api/three.tsx',
-      expected: 'pages/api/one/two/api/three.tsx',
+      input: normalize('app/users/api/one/two/api/three.tsx'),
+      expected: normalize('pages/api/one/two/api/three.tsx'),
     },
     {
       name: 'ignores files outside of app',
-      input: 'thing/users/api/one/two/pages/three.tsx',
-      expected: 'thing/users/api/one/two/pages/three.tsx',
+      input: normalize('thing/users/api/one/two/pages/three.tsx'),
+      expected: normalize('thing/users/api/one/two/pages/three.tsx'),
     },
     {
       name: 'Ignore absolute paths',
-      input: '/User/foo/bar/app/users/api/one/two/three.tsx',
-      expected: 'pages/api/one/two/three.tsx',
+      input: normalize('/User/foo/bar/app/users/api/one/two/three.tsx'),
+      expected: normalize('pages/api/one/two/three.tsx'),
     },
   ]
 

--- a/packages/server/src/synchronizer/pipeline/rules/pages/index.ts
+++ b/packages/server/src/synchronizer/pipeline/rules/pages/index.ts
@@ -1,5 +1,6 @@
-import {through} from '../../../streams'
+import {join} from 'path'
 import File from 'vinyl'
+import {through} from '../../../streams'
 import {getDuplicatePaths, absolutePathTransform} from '../../utils'
 import {RuleArgs} from '../../../types'
 import {DuplicatePathError, NestedRouteError} from '../../../errors'
@@ -70,13 +71,13 @@ const createRulePages = ({config, errors, getInputCache}: RuleArgs) => {
 export default createRulePages
 
 export function pagesPathTransformer(path: string) {
-  const regex = new RegExp(`(?:\\/?app\\/.*?\\/?)(pages\\/.+)$`)
+  const regex = /(?:[\\\/]?app[\\\/].*?[\\\/]?)(pages[\\\/].+)$/
   return (regex.exec(path) || [])[1] || path
 }
 
 export function apiPathTransformer(path: string) {
-  const regex = new RegExp(`(?:\\/?app\\/.*?\\/?)(api\\/.+)$`)
+  const regex = /(?:[\\\/]?app[\\\/].*?[\\\/]?)(api[\\\/].+)$/
   const matchedPath = (regex.exec(path) || [])[1]
 
-  return matchedPath ? `pages/${matchedPath}` : path
+  return matchedPath ? join('pages', matchedPath) : path
 }

--- a/packages/server/src/synchronizer/pipeline/rules/pages/pages.test.ts
+++ b/packages/server/src/synchronizer/pipeline/rules/pages/pages.test.ts
@@ -1,31 +1,32 @@
+import {normalize} from 'path'
 import {pagesPathTransformer} from '.'
 
 describe('createPagesPathTransformer', () => {
   const tests = [
     {
       name: 'extracts paths folder to the root in a basic transformation',
-      input: 'app/users/pages/one/two/three.tsx',
-      expected: 'pages/one/two/three.tsx',
+      input: normalize('app/users/pages/one/two/three.tsx'),
+      expected: normalize('pages/one/two/three.tsx'),
     },
     {
       name: 'handles leading /',
-      input: '/app/users/pages/one/two/three.tsx',
-      expected: 'pages/one/two/three.tsx',
+      input: normalize('/app/users/pages/one/two/three.tsx'),
+      expected: normalize('pages/one/two/three.tsx'),
     },
     {
       name: 'handles nested pages folders',
-      input: 'app/users/pages/one/two/pages/three.tsx',
-      expected: 'pages/one/two/pages/three.tsx',
+      input: normalize('app/users/pages/one/two/pages/three.tsx'),
+      expected: normalize('pages/one/two/pages/three.tsx'),
     },
     {
       name: 'ignores files outside of app',
-      input: 'thing/users/pages/one/two/pages/three.tsx',
-      expected: 'thing/users/pages/one/two/pages/three.tsx',
+      input: normalize('thing/users/pages/one/two/pages/three.tsx'),
+      expected: normalize('thing/users/pages/one/two/pages/three.tsx'),
     },
     {
       name: 'extracts paths folder to the root in a basic transformation',
-      input: '/User/foo/bar/app/users/pages/one/two/three.tsx',
-      expected: 'pages/one/two/three.tsx',
+      input: normalize('/User/foo/bar/app/users/pages/one/two/three.tsx'),
+      expected: normalize('pages/one/two/three.tsx'),
     },
   ]
 


### PR DESCRIPTION
### Pull Request Type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

- [ ] Feature
- [x] Bug fix
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] Tests related changes
- [ ] Other (please describe): Dependency updates

### Checklist

<!-- Please ensure your PR fulfills the following: -->

- [x] Tests added for changes (or N/A)
- [x] Any added terminal logging uses `packages/server/src/log.ts` (or N/A)
- [x] Code Coverage stayed the same or increased

### What's the reason for the change? :question:

The synchronizer rule for handling pages was not working on Windows due to the difference in the path segment separator (`/` vs `\\`).

### What are the changes and their implications? :gear:

- Updated the regular expressions used for detecting `pages` and `api` paths
- Updated the tests to normalize the inputs and expected results

### Does this introduce a breaking change? :warning:

- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path for existing apps-->

### Other information

@ryardley I had to change the regular expression from the `new RegExp` syntax to slash syntax in order to properly escape the Windows path segment separator and combine it with the non-Windows character in a set (`\\/` → `[\\\/]`). Hopefully I understood the original intention properly, or I might've just broke something. But all the tests pass now. :)
