### PR TITLE
Make `blitz h` print the help menu

### DIFF
--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -1,0 +1,23 @@
+import {Command, flags} from '@oclif/command'
+
+import Help from '@oclif/plugin-help'
+
+export default class HelpCommand extends Command {
+  static description = 'display help for <%= config.bin %>'
+
+  static aliases = ['h']
+
+  static flags = {
+    all: flags.boolean({description: 'see all commands in CLI'}),
+  }
+
+  static args = [{name: 'command', required: false, description: 'command to show help for'}]
+
+  static strict = false
+
+  async run() {
+    const {flags, argv} = this.parse(HelpCommand)
+    const help = new Help(this.config, {all: flags.all})
+    help.showHelp(argv)
+  }
+}


### PR DESCRIPTION
### Pull Request Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Tests related changes
- [ ] Other (please describe): Dependency updates

### Checklist
- [ ] Tests added for changes (or N/A)
- [ ] Any added terminal logging uses `packages/server/src/log.ts` (or N/A)
- [ ] Code Coverage stayed the same or increased

**Was unsure on how to get test coverage output so left this section blank**

### What's the reason for the change? :question:

Closes: #227 

### What are the changes and their implications? :gear:

Not sure if this is the right way to do this. The reason `blitz h` does not work is because the `help` command comes from https://github.com/oclif/plugin-help. 

The approach I took was to override this in blitz locally. There are some alternatives, including:

* Use a fork of `oclif/plugin-help`
* Use https://github.com/ds300/patch-package (unsure if this would work)

### Does this introduce a breaking change? :warning:

- [ ] Yes
- [x] No

### Other information

<!-- Before/after screenshots, etc. -->
![image](https://user-images.githubusercontent.com/7850202/80293202-5a817b00-872b-11ea-903c-3a9d2a4b01aa.png)