### PR TITLE
Fix Linux & Remove top level await support in console, temporarily 

### DIFF
--- a/packages/blitz/bin/blitz
+++ b/packages/blitz/bin/blitz
@@ -1,3 +1,3 @@
-#!/usr/bin/env node --experimental-repl-await
+#!/usr/bin/env node
 
 require('../dist/cli')

--- a/packages/blitz/src/bin/cli.ts
+++ b/packages/blitz/src/bin/cli.ts
@@ -51,13 +51,17 @@ if (fs.existsSync(localCLIPkgPath)) {
 const cli = require(pkgPath as string)
 
 const options = require('minimist')(process.argv.slice(2))
-if (options._.length === 0 && (options.v || options.version)) {
-  // TODO: remove
-  console.log('debug:', usageType)
-  console.log('debug: pkgPath:', pkgPath, '\n')
+const hasVersionFlag = options._.length === 0 && (options.v || options.version)
+const hasVerboseFlag = options._.length === 0 && (options.V || options.verbose)
+
+if (hasVersionFlag) {
+  if (hasVerboseFlag) {
+    console.log('debug:', usageType)
+    console.log('debug: pkgPath:', pkgPath, '\n')
+  }
   try {
     const osName = require('os-name')
-    console.log(`${osName()} ${process.platform}-${process.arch} node-${process.version}\n`)
+    console.log(`${osName()} | ${process.platform}-${process.arch} | Node: ${process.version}\n`)
 
     let globalInstallPath
     let localButGlobalLinked = usageType === 'local' && fs.existsSync(globalLinkedPath)

--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env node --experimental-repl-await
+#!/usr/bin/env node
 
 require('@blitzjs/cli').run()

--- a/packages/cli/src/commands/console.ts
+++ b/packages/cli/src/commands/console.ts
@@ -37,8 +37,11 @@ export default class Console extends Command {
   async run() {
     log.branded('You have entered the Blitz console')
     console.log(chalk.yellow('Tips: - Exit by typing .exit or pressing Ctrl-D'))
-    console.log(chalk.yellow('      - Use your db like this: await db.user.findMany()'))
-    console.log(chalk.yellow('      - Use your queries/mutations like this: await getUsers()'))
+    console.log(chalk.yellow('      - Use your db like this: db.user.findMany().then(console.log)'))
+    console.log(chalk.yellow('      - Use your queries/mutations like this: getUsers().then(console.log)'))
+    console.log(
+      chalk.yellow('      - Top level `await` support coming: https://github.com/blitz-js/blitz/issues/230'),
+    )
 
     setupTsnode()
     await runPrismaGeneration({silent: true})


### PR DESCRIPTION
### Pull Request Type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

- [x] Bug fix

### What's the reason for the change? :question:

We were enabling top level await in our binaries using this:
```
#!/usr/bin/env node --experimental-repl-await
```

But that [doesn't work on Linux](https://github.com/nxtep-io/ts-framework-cli/issues/1), which also breaks production deployments, like to Vercel/Zeit. So I had to remove it for now.

New issue for adding it back with cross platform support: https://github.com/blitz-js/blitz/issues/230
