### PR TITLE
Remove unnecessary runtime stream logging

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "cross-spawn": "^7.0.2",
     "fast-glob": "^3.2.2",
+    "flush-write-stream": "^2.0.0",
     "from2": "^2.3.0",
     "gulp-if": "^3.0.0",
     "merge-stream": "^2.0.0",
@@ -55,6 +56,7 @@
   },
   "devDependencies": {
     "@blitzjs/core": "0.7.1-canary.1",
+    "@types/flush-write-stream": "^1.0.0",
     "@types/mock-fs": "^4.10.0",
     "mock-fs": "^4.12.0"
   },

--- a/packages/server/src/synchronizer/display.ts
+++ b/packages/server/src/synchronizer/display.ts
@@ -5,10 +5,10 @@ import chalk from 'chalk'
 import {Event, FILE_WRITTEN, INIT, ERROR_THROWN, READY} from './events'
 
 /**
- * Reporter is a stream that converts build status events and prepares them for the console.
+ * Display is a stream that converts build status events and prepares them for the console.
  * A good way to think about this is as the root of the "view" component of the application.
  */
-export default function createReporter() {
+export default function createDisplay() {
   let lastEvent: Event<any> = {type: INIT, payload: null}
 
   let spinner = log.spinner('Preparing for launch').start()

--- a/packages/server/src/synchronizer/errors.ts
+++ b/packages/server/src/synchronizer/errors.ts
@@ -1,7 +1,7 @@
 import {log} from '../log'
 import {through} from './streams'
 import {Writable} from 'stream'
-import {ERROR_THROWN} from './reporter'
+import {ERROR_THROWN} from './events'
 
 export type Event<T> = {type: string; payload: T}
 

--- a/packages/server/src/synchronizer/events.ts
+++ b/packages/server/src/synchronizer/events.ts
@@ -1,0 +1,7 @@
+export type Event<T> = {type: string; payload: T}
+
+export const IDLE = 'IDLE'
+export const INIT = 'INIT'
+export const FILE_WRITTEN = 'FILE_WRITTEN'
+export const ERROR_THROWN = 'ERROR_THROWN'
+export const READY = 'READY'

--- a/packages/server/src/synchronizer/index.ts
+++ b/packages/server/src/synchronizer/index.ts
@@ -3,7 +3,7 @@ import {pipe} from './streams'
 import createPipeline from './pipeline'
 import agnosticSource from './pipeline/helpers/agnostic-source'
 import {pathExists, ensureDir, remove} from 'fs-extra'
-import createReporter, {READY} from './reporter'
+import createReporter, {READY, IDLE} from './reporter'
 import createErrors from './errors'
 
 type SynchronizeFilesInput = {
@@ -53,6 +53,7 @@ export async function synchronizeFiles({
     }
 
     const readyHandler = () => {
+      reporter.stream.write({type: IDLE, payload: null})
       reporter.stream.write({type: READY, payload: null})
       resolve({
         manifest: fileTransformPipeline.manifest,

--- a/packages/server/src/synchronizer/pipeline/helpers/agnostic-source.ts
+++ b/packages/server/src/synchronizer/pipeline/helpers/agnostic-source.ts
@@ -22,7 +22,6 @@ export const watch = (includePaths: string[] | string, options: chokidar.WatchOp
 
   function processEvent(evt: string) {
     return async (filepath: string, _stat: Stats) => {
-      console.log('Processing file...' + filepath)
       filepath = resolveFilepath(filepath)
 
       const fileOpts = Object.assign({}, options, {path: filepath})

--- a/packages/server/src/synchronizer/pipeline/helpers/idle-handler.test.ts
+++ b/packages/server/src/synchronizer/pipeline/helpers/idle-handler.test.ts
@@ -1,0 +1,53 @@
+import createIdleHandler from './idle-handler'
+
+import {to, pipeline, through} from '../../streams'
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('idlehander', () => {
+  it('should fire the idle event', async (done) => {
+    // TODO: work out a better way to tests streams
+
+    // Setup an input stream
+    const input = through({objectMode: true}, (ev, __, next) => {
+      next(null, ev)
+    })
+
+    // Setup a logger
+    const log: string[] = []
+    const logger = to.obj(function (evt, _, next) {
+      // If end
+      if (evt === 'end') {
+        expect(log).toEqual([{type: 'READY'}, {type: 'IDLE'}, {type: 'IDLE'}])
+        done()
+        next()
+        return
+      }
+
+      // log the event
+      log.push(evt)
+      next()
+    })
+
+    // setup the test pipeline
+    const idleHandler = createIdleHandler(logger, 100)
+    pipeline(input, idleHandler.stream)
+
+    const arr = [1, 2, 3, 4]
+    for (const item of arr) {
+      input.write(item)
+    }
+    await sleep(150)
+    for (const item of arr) {
+      input.write(item)
+    }
+
+    await sleep(150)
+    for (const item of arr) {
+      input.write(item)
+    }
+
+    input.end()
+    logger.write('end')
+  })
+})

--- a/packages/server/src/synchronizer/pipeline/helpers/idle-handler.ts
+++ b/packages/server/src/synchronizer/pipeline/helpers/idle-handler.ts
@@ -3,19 +3,21 @@ import {READY, IDLE} from '../../events'
 import {Writable} from 'stream'
 
 /**
- * Idle handler is used to close the promise and will run when
- * The input stream does not have input for a set time
- * This is asssumed to happen only during watch mode.
- * Note the idle event will continually fire if the threshold is not met
+ * Idle handler will fire events when the stream is idle
+ * for a certain amount of time.
+ *
+ * The first time it fires it will also fire a ready event
  */
-const readyHandler = (reporter: Writable) => {
+const idleHandler = (reporter: Writable) => {
   let timeout: NodeJS.Timeout
   let firstTime = true
 
   const handler = () => {
     if (firstTime) {
       reporter.write({type: READY})
+      firstTime = false
     }
+
     reporter.write({type: IDLE})
   }
 
@@ -41,4 +43,4 @@ const readyHandler = (reporter: Writable) => {
   return {stream}
 }
 
-export default readyHandler
+export default idleHandler

--- a/packages/server/src/synchronizer/pipeline/helpers/idle-handler.ts
+++ b/packages/server/src/synchronizer/pipeline/helpers/idle-handler.ts
@@ -8,7 +8,7 @@ import {Writable} from 'stream'
  *
  * The first time it fires it will also fire a ready event
  */
-const idleHandler = (reporter: Writable) => {
+const idleHandler = (reporter: Writable, delay: number = 500) => {
   let timeout: NodeJS.Timeout
   let firstTime = true
 
@@ -23,7 +23,7 @@ const idleHandler = (reporter: Writable) => {
 
   function resetTimeout() {
     destroyTimeout()
-    timeout = setTimeout(handler, 500)
+    timeout = setTimeout(handler, delay)
   }
 
   function destroyTimeout() {

--- a/packages/server/src/synchronizer/pipeline/helpers/idle-handler.ts
+++ b/packages/server/src/synchronizer/pipeline/helpers/idle-handler.ts
@@ -1,10 +1,10 @@
 import {through} from '../../streams'
 
 /**
- * Ready handler is used to close the promise and will run when
+ * Idle handler is used to close the promise and will run when
  * The input stream does not have input for a set time
  * This is asssumed to happen only during watch mode.
- * Note the ready event will continually fire if the threshold is not met
+ * Note the idle event will continually fire if the threshold is not met
  */
 const readyHandler = (handler: Function) => {
   let timeout: number

--- a/packages/server/src/synchronizer/pipeline/helpers/idle-handler.ts
+++ b/packages/server/src/synchronizer/pipeline/helpers/idle-handler.ts
@@ -1,4 +1,6 @@
 import {through} from '../../streams'
+import {READY, IDLE} from '../../events'
+import {Writable} from 'stream'
 
 /**
  * Idle handler is used to close the promise and will run when
@@ -6,8 +8,16 @@ import {through} from '../../streams'
  * This is asssumed to happen only during watch mode.
  * Note the idle event will continually fire if the threshold is not met
  */
-const readyHandler = (handler: Function) => {
-  let timeout: number
+const readyHandler = (reporter: Writable) => {
+  let timeout: NodeJS.Timeout
+  let firstTime = true
+
+  const handler = () => {
+    if (firstTime) {
+      reporter.write({type: READY})
+    }
+    reporter.write({type: IDLE})
+  }
 
   function resetTimeout() {
     destroyTimeout()

--- a/packages/server/src/synchronizer/pipeline/index.ts
+++ b/packages/server/src/synchronizer/pipeline/index.ts
@@ -2,7 +2,7 @@ import {pipeline, through} from '../streams'
 import {RuleConfig, RuleArgs} from '../types'
 import createFileEnricher from './helpers/enrich-files'
 import createFileCache from './helpers/file-cache'
-import createReadyHandler from './helpers/ready-handler'
+import createIdleHandler from './helpers/idle-handler'
 import createWorkOptimizer from './helpers/work-optimizer'
 import createRuleConfig from './rules/config'
 import createRuleManifest from './rules/manifest'
@@ -32,7 +32,7 @@ export default function createPipeline(
   const optimizer = createWorkOptimizer()
   const enrichFiles = createFileEnricher()
   const srcCache = createFileCache(isSourceFile)
-  const readyHandler = createReadyHandler(ready)
+  const idleHandler = createIdleHandler(ready)
 
   // Send this DI object to every rule
   const api: RuleArgs = {
@@ -73,7 +73,7 @@ export default function createPipeline(
     // TODO: try and move this up to business rules section
     ruleManifest.stream,
 
-    readyHandler.stream,
+    idleHandler.stream,
   )
 
   return {stream, manifest: ruleManifest.manifest}

--- a/packages/server/src/synchronizer/pipeline/index.ts
+++ b/packages/server/src/synchronizer/pipeline/index.ts
@@ -18,21 +18,15 @@ const input = through({objectMode: true}, (f, _, next) => next(null, f))
 /**
  * Creates a pipeline stream that transforms files.
  * @param config Config object containing basic information for the file pipeline
- * @param ready Ready handlerto run when ready event is fired
  * @param errors Stream that takes care of all operational error rendering
  * @param reporter Stream that takes care of all view rendering
  */
-export default function createPipeline(
-  config: RuleConfig,
-  ready: () => void,
-  errors: Writable,
-  reporter: Writable,
-) {
+export default function createPipeline(config: RuleConfig, errors: Writable, reporter: Writable) {
   // Helper streams don't account for business rules
   const optimizer = createWorkOptimizer()
   const enrichFiles = createFileEnricher()
   const srcCache = createFileCache(isSourceFile)
-  const idleHandler = createIdleHandler(ready)
+  const idleHandler = createIdleHandler(reporter)
 
   // Send this DI object to every rule
   const api: RuleArgs = {

--- a/packages/server/src/synchronizer/pipeline/rules/write/index.ts
+++ b/packages/server/src/synchronizer/pipeline/rules/write/index.ts
@@ -4,7 +4,7 @@ import {unlink} from '../../helpers/unlink'
 import {dest} from 'vinyl-fs'
 import File from 'vinyl'
 import {Rule} from '../../../types'
-import {FILE_WRITTEN} from '../../../reporter'
+import {FILE_WRITTEN} from '../../../events'
 
 /**
  * Returns a Rule that writes files to the destination path

--- a/packages/server/src/synchronizer/reporter.ts
+++ b/packages/server/src/synchronizer/reporter.ts
@@ -2,14 +2,7 @@ import {through} from './streams'
 import File from 'vinyl'
 import {log} from '../log'
 import chalk from 'chalk'
-
-export type Event<T> = {type: string; payload: T}
-
-export const IDLE = 'IDLE'
-export const INIT = 'INIT'
-export const FILE_WRITTEN = 'FILE_WRITTEN'
-export const ERROR_THROWN = 'ERROR_THROWN'
-export const READY = 'READY'
+import {Event, FILE_WRITTEN, INIT, ERROR_THROWN, READY} from './events'
 
 /**
  * Reporter is a stream that converts build status events and prepares them for the console.

--- a/packages/server/src/synchronizer/reporter.ts
+++ b/packages/server/src/synchronizer/reporter.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk'
 
 export type Event<T> = {type: string; payload: T}
 
+export const IDLE = 'IDLE'
 export const INIT = 'INIT'
 export const FILE_WRITTEN = 'FILE_WRITTEN'
 export const ERROR_THROWN = 'ERROR_THROWN'

--- a/packages/server/src/synchronizer/streams.ts
+++ b/packages/server/src/synchronizer/streams.ts
@@ -1,3 +1,6 @@
+// The following are a loose collaction of stream
+// helpers based on the missisippi library
+
 import {Stream} from 'stream'
 
 import pipe from 'pump'
@@ -8,7 +11,17 @@ export {through}
 
 export {default as parallel} from 'parallel-transform'
 
-export {default as from} from 'from2'
+// Fix issues with interop
+import from2 from 'from2'
+type From2 = typeof from2
+const from: From2 = require('from2')
+export {from}
+
+// Fix issues with interop
+import flushWriteStream from 'flush-write-stream'
+type FlushWriteStream = typeof flushWriteStream
+const to: FlushWriteStream = require('flush-write-stream')
+export {to}
 
 import pumpify from 'pumpify'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2645,6 +2645,13 @@
   resolved "https://registry.yarnpkg.com/@types/expect/-/expect-1.20.4.tgz#8288e51737bf7e3ab5d7c77bfa695883745264e5"
   integrity sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==
 
+"@types/flush-write-stream@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/flush-write-stream/-/flush-write-stream-1.0.0.tgz#6bc902a50c86ae30938320d269d32843d9aa7d76"
+  integrity sha512-vABEdzyrFxWkHeoLnaxc9NILYA7BWlY2BHQifHDVSRUZbWVuPSB22nzygWeWmjA9en2OzTx6waY7YPs+m9yzmg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/from2@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@types/from2/-/from2-2.3.0.tgz#5a3dd8d9db0363bc1ee6b98e0538fe0ae356ac3a"
@@ -7100,6 +7107,14 @@ flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+flush-write-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-2.0.0.tgz#6f58e776154f5eefacff92a6e5a681c88ac50f7c"
+  integrity sha512-uXClqPxT4xW0lcdSBheb2ObVU+kuqUk3Jk64EwieirEXZx9XUrVwp/JuBfKAWaM4T5Td/VL7QLDWPXp/MvGm/g==
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Type: bug fix

Closes: #213 

### What are the changes and their implications? :gear:

* Ready message only displays once
* Refactors the synchronizer display out to a separate pipable preparing for potential refactor to its own package.
* Uses the reporter as an event bus.
* Extract out events to separate file
* Passes streams not callbacks
* Tests the stream component

### Checklist

- [x] Tests added for changes
- [x] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no

### Other information
