### PR TITLE
Remove JS instructions and flag until we get bugs fixed (#407)"

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -16,13 +16,11 @@ If Blitz is installed, you should see the version of your installation. If it is
 
 If this is your first time using Blitz, you’ll have to begin with some initial setup. We provide a command which takes care of all this for you, generating the configuration and code you need to get started.
 
-From the command line, `cd` into the directory where you’d like to store your code, and then run the following command to create a new TypeScript blitz project:
+From the command line, `cd` into the directory where you’d like to store your code, and then run the following command:
 
 ```sh
 blitz new mysite
 ```
-
-_Note, you can create a JavaScript blitz project instead by running `blitz new mysite --js`; however, this tutorial assumes a TypeScript project._
 
 This should create a `mysite` directory in your current directory.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -31,7 +31,7 @@ Blitz is built on Next.js, so if you are familiar with that, you will feel right
 ### Create Your Blitz App
 
 1. `npm install -g blitz` or `yarn global add blitz`
-2. Run `blitz new myAppName` to create a new TypeScript blitz app in the `myAppName` directory. Alternatively, run `blitz new myAppName --js` to create a JavaScript blitz app
+2. Run `blitz new myAppName` to create a new blitz app in the `myAppName` directory
 3. `cd myAppName`
 4. `blitz start`
 5. View your baby app at [http://localhost:3000](http://localhost:3000)
@@ -301,11 +301,7 @@ You can deploy a Blitz app like a regular Node or Express project.
 
 #### `blitz new NAME`
 
-Generate a new TypeScript blitz project at `<current_folder>./NAME`
-
-#### `blitz new NAME --js`
-
-Generate a new JavaScript blitz project at `<current_folder>./NAME`
+Generate a new blitz project at `<current_folder>./NAME`
 
 #### `blitz start`
 
@@ -362,6 +358,7 @@ Here's the list of big things that are currently missing from Blitz but are a to
 
 ## FAQ
 
+- **Does Blitz support vanilla Javascript?** Yes, but `blitz new` generates all Typescript files right now. You can add new files with JS and/or convert the generated files to JS. There's an [open issue for generating vanilla JS files](https://github.com/blitz-js/blitz/issues/160) that needs help.
 - **Will you support other ESLint configs for the `blitz new` app?** Yes, there's [an issue for this](https://github.com/blitz-js/blitz/issues/161)
 
 <br>

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -358,7 +358,7 @@ Here's the list of big things that are currently missing from Blitz but are a to
 
 ## FAQ
 
-- **Does Blitz support vanilla Javascript?** Yes, but `blitz new` generates all Typescript files right now. You can add new files with JS and/or convert the generated files to JS. There's an [open issue for generating vanilla JS files](https://github.com/blitz-js/blitz/issues/160) that needs help.
+- **Does Blitz support vanilla Javascript?** Yes, but `blitz new` generates all Typescript files right now. We are actively working on this. It mostly works, but we have a few major bugs to fix before it's ready for prime time.
 - **Will you support other ESLint configs for the `blitz new` app?** Yes, there's [an issue for this](https://github.com/blitz-js/blitz/issues/161)
 
 <br>

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -31,6 +31,7 @@ export class New extends Command {
     js: flags.boolean({
       description: 'Generates a JS project. TypeScript is the default unless you add this flag.',
       default: false,
+      hidden: true,
     }),
     npm: flags.boolean({
       description: 'Use npm as the package manager. Yarn is the default if installed',


### PR DESCRIPTION
- This reverts commit 230c3634094567216f8b6e39afcad1bdf93ebb73.
- This hides the `--js` flag from `blitz new`

Because JS isn't fully working yet.
