### PR TITLE
docs(tutorial): fix a couple typos and change some copy

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -27,52 +27,67 @@ This should create a `mysite` directory in your current directory.
 Let’s look at what `blitz new` created:
 
 ```
-mysite/
-  app/
-    components/
-      ErrorBoundary.tsx
-    layouts/
-    pages/
-      _app.tsx
-      _document.tsx
-      index.tsx
-  db/
-  integrations/
-  jobs/
-  node_modules/
-  public/
-  utils/
-  .babelrc.js
-  .env
-  .eslintrc.js
-  .gitignore
-  .npmrc
-  .prettierignore
-  blitz.config.js
-  package.json
-  README.md
-  tsconfig.json
+mysite
+|   .babelrc.js
+|   .env
+|   .eslintrc.js
+|   .gitignore
+|   .npmrc
+|   .prettierignore
+|   blitz.config.js
+|   package.json
+|   README.md
+|   tsconfig.json
+|   yarn.lock
+|
++---app
+|   +---components
+|   |       ErrorBoundary.tsx
+|   |
+|   +---layouts
+|   |
+|   \---pages
+|           index.tsx
+|           _app.tsx
+|           _document.tsx
+|
++---db
+|   |   index.ts
+|   |   schema.prisma
+|   |
+|   \---migrations
+|
++---integrations
+|
++---jobs
+|
++---node_modules
++---public
+|       favicon.ico
+|       logo.png
+|
+\---utils
 ```
 
 These files are:
 
-- The `app/` directory is a container for most of your project. This is where you’ll put any pages or api routes.
+- The `app/` directory is a container for most of your project. This is where you’ll put any pages or API routes.
 
 - `db`/ is where your database configuration goes. If you’re writing models or checking migrations, this is where to go.
 
-- `node_modules/` is where your “dependencies” are stored. This is an auto-generated directory, so you don’t have to worry too much about it.
+- `node_modules/` is where your “dependencies” are stored. This directory is updated by your package manager, so you don’t have to worry too much about it.
 
 - `public/` is a directory where you will put any static assets. If you have images, files, or videos which you want to use in your app, this is where to put them.
 
-- `utils/` is a good place to put any share util files which you might use across different sections of your app.
+- `utils/` is a good place to put any shared utility files which you might use across different sections of your app.
 
-- `dotfiles (.babelrc.js, .env, etc)` are configuration files for various bits of JavaScript tooling.
+- `.babelrc.js`, `.env`, etc. ("dotfiles") are configuration files for various bits of JavaScript tooling.
 
 - `blitz.config.js` is for advanced custom configuration of Blitz. It extends [`next.config.js`](https://nextjs.org/docs/api-reference/next.config.js/introduction).
 
 - `package.json` contains information about your dependencies and devDependencies. If you’re using a tool like `npm` or `yarn`, you won’t have to worry about this much.
 
-- `tsconfig.json` - is our recommended setup for TypeScript.
+- `tsconfig.json` is our recommended setup for TypeScript.
 
 ## The development server
 
@@ -201,7 +216,7 @@ Once you’re in the console, explore the Database API:
 
 ## Writing more pages
 
-Let’s create some more pages. Blitz provides a handy utility for scaffolding out pages, called `generate`. Let’s run it now with our Question model:
+Let’s create some more pages. Blitz provides a handy utility for scaffolding out pages, called `generate`. Let’s run it now with our `Question` model:
 
 ```sh
 $ blitz generate all question
@@ -227,7 +242,7 @@ export const QuestionsList = () => {
 }
 ```
 
-This won’t work though! Remember that the Question model we created above doesn’t have any `name` field. To fix this, replace `question.name` with `question.text`:
+This won’t work though! Remember that the `Question` model we created above doesn’t have any `name` field. To fix this, replace `question.name` with `question.text`:
 
 ```jsx
 export const QuestionsList = () => {
@@ -283,7 +298,7 @@ Great! Now make sure your app is running. If it isn’t, just run `blitz start` 
 
 ## Writing a minimal form
 
-You’re doing great so far! The next thing we’ll do is give our form some real inputs. At the moment it’s giving every Question the same name! Have a look at `app/questions/pages/questions/new.tsx` in your editor.
+You’re doing great so far! The next thing we’ll do is give our form some real inputs. At the moment it’s giving every `Question` the same name! Have a look at `app/questions/pages/questions/new.tsx` in your editor.
 
 Delete the div that says: `<div>Put your form fields here. But for now, just click submit</div>`, and replace it with some inputs:
 
@@ -360,7 +375,7 @@ const NewQuestionPage = () => {
 export default NewQuestionPage
 ```
 
-## Listing choices.
+## Listing choices
 
 Time for a breather. Go back to `http://localhost:3000/questions` in your browser and look at all the questions you‘ve created. How about we list these questions’ choices here too? First, we need to customise the question queries. In Prisma, you need to manually let the client know that you want to query for nested relations. Change your `getQuestion.ts` and `getQuestions.ts` files to look like this:
 
@@ -569,8 +584,8 @@ export default ShowQuestionPage
 
 - Adding styling
 - Showing some more statistics about votes
-- Deploying live so you can sent it around (we recommend [Vercel](https://vercel.com/))
+- Deploying live so you can send it around (we recommend [Vercel](https://vercel.com/))
 
 If you want to share your project with the world wide Blitz community there is no better place to do that than on Slack.
 
-Just visit https://slack.blitzjs.com. Then, post the link to the #show-and-tell channel to share it with everyone!
+Just visit https://slack.blitzjs.com. Then, post the link to the **#show-and-tell** channel to share it with everyone!

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -28,45 +28,36 @@ Let’s look at what `blitz new` created:
 
 ```
 mysite
-|   .babelrc.js
-|   .env
-|   .eslintrc.js
-|   .gitignore
-|   .npmrc
-|   .prettierignore
-|   blitz.config.js
-|   package.json
-|   README.md
-|   tsconfig.json
-|   yarn.lock
-|
-+---app
-|   +---components
-|   |       ErrorBoundary.tsx
-|   |
-|   +---layouts
-|   |
-|   \---pages
-|           index.tsx
-|           _app.tsx
-|           _document.tsx
-|
-+---db
-|   |   index.ts
-|   |   schema.prisma
-|   |
-|   \---migrations
-|
-+---integrations
-|
-+---jobs
-|
-+---node_modules
-+---public
-|       favicon.ico
-|       logo.png
-|
-\---utils
+├── app
+│   ├── components
+│   │   └── ErrorBoundary.tsx
+│   ├── layouts
+│   └── pages
+│       ├── _app.tsx
+│       ├── _document.tsx
+│       └── index.tsx
+├── db
+│   ├── migrations
+│   ├── index.ts
+│   └── schema.prisma
+├── integrations
+├── jobs
+├── node_modules
+├── public
+│   ├── favicon.ico
+│   └── logo.png
+├── utils
+├── .babelrc.js
+├── .env
+├── .eslintrc.js
+├── .gitignore
+├── .npmrc
+├── .prettierignore
+├── README.md
+├── blitz.config.js
+├── package.json
+├── tsconfig.json
+└── yarn.lock
 ```
 
 These files are:


### PR DESCRIPTION
### Type: docs <!-- feature, bug fix, refactor, tests, etc -->

### What are the changes and their implications? :gear:

Fixed a couple typos, formatted a couple things for consistency, generated the directory listing with `tree`, etc.

### Checklist

- [ ] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no <!-- yes or no -->

<!-- If yes, describe the impact and migration path for existing apps-->

### Other information

@merelinguist Thoughts on these changes? I can remove anything you don't care for, just say the word. Also, I noticed a lot of the punctuation (particularly apostrophes and double quotation marks) are currently represented using codes that are part of the ASCII extended character set rather than the basic set (e.g. `<E2><80><99>` instead of `'`). Do we care to change those? It's probably a locale and/or OS thing - not sure how the extended characters look to others.