### PR TITLE
fix(server): force forward slashes in absolute imports

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -51,6 +51,7 @@
     "readable-stream": "^3.6.0",
     "resolve-cwd": "^3.0.0",
     "serialize-error": "^6.0.0",
+    "slash": "^3.0.0",
     "through2": "^3.0.1",
     "vinyl": "^2.2.0",
     "vinyl-file": "^3.0.0",

--- a/packages/server/src/synchronizer/pipeline/rules/relative/index.ts
+++ b/packages/server/src/synchronizer/pipeline/rules/relative/index.ts
@@ -2,7 +2,7 @@ import {through} from '../../../streams'
 import File from 'vinyl'
 import {Rule} from '../../../types'
 import path from 'path'
-// import {relative} from 'path'
+import slash from 'slash'
 
 /**
  * Returns a Rule that converts relative files paths to absolute
@@ -43,7 +43,7 @@ export function relativeToAbsolute(_cwd: string, _filename: string) {
   return (filePath: string) => {
     if (filePath.indexOf('.') !== 0) return filePath
 
-    return path.join(path.dirname(_filename), filePath).replace(_cwd + path.sep, '')
+    return slash(path.join(path.dirname(_filename), filePath)).replace(_cwd + '/', '')
   }
 }
 

--- a/packages/server/src/synchronizer/pipeline/rules/relative/index.ts
+++ b/packages/server/src/synchronizer/pipeline/rules/relative/index.ts
@@ -43,7 +43,7 @@ export function relativeToAbsolute(_cwd: string, _filename: string) {
   return (filePath: string) => {
     if (filePath.indexOf('.') !== 0) return filePath
 
-    return slash(path.join(path.dirname(_filename), filePath)).replace(_cwd + '/', '')
+    return slash(path.join(path.dirname(_filename), filePath)).replace(slash(_cwd + path.sep), '')
   }
 }
 

--- a/packages/server/src/synchronizer/pipeline/rules/relative/index.ts
+++ b/packages/server/src/synchronizer/pipeline/rules/relative/index.ts
@@ -43,7 +43,7 @@ export function relativeToAbsolute(_cwd: string, _filename: string) {
   return (filePath: string) => {
     if (filePath.indexOf('.') !== 0) return filePath
 
-    return slash(path.join(path.dirname(_filename), filePath)).replace(slash(_cwd + path.sep), '')
+    return slash(path.join(path.dirname(_filename), filePath).replace(_cwd + path.sep, ''))
   }
 }
 

--- a/packages/server/src/synchronizer/pipeline/rules/relative/relative-paths.test.ts
+++ b/packages/server/src/synchronizer/pipeline/rules/relative/relative-paths.test.ts
@@ -1,21 +1,21 @@
 import {relativeToAbsolute, replaceRelativeImports} from './index'
 
+// I don't like this one bit, but Node's path module behaves so differently
+// based on the runtime platform that it's just easier to test paths as they
+// would be on the platform currently executing the test suite. Tests should
+// be run on both platforms, so both test paths will be executed - just not
+// during the same run.
+const platformSensitiveAbsolutePath = (p: string) =>
+  process.platform === 'win32' ? 'C:' + p.split('/').join('\\') : p
+
 describe('relativeToAbsolute', () => {
-  // I don't like this one bit, but Node's path module behaves so differently
-  // based on the runtime platform that it's just easier to test paths as they
-  // would be on the platform currently executing the test suite. Tests should
-  // be run on both platforms, so both test paths will be executed - just not
-  // during the same run.
-  const isWindows = process.platform === 'win32'
   const tests = [
     {
       name: 'Provides an absolute path within app',
       input: {
         relativeImport: '../components/three',
-        filename: isWindows
-          ? 'C:\\projects\\blitz\\blitz\\app\\users\\pages.ts'
-          : '/projects/blitz/blitz/app/users/pages.ts',
-        cwd: isWindows ? 'C:\\projects\\blitz\\blitz' : '/projects/blitz/blitz',
+        filename: platformSensitiveAbsolutePath('/projects/blitz/blitz/app/users/pages.ts'),
+        cwd: platformSensitiveAbsolutePath('/projects/blitz/blitz'),
       },
       expected: 'app/components/three',
     },
@@ -23,10 +23,8 @@ describe('relativeToAbsolute', () => {
       name: 'Works outside app',
       input: {
         relativeImport: '../../extras/foo',
-        filename: isWindows
-          ? 'C:\\projects\\blitz\\blitz\\app\\users\\pages.ts'
-          : '/projects/blitz/blitz/app/users/pages.ts',
-        cwd: isWindows ? 'C:\\projects\\blitz\\blitz' : '/projects/blitz/blitz',
+        filename: platformSensitiveAbsolutePath('/projects/blitz/blitz/app/users/pages.ts'),
+        cwd: platformSensitiveAbsolutePath('/projects/blitz/blitz'),
       },
       expected: 'extras/foo',
     },
@@ -34,10 +32,8 @@ describe('relativeToAbsolute', () => {
       name: 'Leaves absolute paths alone',
       input: {
         relativeImport: 'app/one/two',
-        filename: isWindows
-          ? 'C:\\projects\\blitz\\blitz\\app\\users\\pages.ts'
-          : '/projects/blitz/blitz/app/users/pages.ts',
-        cwd: isWindows ? 'C:\\projects\\blitz\\blitz' : '/projects/blitz/blitz',
+        filename: platformSensitiveAbsolutePath('/projects/blitz/blitz/app/users/pages.ts'),
+        cwd: platformSensitiveAbsolutePath('/projects/blitz/blitz'),
       },
       expected: 'app/one/two',
     },

--- a/packages/server/src/synchronizer/pipeline/rules/relative/relative-paths.test.ts
+++ b/packages/server/src/synchronizer/pipeline/rules/relative/relative-paths.test.ts
@@ -1,38 +1,35 @@
 import {relativeToAbsolute, replaceRelativeImports} from './index'
-import {normalize} from 'path'
 
 describe('relativeToAbsolute', () => {
   const tests = [
     {
       name: 'Provides an absolute path within app',
       input: {
-        relativeImport: normalize('../components/three'),
-        filename: normalize('/projects/blitz/blitz/app/users/pages.ts'),
+        relativeImport: '../components/three',
+        filename: '/projects/blitz/blitz/app/users/pages.ts',
       },
-      expected: normalize('app/components/three'),
+      expected: 'app/components/three',
     },
     {
       name: 'Works outside app',
       input: {
-        relativeImport: normalize('../../extras/foo'),
-        filename: normalize('/projects/blitz/blitz/app/users/pages.ts'),
+        relativeImport: '../../extras/foo',
+        filename: '/projects/blitz/blitz/app/users/pages.ts',
       },
-      expected: normalize('extras/foo'),
+      expected: 'extras/foo',
     },
     {
       name: 'Leaves absolute paths alone',
       input: {
-        relativeImport: normalize('app/one/two'),
-        filename: normalize('/projects/blitz/blitz/app/users/pages.ts'),
+        relativeImport: 'app/one/two',
+        filename: '/projects/blitz/blitz/app/users/pages.ts',
       },
-      expected: normalize('app/one/two'),
+      expected: 'app/one/two',
     },
   ]
   tests.forEach(({name, input: {filename, relativeImport}, expected}) => {
     it(name, () => {
-      expect(relativeToAbsolute(normalize('/projects/blitz/blitz'), filename)(relativeImport)).toEqual(
-        expected,
-      )
+      expect(relativeToAbsolute('/projects/blitz/blitz', filename)(relativeImport)).toEqual(expected)
     })
   })
 })

--- a/packages/server/src/synchronizer/pipeline/rules/relative/relative-paths.test.ts
+++ b/packages/server/src/synchronizer/pipeline/rules/relative/relative-paths.test.ts
@@ -1,15 +1,21 @@
 import {relativeToAbsolute, replaceRelativeImports} from './index'
 
 describe('relativeToAbsolute', () => {
+  // I don't like this one bit, but Node's path module behaves so differently
+  // based on the runtime platform that it's just easier to test paths as they
+  // would be on the platform currently executing the test suite. Tests should
+  // be run on both platforms, so both test paths will be executed - just not
+  // during the same run.
+  const isWindows = process.platform === 'win32'
   const tests = [
     {
       name: 'Provides an absolute path within app',
       input: {
         relativeImport: '../components/three',
-        filename: '/projects/blitz/blitz/app/users/pages.ts',
-        filenameWindows: 'C:\\projects\\blitz\\blitz\\app\\users\\pages.ts',
-        cwd: '/projects/blitz/blitz',
-        cwdWindows: 'C:\\projects\\blitz\\blitz',
+        filename: isWindows
+          ? 'C:\\projects\\blitz\\blitz\\app\\users\\pages.ts'
+          : '/projects/blitz/blitz/app/users/pages.ts',
+        cwd: isWindows ? 'C:\\projects\\blitz\\blitz' : '/projects/blitz/blitz',
       },
       expected: 'app/components/three',
     },
@@ -17,10 +23,10 @@ describe('relativeToAbsolute', () => {
       name: 'Works outside app',
       input: {
         relativeImport: '../../extras/foo',
-        filename: '/projects/blitz/blitz/app/users/pages.ts',
-        filenameWindows: 'C:\\projects\\blitz\\blitz\\app\\users\\pages.ts',
-        cwd: '/projects/blitz/blitz',
-        cwdWindows: 'C:\\projects\\blitz\\blitz',
+        filename: isWindows
+          ? 'C:\\projects\\blitz\\blitz\\app\\users\\pages.ts'
+          : '/projects/blitz/blitz/app/users/pages.ts',
+        cwd: isWindows ? 'C:\\projects\\blitz\\blitz' : '/projects/blitz/blitz',
       },
       expected: 'extras/foo',
     },
@@ -28,28 +34,18 @@ describe('relativeToAbsolute', () => {
       name: 'Leaves absolute paths alone',
       input: {
         relativeImport: 'app/one/two',
-        filename: '/projects/blitz/blitz/app/users/pages.ts',
-        filenameWindows: 'C:\\projects\\blitz\\blitz\\app\\users\\pages.ts',
-        cwd: '/projects/blitz/blitz',
-        cwdWindows: 'C:\\projects\\blitz\\blitz',
+        filename: isWindows
+          ? 'C:\\projects\\blitz\\blitz\\app\\users\\pages.ts'
+          : '/projects/blitz/blitz/app/users/pages.ts',
+        cwd: isWindows ? 'C:\\projects\\blitz\\blitz' : '/projects/blitz/blitz',
       },
       expected: 'app/one/two',
     },
   ]
 
-  describe('macOS and Linux', () => {
-    tests.forEach(({name, input: {cwd, filename, relativeImport}, expected}) => {
-      it(name, () => {
-        expect(relativeToAbsolute(cwd, filename)(relativeImport)).toEqual(expected)
-      })
-    })
-  })
-
-  describe('Windows', () => {
-    tests.forEach(({name, input: {cwdWindows, filenameWindows, relativeImport}, expected}) => {
-      it(name, () => {
-        expect(relativeToAbsolute(cwdWindows, filenameWindows)(relativeImport)).toEqual(expected)
-      })
+  tests.forEach(({name, input: {cwd, filename, relativeImport}, expected}) => {
+    it(name, () => {
+      expect(relativeToAbsolute(cwd, filename)(relativeImport)).toEqual(expected)
     })
   })
 })

--- a/packages/server/src/synchronizer/pipeline/rules/relative/relative-paths.test.ts
+++ b/packages/server/src/synchronizer/pipeline/rules/relative/relative-paths.test.ts
@@ -7,6 +7,9 @@ describe('relativeToAbsolute', () => {
       input: {
         relativeImport: '../components/three',
         filename: '/projects/blitz/blitz/app/users/pages.ts',
+        filenameWindows: 'C:\\projects\\blitz\\blitz\\app\\users\\pages.ts',
+        cwd: '/projects/blitz/blitz',
+        cwdWindows: 'C:\\projects\\blitz\\blitz',
       },
       expected: 'app/components/three',
     },
@@ -15,6 +18,9 @@ describe('relativeToAbsolute', () => {
       input: {
         relativeImport: '../../extras/foo',
         filename: '/projects/blitz/blitz/app/users/pages.ts',
+        filenameWindows: 'C:\\projects\\blitz\\blitz\\app\\users\\pages.ts',
+        cwd: '/projects/blitz/blitz',
+        cwdWindows: 'C:\\projects\\blitz\\blitz',
       },
       expected: 'extras/foo',
     },
@@ -23,13 +29,27 @@ describe('relativeToAbsolute', () => {
       input: {
         relativeImport: 'app/one/two',
         filename: '/projects/blitz/blitz/app/users/pages.ts',
+        filenameWindows: 'C:\\projects\\blitz\\blitz\\app\\users\\pages.ts',
+        cwd: '/projects/blitz/blitz',
+        cwdWindows: 'C:\\projects\\blitz\\blitz',
       },
       expected: 'app/one/two',
     },
   ]
-  tests.forEach(({name, input: {filename, relativeImport}, expected}) => {
-    it(name, () => {
-      expect(relativeToAbsolute('/projects/blitz/blitz', filename)(relativeImport)).toEqual(expected)
+
+  describe('macOS and Linux', () => {
+    tests.forEach(({name, input: {cwd, filename, relativeImport}, expected}) => {
+      it(name, () => {
+        expect(relativeToAbsolute(cwd, filename)(relativeImport)).toEqual(expected)
+      })
+    })
+  })
+
+  describe('Windows', () => {
+    tests.forEach(({name, input: {cwdWindows, filenameWindows, relativeImport}, expected}) => {
+      it(name, () => {
+        expect(relativeToAbsolute(cwdWindows, filenameWindows)(relativeImport)).toEqual(expected)
+      })
     })
   })
 })


### PR DESCRIPTION
### Type: bug fix <!-- feature, bug fix, refactor, tests, etc -->

Closes: #353

### What are the changes and their implications? :gear:

Sindre Sorhus to the rescue again. Slashified the result of `path.join` (it was trying to be helpful, but it wasn't in this particular case) to enforce forward slashes in absolute paths. A hack? Maybe. I don't know anymore.

### Checklist

- [x] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no <!-- yes or no -->

At least, I sure hope not.

### Other information

![CrossPlatformFileAccess50](https://user-images.githubusercontent.com/1288694/80831666-7ad88c00-8ba8-11ea-9bf5-3add653da6cf.gif)
