### PR TITLE
Fix `blitz new` on Linux (fromEntries/eslint-plugin error)

### DIFF
--- a/packages/cli/src/utils/get-latest-version.ts
+++ b/packages/cli/src/utils/get-latest-version.ts
@@ -25,7 +25,7 @@ export const getLatestVersion = async (
       fetchLatestDistVersion(dependency),
     ])
 
-    const latestVersion = Object.keys(allVersions)
+    const latestVersion = allVersions
       .filter((version) => version.startsWith(major))
       .sort((a, b) => a.localeCompare(b, undefined, {numeric: true}))
       .reverse()[0]

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -1,4 +1,5 @@
 import NewCmd from '../../src/commands/new'
+import {getLatestVersion} from '../../src/utils/get-latest-version'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
@@ -58,6 +59,26 @@ describe('`new` command', () => {
           expect(blitzVersion).toEqual(latest)
         }
       }))
+
+    it('fetches latest version from template', async () => {
+      const expectedVersion = '3.0.0'
+      const templatePackage = {name: 'eslint-plugin-react-hooks', version: '3.x'}
+
+      nock('https://registry.npmjs.org')
+        .get(`/${templatePackage.name}`)
+        .reply(200, {versions: {'4.0.0': {}, '3.0.0': {}}})
+        .persist()
+
+      nock('https://registry.npmjs.org')
+        .get(`/-/package/${templatePackage.name}/dist-tags`)
+        .reply(200, {
+          latest: '4.0.0',
+        })
+        .persist()
+
+      const {value: latestVersion} = await getLatestVersion(templatePackage.name, templatePackage.version)
+      expect(latestVersion).toBe(expectedVersion)
+    })
 
     describe('with network trouble', () => {
       it('uses template versions', async () => {

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -64,12 +64,14 @@ describe('`new` command', () => {
       const expectedVersion = '3.0.0'
       const templatePackage = {name: 'eslint-plugin-react-hooks', version: '3.x'}
 
-      nock('https://registry.npmjs.org')
+      const scope = nock('https://registry.npmjs.org')
+
+      scope
         .get(`/${templatePackage.name}`)
         .reply(200, {versions: {'4.0.0': {}, '3.0.0': {}}})
         .persist()
 
-      nock('https://registry.npmjs.org')
+      scope
         .get(`/-/package/${templatePackage.name}/dist-tags`)
         .reply(200, {
           latest: '4.0.0',


### PR DESCRIPTION
### Type: bug fix

Closes: #392 
Closes: #394 
Closes: #395 

### What are the changes and their implications? :gear:

`latestVersion` now returns version instead of array's index number. This will return the correct version when `latestDistVersion` does not contain desired version located in template.

### Checklist

- [x] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: No

<!-- If yes, describe the impact and migration path for existing apps-->

