### PR TITLE
Pin react experimental version & fix graceful fallback for prisma version

### DIFF
--- a/packages/generator/src/utils/fetch-latest-version-for.ts
+++ b/packages/generator/src/utils/fetch-latest-version-for.ts
@@ -10,7 +10,8 @@ export const fetchLatestVersionsFor = async <T extends Record<string, string>>(
 
   const updated = await Promise.all(
     entries.map(async ([dep, version]) => {
-      if (version.match(/\d.x/)) {
+      // We pin experimental versions to ensure they work, so don't auto update experimental
+      if (version.match(/\d.x/) && !version.match(/experimental/)) {
         const {value: latestVersion, isFallback} = await getLatestVersion(dep, version)
 
         if (isFallback) {

--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -27,11 +27,11 @@
     ]
   },
   "dependencies": {
-    "@prisma/cli": "2.x",
-    "@prisma/client": "2.x",
+    "@prisma/cli": "2.0.0-beta.3",
+    "@prisma/client": "2.0.0-beta.3",
     "blitz": "canary",
-    "react": "experimental",
-    "react-dom": "experimental"
+    "react": "0.0.0-experimental-e5d06e34b",
+    "react-dom": "0.0.0-experimental-e5d06e34b"
   },
   "devDependencies": {
     "@types/react": "16.x",


### PR DESCRIPTION
### Type: bug fix 

### What are the changes and their implications? :gear:

1. Pin the react experimental version to one that works (latest is broken)
2. Change prisma version in package.json template to be a valid version `2.0.0-beta.4` instead of an invalid version `2.x` so that `npm i` will work if the dependency updater fails for some reason during `blitz new`

### Checklist

- [ ] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no

