### PR TITLE
Remove next dependency from new app template package.json

### DIFF
--- a/examples/store/package.json
+++ b/examples/store/package.json
@@ -14,18 +14,15 @@
     "@prisma/client": "2.0.0-beta.3",
     "blitz": "0.8.0-canary.2",
     "final-form": "4.19.1",
-    "next": "9.3.6",
     "react": "0.0.0-experimental-e5d06e34b",
     "react-dom": "0.0.0-experimental-e5d06e34b",
     "react-final-form": "6.4.0",
     "typescript": "3.8.3"
   },
-  "NOTE": "Next.js dependency is currently only required for deploying to zeit",
   "devDependencies": {
     "@types/react": "16.9.34",
     "cypress": "^4.4.1",
     "eslint-plugin-cypress": "2.10.3",
-    "next": "9.3.5",
     "start-server-and-test": "1.11.0"
   }
 }

--- a/examples/tailwind/package.json
+++ b/examples/tailwind/package.json
@@ -29,12 +29,10 @@
     "@prisma/cli": "2.0.0-beta.3",
     "@prisma/client": "2.0.0-beta.3",
     "blitz": "0.8.0-canary.2",
-    "next": "9.3.6",
     "react": "0.0.0-experimental-e5d06e34b",
     "react-dom": "0.0.0-experimental-e5d06e34b",
     "typescript": "3.8.3"
   },
-  "NOTE": "Next.js dependency is currently only required for deploying to zeit",
   "devDependencies": {
     "@types/react": "16.9.34",
     "@typescript-eslint/eslint-plugin": "2.29.0",
@@ -49,7 +47,6 @@
     "eslint-plugin-react-hooks": "3.0.0",
     "husky": "4.2.5",
     "lint-staged": "10.1.7",
-    "next": "9.3.5",
     "postcss-preset-env": "6.7.0",
     "prettier": "2.0.5",
     "pretty-quick": "2.0.1",

--- a/packages/cli/templates/app/package.json
+++ b/packages/cli/templates/app/package.json
@@ -33,7 +33,6 @@
     "react": "experimental",
     "react-dom": "experimental"
   },
-  "NOTE": "Next.js dependency is currently only required for deploying to zeit",
   "devDependencies": {
     "@types/react": "16.x",
     "@typescript-eslint/eslint-plugin": "2.x",
@@ -48,7 +47,6 @@
     "eslint-plugin-react-hooks": "3.x",
     "husky": "4.x",
     "lint-staged": "10.x",
-    "next": "9.x",
     "prettier": "2.x",
     "pretty-quick": "2.x",
     "typescript": "3.x"


### PR DESCRIPTION
### Type: fix <!-- feature, bug fix, refactor, tests, etc -->


### What are the changes and their implications? :gear:

This removes the `next` dependency from the package.json of the new app template and the examples apps.

This was causing some weird errors, like `blitz new` was failing when installed via npm.

We'll soon have native support on Vercel and this won't be needed anyways.