### PR TITLE
Add instructions on how to generate a plain JS project

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -16,11 +16,13 @@ If Blitz is installed, you should see the version of your installation. If it is
 
 If this is your first time using Blitz, you’ll have to begin with some initial setup. We provide a command which takes care of all this for you, generating the configuration and code you need to get started.
 
-From the command line, `cd` into the directory where you’d like to store your code, and then run the following command:
+From the command line, `cd` into the directory where you’d like to store your code, and then run the following command to create a new TypeScript blitz project:
 
 ```sh
 blitz new mysite
 ```
+
+*Note, you can create a JavaScript blitz project instead by running `blitz new mysite --js`; however, this tutorial assumes a TypeScript project.*
 
 This should create a `mysite` directory in your current directory.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -31,7 +31,7 @@ Blitz is built on Next.js, so if you are familiar with that, you will feel right
 ### Create Your Blitz App
 
 1. `npm install -g blitz` or `yarn global add blitz`
-2. Run `blitz new myAppName` to create a new blitz app in the `myAppName` directory
+2. Run `blitz new myAppName` to create a new TypeScript blitz app in the `myAppName` directory. Alternatively, run `blitz new myAppName --js` to create a JavaScript blitz app
 3. `cd myAppName`
 4. `blitz start`
 5. View your baby app at [http://localhost:3000](http://localhost:3000)
@@ -358,7 +358,6 @@ Here's the list of big things that are currently missing from Blitz but are a to
 
 ## FAQ
 
-- **Does Blitz support vanilla Javascript?** Yes, but `blitz new` generates all Typescript files right now. You can add new files with JS and/or convert the generated files to JS. There's an [open issue for generating vanilla JS files](https://github.com/blitz-js/blitz/issues/160) that needs help.
 - **Will you support other ESLint configs for the `blitz new` app?** Yes, there's [an issue for this](https://github.com/blitz-js/blitz/issues/161)
 
 <br>

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -301,7 +301,11 @@ You can deploy a Blitz app like a regular Node or Express project.
 
 #### `blitz new NAME`
 
-Generate a new blitz project at `<current_folder>./NAME`
+Generate a new TypeScript blitz project at `<current_folder>./NAME`
+
+#### `blitz new NAME --js`
+
+Generate a new JavaScript blitz project at `<current_folder>./NAME`
 
 #### `blitz start`
 


### PR DESCRIPTION
### Type: Docs update

Closes: #400 

### What are the changes and their implications? :gear:

* `USER_GUIDE.md` now contains instructions for creating a plain JS project - also, the FAQ item about the possibility of creating JS projects has been removed.
* `TUTORIAL.md` now contains a note about the existence of the `--js` option, while noting however that the tutorial assumes a TypeScript project.

### Checklist

- [ ] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no

### Other information
