### PR TITLE
fix(cli): populate new apps with latest version of deps in range

### DIFF
--- a/packages/cli/src/utils/get-latest-version.ts
+++ b/packages/cli/src/utils/get-latest-version.ts
@@ -11,7 +11,8 @@ export const getLatestVersion = async (dependency: string, templateVersion: stri
 
   const latestVersion = Object.keys(allVersions)
     .filter((version) => version.startsWith(major))
-    .sort((a, b) => a.localeCompare(b, undefined, {numeric: true}))[0]
+    .sort((a, b) => a.localeCompare(b, undefined, {numeric: true}))
+    .reverse()[0]
 
   // If the latest tagged version matches our pinned major, use that, otherwise use the
   // latest untagged which does


### PR DESCRIPTION
### Pull Request Type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Tests related changes
- [ ] Other (please describe): Dependency updates

### Checklist

<!-- Please ensure your PR fulfills the following: -->

- [x] Tests added for changes (or N/A)
- [x] Any added terminal logging uses `packages/server/src/log.ts` (or N/A)
- [x] Code Coverage stayed the same or increased

### What's the reason for the change? :question:

Closes #205

### What are the changes and their implications? :gear:

Reverse the sort order of available package versions to get the latest instead of the oldest.

### Does this introduce a breaking change? :warning:

- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path for existing apps-->

### Other information

Prior to this change, a new Blitz app is generated with old dependencies (e.g. `eslint-plugin-react-hooks@2.0.0`). After this change, a new app will contain the latest dependencies (e.g. `eslint-plugin-react-hooks@2.5.1`).