### PR TITLE
Fix postcss purge routes on Tailwind example

### DIFF
--- a/examples/tailwind/tailwind.config.js
+++ b/examples/tailwind/tailwind.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   purge: [
-    "./app/pages/**/*.{js,jsx,ts,tsx}",
-    "./app/components/**/*.{js,jsx,ts,tsx}"
+    "./**/{pages,components}/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
     extend: {},

--- a/examples/tailwind/tailwind.config.js
+++ b/examples/tailwind/tailwind.config.js
@@ -1,5 +1,8 @@
 module.exports = {
-  purge: ["./pages/**/*.{js,jsx,ts,tsx}", "./components/**/*.{js,jsx,ts,tsx}"],
+  purge: [
+    "./app/pages/**/*.{js,jsx,ts,tsx}",
+    "./app/components/**/*.{js,jsx,ts,tsx}"
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION

### Type: bug fix <!-- feature, bug fix, refactor, tests, etc -->

### What are the changes and their implications? :gear:

Fix `examples/tailwind`. Nextjs lives on `/app`.
```
module.exports = {
  purge: [
    "./app/pages/**/*.{js,jsx,ts,tsx}",
    "./app/components/**/*.{js,jsx,ts,tsx}"
  ],
  theme: {
```

### Checklist

- [ ] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no <!-- yes or no -->

<!-- If yes, describe the impact and migration path for existing apps-->

### Other information

<!-- Before/after screenshots, etc. -->

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
