### PR TITLE
test(generator): ignore dist directory

### DIFF
--- a/packages/generator/jest.config.js
+++ b/packages/generator/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   // collectCoverage: !!`Boolean(process.env.CI)`,
   collectCoverageFrom: ['src/**/*.ts'],
   coveragePathIgnorePatterns: ['/templates/'],
-  modulePathIgnorePatterns: ['<rootDie>/tmp', '<rootDir>/lib'],
+  modulePathIgnorePatterns: ['<rootDie>/tmp', '<rootDir>/dist'],
   // TODO enable threshold
   // coverageThreshold: {
   //   global: {


### PR DESCRIPTION
### Type: tests <!-- feature, bug fix, refactor, tests, etc -->

### What are the changes and their implications? :gear:

Configure Jest to ignore the `dist` (build output) directory.

### Checklist

- [ ] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no <!-- yes or no -->

N/A

### Other information


Jest complained about naming collisions with `dist`:

```
@blitzjs/generator: $ tsdx test
@blitzjs/generator: jest-haste-map: Haste module naming collision: __name__
@blitzjs/generator:   The following files share their name; please adjust your hasteImpl:
@blitzjs/generator:     * <rootDir>\templates\app\package.json
@blitzjs/generator:     * <rootDir>\dist\templates\app\package.json
```

It shouldn't be paying any attention to that directory, though (probably just left over from copy-pasta).
