### PR TITLE
[#330] Fix new app command order

### DIFF
--- a/packages/cli/src/generators/app.ts
+++ b/packages/cli/src/generators/app.ts
@@ -44,7 +44,7 @@ class AppGenerator extends Generator<AppGeneratorOptions> {
     const pkg = readJSONSync(pkgJsonLocation)
 
     console.log('') // New line needed
-    const spinner = log.spinner(log.withBranded('Retrieving the freshest of dependencies')).start()
+    const spinner = log.spinner(log.withBrand('Retrieving the freshest of dependencies')).start()
 
     const [
       {value: newDependencies, isFallback: dependenciesUsedFallback},
@@ -85,7 +85,7 @@ class AppGenerator extends Generator<AppGeneratorOptions> {
 
         if (!this.options.yarn) {
           const spinner = log
-            .spinner(log.withBranded('Installing those dependencies (this will take a few minutes)'))
+            .spinner(log.withBrand('Installing those dependencies (this will take a few minutes)'))
             .start()
           spinners.push(spinner)
         }
@@ -97,7 +97,7 @@ class AppGenerator extends Generator<AppGeneratorOptions> {
             let json = getJSON(data)
             if (json && json.type === 'step') {
               spinners[spinners.length - 1]?.succeed()
-              const spinner = log.spinner(log.withBranded(json.data.message)).start()
+              const spinner = log.spinner(log.withBrand(json.data.message)).start()
               spinners.push(spinner)
             }
             if (json && json.type === 'success') {

--- a/packages/cli/test/generators/app.test.ts
+++ b/packages/cli/test/generators/app.test.ts
@@ -1,0 +1,131 @@
+import * as fs from 'fs-extra'
+import spawn from 'cross-spawn'
+
+import AppGenerator from '../../src/generators/app'
+
+// Spies process to avoid trying to chdir to a non existing folder
+jest.spyOn(process, 'chdir').mockImplementation(() => true)
+// Mocks the log output
+jest.mock(
+  '@blitzjs/server',
+  jest.fn(() => {
+    return {
+      log: {
+        success: jest.fn(),
+        progress: jest.fn(),
+        error: jest.fn(),
+        withBranded: jest.fn(),
+        spinner: jest.fn().mockImplementation(() => {
+          return {
+            start: jest.fn().mockImplementation(() => ({succeed: jest.fn()})),
+          }
+        }),
+      },
+    }
+  }),
+)
+
+// Mocks spawn
+jest.mock('cross-spawn', () => {
+  const spawn = jest.fn().mockImplementation(() => {
+    return {
+      stdout: {
+        setEncoding: jest.fn(),
+        on: jest.fn(),
+      },
+      on: (_: any, callback: any) => callback(),
+    }
+  })
+  // @ts-ignore (TS complains about reassign)
+  spawn.sync = jest.fn().mockImplementation(() => {
+    return {status: 0}
+  })
+  return spawn
+})
+
+// Mocks fs-extra used by both AppGenerator and Generator base class
+jest.mock(
+  'fs-extra',
+  jest.fn(() => {
+    return {
+      readJSONSync: jest.fn().mockImplementation(() => ({
+        dependencies: {
+          react: '^16.8.0',
+        },
+        devDependencies: {
+          debug: '^4.1.1',
+        },
+      })),
+      ensureDir: jest.fn(),
+      existsSync: jest.fn(),
+      writeJson: jest.fn(),
+    }
+  }),
+)
+
+jest.mock(
+  'mem-fs-editor',
+  jest.fn(() => {
+    return {
+      create: jest.fn().mockImplementation(() => {
+        return {
+          move: jest.fn(),
+          commit: (_: any, callback: any) => callback(),
+          copy: jest.fn(),
+        }
+      }),
+    }
+  }),
+)
+
+describe('AppGenerator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const generator = new AppGenerator({
+    sourceRoot: '../../templates/app',
+    destinationRoot: '/new-app',
+    appName: 'new-app',
+    dryRun: false,
+    useTs: true,
+    yarn: true,
+    version: '1.0',
+    skipInstall: false,
+  })
+
+  describe('when creating dependencies', () => {
+    it('calls readJSONSync with package json location', async () => {
+      const expectedLocation = '/new-app/package.json'
+      await generator.run()
+      expect(fs.readJSONSync).toHaveBeenCalledWith(expectedLocation)
+    })
+
+    it('calls writeJson with package json location and package', async () => {
+      const expectedLocation = '/new-app/package.json'
+      await generator.run()
+
+      expect(fs.writeJson).toHaveBeenCalledWith(expectedLocation, expect.any(Object), {spaces: 2})
+    })
+  })
+
+  it('calls git init', async () => {
+    await generator.run()
+
+    expect(spawn.sync).toHaveBeenCalledWith('git', ['init'], {stdio: 'ignore'})
+  })
+
+  it('calls git add', async () => {
+    await generator.run()
+
+    expect(spawn.sync).toHaveBeenCalledWith('git', ['add', '.'], {stdio: 'ignore'})
+  })
+
+  it('calls git commit', async () => {
+    await generator.run()
+
+    expect(spawn.sync).toHaveBeenCalledWith('git', ['commit', '-m', 'New baby Blitz app!'], {
+      stdio: 'ignore',
+    })
+  })
+})


### PR DESCRIPTION
### Type: bug fix
Closes: #330

### What are the changes and their implications? :gear:
* Git init happens before any other step in `AppGenerator`.
* Husky hooks will now correctly be applied when commiting files.

### Checklist
- [x] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no

### Other information

I've took the opportunity to add tests as there were none before. I had to do some tricky mocks though, not super happy.

Locally when I run `yarn test` in the root folder in the project the `cli` tests fail. However, when running inside the `cd packages/cli && yarn test` everything is green. Does anyone know what is the issue?
I had to ignore the test hooks because they were not allowing me to push the code.
