### PR TITLE
Fix prettier failure on `blitz new` with npm

### DIFF
--- a/packages/cli/src/generators/app.ts
+++ b/packages/cli/src/generators/app.ts
@@ -69,14 +69,16 @@ class AppGenerator extends Generator<AppGeneratorOptions> {
 
     console.log(chalk.hex(themeColor).bold('\nDependencies successfully installed.'))
 
+    const runLocalNodeCLI = (command: string) => {
+      if (this.options.yarn) {
+        return spawn.sync('yarn', ['run', ...command.split(' ')])
+      } else {
+        return spawn.sync('npx', command.split(' '))
+      }
+    }
+
     // Ensure the generated files are formatted with the installed prettier version
-    const prettierResult = spawn.sync(
-      this.options.yarn ? 'yarn' : 'npm',
-      'run prettier --loglevel silent --write .'.split(' '),
-      {
-        stdio: 'ignore',
-      },
-    )
+    const prettierResult = runLocalNodeCLI('prettier --loglevel silent --write .')
     if (prettierResult.status !== 0) {
       throw new Error('Failed running prettier')
     }


### PR DESCRIPTION


### Type: bug fix

Closes: #331

### What are the changes and their implications? :gear:

The code was trying to run `npm run prettier`, but that's not that easy:
You'd have to create a special `prettier` script in your package.json to make that work.
The workaround for NPM users is to use NPX, which ships since NPM v5.2.

### Checklist

- [ ] Tests added for changes
- [x] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no

<!-- If yes, describe the impact and migration path for existing apps-->
