### PR TITLE
Fix badly broken `blitz generate` command!

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -152,18 +152,13 @@ export class Generate extends Command {
     }
 
     try {
-      let fileRoot: string
       let singularRootContext: string
-      // let pluralRootContext: string
-      let nestedContextPaths: string[] = []
-      // otherwise, validate the provided path, prompting the user if it's absent or invalid
+
       if (!flags.context) {
         if (fs.existsSync(path.resolve('app', pluralize(args.model)))) {
           singularRootContext = modelName(args.model)
-          fileRoot = modelNames(args.model)
         } else {
           singularRootContext = modelName(args.model)
-          fileRoot = modelNames(args.model)
         }
       } else {
         // use [\\/] as the separator to match UNIX and Windows path formats
@@ -175,14 +170,8 @@ export class Generate extends Command {
             )}'?`,
           )
           singularRootContext = modelName(args.model)
-          fileRoot = modelNames(args.model)
         } else {
-          // @ts-ignore shift can technically return undefined, but we already know the array isn't empty
-          // so we can bypass the check
-          fileRoot = modelNames(contextParts.shift())
           singularRootContext = modelName(args.model)
-          // pluralRootContext = modelNames(args.model)
-          nestedContextPaths = [...contextParts, modelNames(args.model)]
         }
       }
 
@@ -195,14 +184,6 @@ export class Generate extends Command {
           ModelName: ModelName(singularRootContext),
           ModelNames: ModelNames(singularRootContext),
           dryRun: flags['dry-run'],
-          // provide the file context as a relative path to the current directory (with a slash appended)
-          // to generate files without changing the current directory. This allows yeoman to print out the
-          // full file path rather than the current path
-          fileContext:
-            path.relative(
-              path.resolve(),
-              path.resolve('app', fileRoot, GeneratorClass.subdirectory, fileRoot, ...nestedContextPaths),
-            ) + '/',
           useTs: fs.existsSync(path.resolve('tsconfig.json')),
         })
         await generator.run()

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -15,7 +15,6 @@ export interface GeneratorOptions {
   destinationRoot?: string
   dryRun?: boolean
   useTs?: boolean
-  fileContext?: string
 }
 
 const alwaysIgnoreFiles = ['.blitz', '.DS_Store', '.git', '.next', '.now', 'node_modules']
@@ -51,6 +50,8 @@ export abstract class Generator<T extends GeneratorOptions = GeneratorOptions> e
   }
 
   abstract async getTemplateValues(): Promise<any>
+
+  abstract getTargetDirectory(): string
 
   filesToIgnore(): string[] {
     // allow subclasses to conditionally ignore certain template files
@@ -94,10 +95,7 @@ export abstract class Generator<T extends GeneratorOptions = GeneratorOptions> e
     for (let filePath of paths) {
       try {
         let pathSuffix = filePath
-        // if context was provided, prepend the context;
-        if (this.options.fileContext) {
-          pathSuffix = path.join(this.options.fileContext, pathSuffix)
-        }
+        pathSuffix = path.join(this.getTargetDirectory(), pathSuffix)
         const templateValues = await this.getTemplateValues()
 
         this.fs.copy(this.sourcePath(filePath), this.destinationPath(pathSuffix), {

--- a/packages/generator/src/generators/app-generator.ts
+++ b/packages/generator/src/generators/app-generator.ts
@@ -33,6 +33,10 @@ export class AppGenerator extends Generator<AppGeneratorOptions> {
     }
   }
 
+  getTargetDirectory() {
+    return ''
+  }
+
   async preCommit() {
     this.fs.move(this.destinationPath('gitignore'), this.destinationPath('.gitignore'))
   }

--- a/packages/generator/src/generators/model-generator.ts
+++ b/packages/generator/src/generators/model-generator.ts
@@ -7,7 +7,6 @@ export interface ModelGeneratorOptions extends GeneratorOptions {
   ModelNames: string
   modelName: string
   modelNames: string
-  fileContext: string
 }
 
 export class ModelGenerator extends Generator<ModelGeneratorOptions> {
@@ -16,6 +15,10 @@ export class ModelGenerator extends Generator<ModelGeneratorOptions> {
   sourceRoot: string = ''
 
   async getTemplateValues() {}
+
+  getTargetDirectory() {
+    return ''
+  }
 
   async write() {
     try {

--- a/packages/generator/src/generators/mutation-generator.ts
+++ b/packages/generator/src/generators/mutation-generator.ts
@@ -6,7 +6,6 @@ export interface MutationGeneratorOptions extends GeneratorOptions {
   ModelNames: string
   modelName: string
   modelNames: string
-  fileContext: string
 }
 
 export class MutationGenerator extends Generator<MutationGeneratorOptions> {
@@ -20,5 +19,9 @@ export class MutationGenerator extends Generator<MutationGeneratorOptions> {
       ModelName: this.options.ModelName,
       ModelNames: this.options.ModelNames,
     }
+  }
+
+  getTargetDirectory() {
+    return `app/${this.options.modelNames}/mutations`
   }
 }

--- a/packages/generator/src/generators/page-generator.ts
+++ b/packages/generator/src/generators/page-generator.ts
@@ -6,7 +6,6 @@ export interface PageGeneratorOptions extends GeneratorOptions {
   ModelNames: string
   modelName: string
   modelNames: string
-  fileContext: string
 }
 
 export class PageGenerator extends Generator<PageGeneratorOptions> {
@@ -21,5 +20,9 @@ export class PageGenerator extends Generator<PageGeneratorOptions> {
       ModelName: this.options.ModelName,
       ModelNames: this.options.ModelNames,
     }
+  }
+
+  getTargetDirectory() {
+    return `app/${this.options.modelNames}/pages/${this.options.modelNames}`
   }
 }

--- a/packages/generator/src/generators/query-generator.ts
+++ b/packages/generator/src/generators/query-generator.ts
@@ -6,7 +6,6 @@ export interface QueryGeneratorOptions extends GeneratorOptions {
   ModelNames: string
   modelName: string
   modelNames: string
-  fileContext: string
 }
 
 export class QueryGenerator extends Generator<QueryGeneratorOptions> {
@@ -20,5 +19,9 @@ export class QueryGenerator extends Generator<QueryGeneratorOptions> {
       ModelName: this.options.ModelName,
       ModelNames: this.options.ModelNames,
     }
+  }
+
+  getTargetDirectory() {
+    return `app/${this.options.modelNames}/queries`
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1225,7 +1225,7 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@fullhuman/postcss-purgecss@^2.1.2":
+"@fullhuman/postcss-purgecss@2.1.2", "@fullhuman/postcss-purgecss@^2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.1.2.tgz#8fe4d4ae2b58214b5452cb490a31c7146517442f"
   integrity sha512-Jf34YVBK9GtXTblpu0svNUJdA7rTQoRMz+yEJe6mwTnXDIGipWLzaX/VgU/x6IPC6WvU5SY/XlawwqhxoyFPTg==
@@ -3841,6 +3841,11 @@ ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
+ast-types@0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.3.tgz#50da3f28d17bdbc7969a3a2d83a0e4a72ae755a7"
+  integrity sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -4093,6 +4098,11 @@ babel-types@^6.26.0:
     esutils "^2.0.2"
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
+
+babylon@7.0.0-beta.47:
+  version "7.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.47.tgz#6d1fa44f0abec41ab7c780481e62fd9aafbdea80"
+  integrity sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==
 
 babylon@^6.18.0:
   version "6.18.0"
@@ -12931,6 +12941,16 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
+recast@0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.19.1.tgz#555f3612a5a10c9f44b9a923875c51ff775de6c8"
+  integrity sha512-8FCjrBxjeEU2O6I+2hyHyBFH1siJbMBLwIRvVr1T3FD2cL754sOaJDsJ/8h3xYltasbJ8jqWRIhMuDGBSiSbjw==
+  dependencies:
+    ast-types "0.13.3"
+    esprima "~4.0.0"
+    private "^0.1.8"
+    source-map "~0.6.1"
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
@@ -14558,6 +14578,31 @@ tagged-versions@1.3.0:
   dependencies:
     child-process-promise "^2.1.3"
     semver "^5.3.0"
+
+tailwindcss@1:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.4.4.tgz#a866f281f99ee7058fa3301ef0ce34b16141deb6"
+  integrity sha512-49Hy/+WnqQhxtGGjcGlhRlE7+hooX2A0/JOeJnA78fCEqDRlhURWujHY05aCl+lJ6G2qQ+1wlQTg4PqMPUcFVA==
+  dependencies:
+    "@fullhuman/postcss-purgecss" "^2.1.2"
+    autoprefixer "^9.4.5"
+    browserslist "^4.12.0"
+    bytes "^3.0.0"
+    chalk "^4.0.0"
+    color "^3.1.2"
+    detective "^5.2.0"
+    fs-extra "^8.0.0"
+    lodash "^4.17.15"
+    node-emoji "^1.8.1"
+    normalize.css "^8.0.1"
+    postcss "^7.0.11"
+    postcss-functions "^3.0.0"
+    postcss-js "^2.0.0"
+    postcss-nested "^4.1.1"
+    postcss-selector-parser "^6.0.0"
+    pretty-hrtime "^1.0.3"
+    reduce-css-calc "^2.1.6"
+    resolve "^1.14.2"
 
 tailwindcss@1.4.0:
   version "1.4.0"


### PR DESCRIPTION
### Type: bugfix 🤕

Closes: https://github.com/blitz-js/blitz/issues/402

### What are the changes and their implications? :gear:

Previously, we tried to dynamically generate a best-effort file path using generic rules in the `generate` command. However, the `generate` command doesn't really care, and shouldn't know about, where its files get placed. This odd merging of concerns made the path generation brittle and hard to understand.

By moving path generation into an abstract function in the Generator class we can delegate path construction to each child generator, allowing path generation to be easily special-cased rather than a one-size-fits-all solution. This drastically simplifies the logic in both the `blitz generate` command as well as the base `Generator`. 

### Checklist

- [ ] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no

I did run through the tutorial using my local build and things worked much more smoothly with this change :) 