### PR TITLE
Fix blitz new --js not working in monorepo

### DIFF
--- a/examples/store/cypress/integration/products.test.ts
+++ b/examples/store/cypress/integration/products.test.ts
@@ -49,7 +49,7 @@ describe('products#ssr page', () => {
     cy.get('#products > p > a').first().click()
     cy.location('pathname').should('not.match', /\/products\/ssr$/)
 
-    cy.get('a').click()
+    cy.get('a').first().click()
     cy.location('pathname').should('equal', '/products')
   })
 })

--- a/packages/cli/src/commands/console.ts
+++ b/packages/cli/src/commands/console.ts
@@ -1,6 +1,7 @@
 import {Command} from '@oclif/command'
 import * as REPL from 'repl'
 import path from 'path'
+import fs from 'fs'
 import {REPLCommand, REPLServer} from 'repl'
 import {watch} from 'chokidar'
 import pkgDir from 'pkg-dir'
@@ -12,6 +13,7 @@ import {setupTsnode, getBlitzModulePaths, loadBlitz} from '../utils/load-blitz'
 import {runPrismaGeneration} from './db'
 
 const projectRoot = pkgDir.sync() || process.cwd()
+const isTypescript = fs.existsSync(path.join(projectRoot, 'tsconfig.json'))
 
 export class Console extends Command {
   static description = 'Run the Blitz console REPL'
@@ -37,14 +39,17 @@ export class Console extends Command {
   async run() {
     log.branded('You have entered the Blitz console')
     console.log(chalk.yellow('Tips: - Exit by typing .exit or pressing Ctrl-D'))
-    console.log(chalk.yellow('      - Use your db like this: db.user.findMany().then(console.log)'))
-    console.log(chalk.yellow('      - Use your queries/mutations like this: getUsers().then(console.log)'))
+    console.log(chalk.yellow('      - Use your db like this: db.project.findMany().then(console.log)'))
+    console.log(chalk.yellow('      - Use your queries/mutations like this: getProjects().then(console.log)'))
     console.log(
       chalk.yellow('      - Top level `await` support coming: https://github.com/blitz-js/blitz/issues/230'),
     )
 
     const spinner = log.spinner('Loading your code').start()
-    setupTsnode()
+    if (isTypescript) {
+      setupTsnode()
+    }
+
     await runPrismaGeneration({silent: true})
     spinner.succeed()
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -8,9 +8,13 @@ import {PageGenerator, MutationGenerator, QueryGenerator /* ModelGenerator */} f
 import {PromptAbortedError} from '../errors/prompt-aborted'
 import {log} from '@blitzjs/server'
 import camelCase from 'camelcase'
+import pkgDir from 'pkg-dir'
 const debug = require('debug')('blitz:generate')
 
 const pascalCase = (str: string) => camelCase(str, {pascalCase: true})
+
+const projectRoot = pkgDir.sync() || process.cwd()
+const isTypescript = fs.existsSync(path.join(projectRoot, 'tsconfig.json'))
 
 enum ResourceType {
   All = 'all',
@@ -177,7 +181,7 @@ export class Generate extends Command {
           ModelName: ModelName(singularRootContext),
           ModelNames: ModelNames(singularRootContext),
           dryRun: flags['dry-run'],
-          useTs: fs.existsSync(path.resolve('tsconfig.json')),
+          useTs: isTypescript,
         })
         await generator.run()
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3147,6 +3147,16 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
+"@typescript-eslint/eslint-plugin@2.31.0":
+  version "2.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.31.0.tgz#942c921fec5e200b79593c71fafb1e3f57aa2e36"
+  integrity sha512-iIC0Pb8qDaoit+m80Ln/aaeu9zKQdOLF4SHcGLarSeY1gurW6aU4JsOPMjKQwXlw70MvWKZQc6S2NamA8SJ/gg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "2.31.0"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/eslint-plugin@^2.12.0":
   version "2.30.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.30.0.tgz#312a37e80542a764d96e8ad88a105316cdcd7b05"
@@ -3177,6 +3187,16 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
+"@typescript-eslint/experimental-utils@2.31.0":
+  version "2.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.31.0.tgz#a9ec514bf7fd5e5e82bc10dcb6a86d58baae9508"
+  integrity sha512-MI6IWkutLYQYTQgZ48IVnRXmLR/0Q6oAyJgiOror74arUMh7EWjJkADfirZhRsUMHeLJ85U2iySDwHTSnNi9vA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.31.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
 "@typescript-eslint/parser@2.29.0":
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.29.0.tgz#6e3c4e21ed6393dc05b9d8b47f0b7e731ef21c9c"
@@ -3185,6 +3205,16 @@
     "@types/eslint-visitor-keys" "^1.0.0"
     "@typescript-eslint/experimental-utils" "2.29.0"
     "@typescript-eslint/typescript-estree" "2.29.0"
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/parser@2.31.0":
+  version "2.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.31.0.tgz#beddd4e8efe64995108b229b2862cd5752d40d6f"
+  integrity sha512-uph+w6xUOlyV2DLSC6o+fBDzZ5i7+3/TxAsH4h3eC64tlga57oMb96vVlXoMwjR/nN+xyWlsnxtbDkB46M2EPQ==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.31.0"
+    "@typescript-eslint/typescript-estree" "2.31.0"
     eslint-visitor-keys "^1.1.0"
 
 "@typescript-eslint/parser@^2.12.0":
@@ -3214,6 +3244,19 @@
   version "2.30.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.30.0.tgz#1b8e848b55144270255ffbfe4c63291f8f766615"
   integrity sha512-nI5WOechrA0qAhnr+DzqwmqHsx7Ulr/+0H7bWCcClDhhWkSyZR5BmTvnBEyONwJCTWHfc5PAQExX24VD26IAVw==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/typescript-estree@2.31.0":
+  version "2.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.31.0.tgz#ac536c2d46672aa1f27ba0ec2140d53670635cfd"
+  integrity sha512-vxW149bXFXXuBrAak0eKHOzbcu9cvi6iNcJDzEtOkRwGHxJG15chiAQAwhLOsk+86p9GTr/TziYvw+H9kMaIgA==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -9621,6 +9664,25 @@ lint-staged@10.1.7:
     dedent "^0.7.0"
     execa "^4.0.0"
     listr "^0.14.3"
+    log-symbols "^3.0.0"
+    micromatch "^4.0.2"
+    normalize-path "^3.0.0"
+    please-upgrade-node "^3.2.0"
+    string-argv "0.3.1"
+    stringify-object "^3.3.0"
+
+lint-staged@10.2.2:
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.2.2.tgz#901403c120eb5d9443a0358b55038b04c8a7db9b"
+  integrity sha512-78kNqNdDeKrnqWsexAmkOU3Z5wi+1CsQmUmfCuYgMTE8E4rAIX8RHW7xgxwAZ+LAayb7Cca4uYX4P3LlevzjVg==
+  dependencies:
+    chalk "^4.0.0"
+    commander "^5.0.0"
+    cosmiconfig "^6.0.0"
+    debug "^4.1.1"
+    dedent "^0.7.0"
+    execa "^4.0.0"
+    listr2 "1.3.8"
     log-symbols "^3.0.0"
     micromatch "^4.0.2"
     normalize-path "^3.0.0"


### PR DESCRIPTION
### What are the changes and their implications? :gear:

- Fix generator not generating JS when inside monorepo
- Fix warning about tsconfig-paths when loading `blitz console` in JS project

### Checklist

- [ ] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`
