### PR TITLE
Fix yarn dev errors

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "b": "./bin/run",
-    "predev": "wait-on -d 500 ../server/dist/packages/server/src/index.d.ts",
+    "predev": "wait-on -d 500 ../generator/dist/packages/generator/src/index.d.ts",
     "dev": "rimraf lib && tsc --watch --preserveWatchOutput",
     "build": "rimraf lib && tsc",
     "lint": "tsdx lint",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -9,7 +9,7 @@
     "register"
   ],
   "scripts": {
-    "dev": "tsdx watch --verbose",
+    "dev": "wait-on -d 500 ../server/dist/packages/server/src/index.d.ts && tsdx watch --verbose",
     "build": "tsdx build && yarn build:templates",
     "build:templates": "rimraf templates/**/node_modules && cpy --dot --parents '!/node_modules/' templates dist",
     "test": "tsdx test",


### PR DESCRIPTION
### Type:  bug fix

Closes: #431 

### What are the changes and their implications? :gear:

Ensure that when yarn dev is run that cli waits on generator waits on server. 

### Checklist

- [x] Tests added for changes
- [x] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no