### PR TITLE
Fix broken `blitz start` in canary

### DIFF
--- a/packages/server/src/parse-chokidar-rules-from-gitignore.ts
+++ b/packages/server/src/parse-chokidar-rules-from-gitignore.ts
@@ -3,9 +3,17 @@ import fs from 'fs'
 import partition from 'lodash/partition'
 import fastGlob from 'fast-glob'
 
+function isControlledByUser(file: string) {
+  if (file.startsWith('node_modules')) {
+    return false
+  }
+
+  return true
+}
+
 function getAllGitIgnores(rootFolder: string) {
   const files = fastGlob.sync('**/.gitignore', {cwd: rootFolder})
-  return files.map((file) => {
+  return files.filter(isControlledByUser).map((file) => {
     const [prefix] = file.split('.gitignore')
     return {
       gitIgnore: fs.readFileSync(file, {encoding: 'utf8'}),

--- a/packages/server/src/parse-chokidar-rules-from-gitignore.ts
+++ b/packages/server/src/parse-chokidar-rules-from-gitignore.ts
@@ -35,7 +35,7 @@ export function chokidarRulesFromGitignore({gitIgnore, prefix}: {gitIgnore: stri
     if (!prefix) {
       return rule
     } else {
-      return prefix + '/' + rule
+      return prefix + rule
     }
   }
 

--- a/packages/server/src/parse-chokidar-rules-from-gitignore.ts
+++ b/packages/server/src/parse-chokidar-rules-from-gitignore.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import partition from 'lodash/partition'
 import fastGlob from 'fast-glob'
 
-function isControlledByUser(file: string) {
+export function isControlledByUser(file: string) {
   if (file.startsWith('node_modules')) {
     return false
   }

--- a/packages/server/test/parse-chokidar-rules-from-gitignore.test.ts
+++ b/packages/server/test/parse-chokidar-rules-from-gitignore.test.ts
@@ -1,11 +1,25 @@
-import {chokidarRulesFromGitignore} from '../src/parse-chokidar-rules-from-gitignore'
+import {chokidarRulesFromGitignore, isControlledByUser} from '../src/parse-chokidar-rules-from-gitignore'
+
+describe('isControlledByUser', () => {
+  describe('given a .gitignore from a dependency', () => {
+    it('returns false', () => {
+      expect(isControlledByUser('node_modules/npm-normalize-package-bin/.gitignore')).toBe(false)
+    })
+  })
+
+  describe('given a nested, but user-controlled file', () => {
+    it('returns true', () => {
+      expect(isControlledByUser('app/myassets/.gitignore')).toBe(true)
+    })
+  })
+})
 
 describe('chokidarRulesFromGitignore', () => {
   describe('when passed a simple, prefixed .gitignore file', () => {
     it('returns the prefixed chokidar rules', () => {
       expect(
         chokidarRulesFromGitignore({
-          prefix: 'src/app/db',
+          prefix: 'src/app/db/',
           gitIgnore: `
 .db_log
 !migrations


### PR DESCRIPTION
### Type: bug fix

Closes: #388

### What are the changes and their implications? :gear:

Fixes a bug in where a `.gitignore` file that's part of `node_modules` breaks `blitz start`.

### Checklist

- [x] Tests added for changes
- [x] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no
