### PR TITLE
Fix super slow CLI startup when used in a folder with many files

### DIFF
--- a/packages/cli/src/commands/console.ts
+++ b/packages/cli/src/commands/console.ts
@@ -8,7 +8,7 @@ import {log} from '@blitzjs/server'
 import chalk from 'chalk'
 
 // import {loadDependencies} from '../utils/load-dependencies'
-import {setupTsnode, BLITZ_MODULE_PATHS, loadBlitz} from '../utils/load-blitz'
+import {setupTsnode, getBlitzModulePaths, loadBlitz} from '../utils/load-blitz'
 import {runPrismaGeneration} from './db'
 
 const projectRoot = pkgDir.sync() || process.cwd()
@@ -50,7 +50,7 @@ export default class Console extends Command {
 
     const watchers = [
       // watch('package.json').on('change', () => Console.loadDependencies(repl)),
-      watch(BLITZ_MODULE_PATHS).on('all', () => Console.loadBlitz(repl)),
+      watch(getBlitzModulePaths()).on('all', () => Console.loadBlitz(repl)),
     ]
 
     repl

--- a/packages/cli/src/utils/load-blitz.ts
+++ b/packages/cli/src/utils/load-blitz.ts
@@ -14,23 +14,25 @@ export const setupTsnode = () => {
   require('tsconfig-paths/register')
 }
 
-export const BLITZ_MODULE_PATHS = [
-  ...globby.sync(
-    [
-      'app/**/{queries,mutations}/*.{js,ts,tsx}',
-      '**/utils/*.{js,ts,tsx}',
-      'jobs/**/*.{js,ts,tsx}',
-      'integrations/**/*.{js,ts,tsx}',
-    ],
-    {cwd: projectRoot, gitignore: true},
-  ),
-  'db',
-].map((p) => path.join(projectRoot, p))
+export function getBlitzModulePaths() {
+  return [
+    ...globby.sync(
+      [
+        'app/**/{queries,mutations}/*.{js,ts,tsx}',
+        '**/utils/*.{js,ts,tsx}',
+        'jobs/**/*.{js,ts,tsx}',
+        'integrations/**/*.{js,ts,tsx}',
+      ],
+      {cwd: projectRoot, gitignore: true},
+    ),
+    'db',
+  ].map((p) => path.join(projectRoot, p))
+}
 
 export const loadBlitz = () => {
   return Object.assign(
     {},
-    ...BLITZ_MODULE_PATHS.map((modulePath) => {
+    ...getBlitzModulePaths().map((modulePath) => {
       let name = path.parse(modulePath).name
       if (name === 'index') {
         const dirs = path.dirname(modulePath).split(path.sep)

--- a/packages/cli/test/commands/console.test.ts
+++ b/packages/cli/test/commands/console.test.ts
@@ -1,7 +1,7 @@
 import * as repl from 'repl'
 import * as chokidar from 'chokidar'
 import ConsoleCmd from '../../src/commands/console'
-import {BLITZ_MODULE_PATHS} from '../../src/utils/load-blitz'
+import {getBlitzModulePaths} from '../../src/utils/load-blitz'
 import {REPLServer} from 'repl'
 import {FSWatcher} from 'chokidar'
 
@@ -43,6 +43,6 @@ describe('Console command', () => {
     expect(mockRepl.defineCommand).toBeCalledWith('reload', ConsoleCmd.commands.reload)
 
     // expect(chokidar.watch).toBeCalledWith('package.json')
-    expect(chokidar.watch).toBeCalledWith(BLITZ_MODULE_PATHS)
+    expect(chokidar.watch).toBeCalledWith(getBlitzModulePaths())
   })
 })


### PR DESCRIPTION
### Pull Request Type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Tests related changes
- [ ] Other (please describe): Dependency updates

### Checklist

<!-- Please ensure your PR fulfills the following: -->

- [x] Tests added for changes (or N/A)
- [ ] Any added terminal logging uses `packages/server/src/log.ts` (or N/A)
- [ ] Code Coverage stayed the same or increased

### What's the reason for the change? :question:

Closes: #207 

### What are the changes and their implications? :gear:

This removes a globby side effect that was happening when the module was imported. Now the side effects are wrapped in a function so that importing the module does not cause the file system to start scanning.

### Does this introduce a breaking change? :warning:

- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path for existing apps-->

### Other information

<!-- Before/after screenshots, etc. -->
