### PR TITLE
Remove blitz db migrate from new app template build script

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -264,6 +264,7 @@ Blitz uses the `blitz.config.js` config file at the root of your project. This i
 3. You need your entire database connection string. If you need, [read the Prisma docs on this](https://www.prisma.io/docs/reference/database-connectors/postgresql#connection-details).
    1. If deploying to serverless with a connection pool, make sure you get the connection string to your connection pool, not directly to the DB.
 4. You need to change the defined datasource in `db/schema.prisma` from SQLite to Postgres
+5. Change your build script in package.json to be `blitz db migrate && blitz build` so that the production DB will be migrated on each deploy
 
 #### Serverless
 

--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "blitz start",
-    "build": "blitz db migrate && blitz build",
+    "build": "blitz build",
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts,.tsx .",
     "test": "echo \"No tests yet\""
   },


### PR DESCRIPTION
### Type: bug fix

Closes: #470

### What are the changes and their implications? :gear:

- Remove `blitz db migrate` from default package.json build script since it fails if DB isn't being used.
- Add to user guide about adding the migrate command to the build script

### Checklist

- [ ] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no