### PR TITLE
Allow blitz in both dependencies and dev dependencies

### DIFF
--- a/packages/cli/src/utils/is-blitz-root.ts
+++ b/packages/cli/src/utils/is-blitz-root.ts
@@ -35,7 +35,7 @@ export const isBlitzRoot = async (): Promise<{err: boolean; message?: IsBlitzRoo
   try {
     const local = await readJSON('./package.json')
     if (local) {
-      if (Object.keys(local.dependencies || {}).includes('blitz')) {
+      if (local.dependencies['blitz'] || local.devDependencies['blitz']) {
         return {err: false}
       } else {
         return {


### PR DESCRIPTION
### Type:  bug fix

Closes: #473 

### What are the changes and their implications? :gear:

This allows blitz to run if it has been installed in either devDependencies as well as dependencies within `package.json`

### Checklist

- [ ] Tests added for changes
- [x] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no

