### PR TITLE
Remove extraneous console.log

### DIFF
--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -126,7 +126,6 @@ abstract class Generator<T extends GeneratorOptions = GeneratorOptions> extends 
   }
 
   sourcePath(...paths: string[]): string {
-    console.log(path.join(this.sourceRoot, ...paths))
     return path.join(this.sourceRoot, ...paths)
   }
 


### PR DESCRIPTION
This extra `console.log` statement made it into the extraction of the generator from the CLI, just removing that line.