### PR TITLE
Speed up blitz start/build by parallelizing prisma generation

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -24,9 +24,8 @@ export default class Start extends Command {
     if (flags.production) {
       await prod(config)
     } else {
-      await runPrismaGeneration({silent: true})
       try {
-        await dev(config)
+        await dev(config, runPrismaGeneration({silent: true}))
       } catch (err) {
         process.exit(1) // clean up?
       }

--- a/packages/cli/test/commands/start.test.ts
+++ b/packages/cli/test/commands/start.test.ts
@@ -27,7 +27,7 @@ describe('Start command', () => {
 
   it('runs the dev script', async () => {
     await StartCmd.run([])
-    expect(dev).toBeCalledWith(options)
+    expect(dev).toBeCalledWith(options, Promise.resolve())
   })
 
   it('runs the prod script when passed the production flag', async () => {

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -3,7 +3,7 @@ import {synchronizeFiles} from './synchronizer'
 import {ServerConfig, enhance} from './config'
 import {nextStartDev} from './next-utils'
 
-export async function dev(config: ServerConfig, readyForNextDev: Promise<any>) {
+export async function dev(config: ServerConfig, readyForNextDev: Promise<any> = Promise.resolve()) {
   const {
     rootFolder,
     nextBin,

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -3,7 +3,7 @@ import {synchronizeFiles} from './synchronizer'
 import {ServerConfig, enhance} from './config'
 import {nextStartDev} from './next-utils'
 
-export async function dev(config: ServerConfig) {
+export async function dev(config: ServerConfig, readyForNextDev: Promise<any>) {
   const {
     rootFolder,
     nextBin,
@@ -20,14 +20,18 @@ export async function dev(config: ServerConfig) {
   const src = resolve(rootFolder)
   const dest = resolve(rootFolder, devFolder)
 
-  const {manifest} = await synchronizeFiles({
-    src,
-    dest,
-    watch,
-    ignoredPaths,
-    includePaths,
-    manifestPath,
-    writeManifestFile,
-  })
+  const [{manifest}] = await Promise.all([
+    synchronizeFiles({
+      src,
+      dest,
+      watch,
+      ignoredPaths,
+      includePaths,
+      manifestPath,
+      writeManifestFile,
+    }),
+    readyForNextDev,
+  ])
+
   nextStartDev(nextBin, dest, manifest, devFolder)
 }


### PR DESCRIPTION
### Pull Request Type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Tests related changes
- [ ] Other (please describe): Dependency updates

### Checklist

<!-- Please ensure your PR fulfills the following: -->

- [x] Tests added for changes (or N/A)
- [x] Any added terminal logging uses `packages/server/src/log.ts` (or N/A)
- [x] Code Coverage stayed the same or increased

### What's the reason for the change? :question:

`blitz start` feels sluggish because there is no user feedback and prisma generate occurs in series when it can occur in parallel.

### What are the changes and their implications? :gear:

Passing in a promise to the dev function that represents when we can start next.

### Does this introduce a breaking change? :warning:

- [ ] Yes
- [x] No

