### PR TITLE
Infer query arguments for Type Checking

### DIFF
--- a/packages/core/src/ssrQuery.ts
+++ b/packages/core/src/ssrQuery.ts
@@ -1,4 +1,5 @@
 import {IncomingMessage, OutgoingMessage} from 'http'
+import {InferUnaryParam} from '../types'
 
 type QueryFn = (...args: any) => Promise<any>
 
@@ -9,7 +10,7 @@ type SsrQueryContext = {
 
 export async function ssrQuery<T extends QueryFn>(
   queryFn: T,
-  params: any,
+  params: InferUnaryParam<T>,
   // @ts-ignore unused
   context: SsrQueryContext,
 ): Promise<ReturnType<T>> {

--- a/packages/core/src/ssrQuery.ts
+++ b/packages/core/src/ssrQuery.ts
@@ -1,5 +1,4 @@
 import {IncomingMessage, OutgoingMessage} from 'http'
-import {InferUnaryParam} from '../types'
 
 type QueryFn = (...args: any) => Promise<any>
 
@@ -7,6 +6,11 @@ type SsrQueryContext = {
   req: IncomingMessage
   res: OutgoingMessage
 }
+
+/**
+ * Infer the type of the parameter from function that takes a single argument
+ */
+type InferUnaryParam<F extends Function> = F extends (args: infer A) => any ? A : never
 
 export async function ssrQuery<T extends QueryFn>(
   queryFn: T,

--- a/packages/core/src/useQuery.ts
+++ b/packages/core/src/useQuery.ts
@@ -1,4 +1,5 @@
 import {useQuery as useReactQuery} from 'react-query'
+import {InferUnaryParam} from '../types'
 
 /**
  * Get the type of the value, that the Promise holds.
@@ -19,7 +20,7 @@ type QueryFn = (...args: any) => Promise<any>
 
 export function useQuery<T extends QueryFn>(
   queryFn: T,
-  params?: any,
+  params?: InferUnaryParam<T>,
   options: any = {},
 ): [PromiseReturnType<T>, Record<any, any>] {
   const {data, ...rest} = useReactQuery([(queryFn as any).cacheKey, params], (_, params) => queryFn(params), {

--- a/packages/core/src/useQuery.ts
+++ b/packages/core/src/useQuery.ts
@@ -1,5 +1,4 @@
 import {useQuery as useReactQuery} from 'react-query'
-import {InferUnaryParam} from '../types'
 
 /**
  * Get the type of the value, that the Promise holds.
@@ -17,6 +16,11 @@ type QueryFn = (...args: any) => Promise<any>
 //   (...args: any): Promise<any>
 //   cacheKey: string
 // }
+
+/**
+ * Infer the type of the parameter from function that takes a single argument
+ */
+type InferUnaryParam<F extends Function> = F extends (args: infer A) => any ? A : never
 
 export function useQuery<T extends QueryFn>(
   queryFn: T,

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -13,8 +13,3 @@ export type PromiseType<T extends PromiseLike<any>> = T extends PromiseLike<infe
  * Get the return type of a function which returns a Promise.
  */
 export type PromiseReturnType<T extends (...args: any) => Promise<any>> = PromiseType<ReturnType<T>>
-
-/**
- * Infer the type of the parameter from function that takes a single argument
- */
-export type InferUnaryParam<F extends Function> = F extends (args: infer A) => any ? A : never

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -13,3 +13,8 @@ export type PromiseType<T extends PromiseLike<any>> = T extends PromiseLike<infe
  * Get the return type of a function which returns a Promise.
  */
 export type PromiseReturnType<T extends (...args: any) => Promise<any>> = PromiseType<ReturnType<T>>
+
+/**
+ * Infer the type of the parameter from function that takes a single argument
+ */
+export type InferUnaryParam<F extends Function> = F extends (args: infer A) => any ? A : never


### PR DESCRIPTION
### Type: Type Checking 


### What are the changes and their implications? :gear:

This PR infer the type of query functions in order to have typesafe arguments

both for `useQuery` and `ssrQuery, it used to be `any`

### Breaking change: no

### Other information

![Screenshot 2020-04-26 at 11 47 29](https://user-images.githubusercontent.com/4562878/80310182-b99dc900-87d9-11ea-9460-e28e4593ad41.png)


Due to compiled code not being able to import type definition from the file `packages/core/types/index.d.tspackages/core/types/index.d.ts` I was forced to colocate the type definition (even tried with version 0.6.6, still not able to import it)





