### PR TITLE
Fix fetchRemote dev script to be sh compatible

### DIFF
--- a/scripts/fetchRemote.sh
+++ b/scripts/fetchRemote.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/scripts/fetchRemote.sh
+++ b/scripts/fetchRemote.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
-if [[ $(git remote -v | grep 'upstream' | wc -l) -eq 0 ]]; then
+if test "$(git remote -v | grep 'upstream' | wc -l)" = 0; then
   echo "Upstream remote not found, adding one"
   git remote add upstream https://github.com/blitz-js/blitz.git
 fi


### PR DESCRIPTION
### Type bug fix

Closes: #405 
### What are the changes and their implications? :gear:

* Does not use the `bash` `[[` syntax. Also uses `=` instead of `eq`.

### Checklist

- [ ] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change:no

### Other information

*Note: The original pull request simply changed the script to use `/bin/bash` but has since been refactored to continue using `sh` with compatible syntax.*