### PR TITLE
test(server): normalize CWD in relative paths synchronizer rule test

### DIFF
--- a/packages/server/src/synchronizer/pipeline/rules/relative/relative-paths.test.ts
+++ b/packages/server/src/synchronizer/pipeline/rules/relative/relative-paths.test.ts
@@ -30,7 +30,9 @@ describe('relativeToAbsolute', () => {
   ]
   tests.forEach(({name, input: {filename, relativeImport}, expected}) => {
     it(name, () => {
-      expect(relativeToAbsolute('/projects/blitz/blitz', filename)(relativeImport)).toEqual(expected)
+      expect(relativeToAbsolute(normalize('/projects/blitz/blitz'), filename)(relativeImport)).toEqual(
+        expected,
+      )
     })
   })
 })


### PR DESCRIPTION
### Type: tests <!-- feature, bug fix, refactor, tests, etc -->

Tests were failing on Windows as the string replacement to strip the CWD from the final absolute path wasn't working due to it trying to strip `/projects/blitz/blitz` from `\projects\blitz\blitz\app\components\three`.

### What are the changes and their implications? :gear:

Normalized the CWD passed to `relativeToAbsolute` in test.

### Checklist

- [x] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no <!-- yes or no -->

N/A

### Other information

N/A