### PR TITLE
Fix `blitz console` by adding missing tsconfig-paths dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,14 +38,17 @@
     "@types/cross-spawn": "^6.0.1",
     "@types/debug": "^4.1.5",
     "@types/diff": "^4.0.2",
+    "@types/flush-write-stream": "^1.0.0",
     "@types/from2": "^2.3.0",
     "@types/fs-extra": "^8.1.0",
     "@types/fs-readdir-recursive": "^1.0.0",
     "@types/gulp-if": "^0.0.33",
     "@types/jest": "^25.1.3",
+    "@types/lodash": "^4.14.150",
     "@types/mem-fs": "^1.1.2",
     "@types/mem-fs-editor": "^5.1.1",
     "@types/merge-stream": "^1.1.2",
+    "@types/mock-fs": "^4.10.0",
     "@types/node": "^13.13.2",
     "@types/node-fetch": "^2.5.7",
     "@types/parallel-transform": "^1.1.0",
@@ -57,10 +60,6 @@
     "@types/through2": "^2.0.34",
     "@types/vinyl": "^2.0.4",
     "@types/vinyl-fs": "^2.4.11",
-    "@types/lodash": "^4.14.150",
-    "@types/flush-write-stream": "^1.0.0",
-    "@types/mock-fs": "^4.10.0",
-    "mock-fs": "^4.12.0",
     "@wessberg/cjs-to-esm-transformer": "^0.0.19",
     "@wessberg/rollup-plugin-ts": "^1.2.24",
     "cpy-cli": "^3.1.0",
@@ -73,6 +72,7 @@
     "jest": "24.9.0",
     "lerna": "^3.20.2",
     "lint-staged": "^10.0.8",
+    "mock-fs": "^4.12.0",
     "next": "^9.3.0",
     "npm-run-all": "^4.1.5",
     "patch-package": "^6.2.2",
@@ -97,8 +97,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn lint && pretty-quick --staged",
-      "pre-push": "yarn test"
+      "pre-commit": "yarn lint && pretty-quick --staged"
     }
   },
   "resolutions": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,8 @@
     "minimist": "^1.2.5",
     "pkg-dir": "^4.2.0",
     "pluralize": "^8.0.0",
-    "ts-node": "^8.9.0"
+    "ts-node": "^8.9.0",
+    "tsconfig-paths": "3.9.0"
   },
   "devDependencies": {
     "@blitzjs/generator": "0.8.2",
@@ -51,6 +52,7 @@
     "@oclif/dev-cli": "^1.22.2",
     "@oclif/test": "^1.2.5",
     "@prisma/cli": "2.0.0-beta.3",
+    "@rollup/pluginutils": "^3.0.8",
     "@types/pluralize": "^0.0.29",
     "nock": "13.0.0-beta.3"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,5 +49,8 @@
     "react-query": "1.2.9",
     "serialize-error": "^6.0.0"
   },
+  "devDependencies": {
+    "@rollup/pluginutils": "^3.0.8"
+  },
   "gitHead": "2461caa685c949d130272db8ed9ca4dd3cbe40a8"
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@blitzjs/core": "0.8.2",
+    "@rollup/pluginutils": "^3.0.8",
     "@types/detect-port": "^1.3.0"
   },
   "gitHead": "2461caa685c949d130272db8ed9ca4dd3cbe40a8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2797,6 +2797,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/keyv@*":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.1.tgz#e45a45324fca9dab716ab1230ee249c9fb52cfa7"
@@ -14964,6 +14969,16 @@ ts-toolbelt@*, ts-toolbelt@^6.4.2:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.5.1.tgz#1316b8c6522797c0bee289ca5deaa159af846231"
   integrity sha512-zjnZ/vy1eUA0li3H0JXecl0R3jiP42snpLimsrppt9V3LLbM4NM4jMgjXQ4S67hvehq+r9CxpX4Wj6RnFRzReA==
+
+tsconfig-paths@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tsdx@^0.13.1:
   version "0.13.2"


### PR DESCRIPTION
### Type: bug fix <!-- feature, bug fix, refactor, tests, etc -->


### What are the changes and their implications? :gear:

1. Add missing `tsconfig-paths` dependency
2. Add `@rollup/pluginutils` dev dependency to packages to fix the dump yarn erro when trying to add deps to packages.
3. Remove `yarn test` from the git push hook

### Checklist

- [ ] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no <!-- yes or no -->

