### PR TITLE
Correct Prisma schema name in USER_GUIDE.md

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -43,7 +43,7 @@ Blitz is built on Next.js, so if you are familiar with that, you will feel right
 
 By default, Blitz uses Prisma 2 which is a strongly typed database client. **You probably want to read [the Prisma 2 documentation](https://www.prisma.io/docs/understand-prisma/introduction).** _Note, Prisma 2 is not required for Blitz. The only Prisma-Blitz integration is the `blitz db` cli command. You can use anything you want, such as Mongo, TypeORM, etc._
 
-1. Open `db/prisma.schema` and add the following:
+1. Open `db/schema.prisma` and add the following:
 
 ```prisma
 model Project {


### PR DESCRIPTION
### Pull Request Type

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Tests related changes
- [x] Other (please describe): Documentation update

### Checklist

<!-- Please ensure your PR fulfills the following: -->

- [ ] Tests added for changes (or N/A) - N/A
- [ ] Any added terminal logging uses `packages/server/src/log.ts` (or N/A) - N/A
- [x] Code Coverage stayed the same or increased

### What's the reason for the change? :question:

It seems the default Prisma schema filename is `schema.prisma` (see screenshot in Other Information).

### What are the changes and their implications? :gear:

This should have no negative implications on development, as it's a correction in documentation only.

### Does this introduce a breaking change? :warning:

- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path for existing apps-->

### Other information

<!-- Before/after screenshots, etc. -->

<img width="226" alt="image" src="https://user-images.githubusercontent.com/354652/80291731-25baf700-871e-11ea-8744-ce616288a9f2.png">
