### PR TITLE
🚀 Add context path option to `blitz generate`

### DIFF
--- a/packages/cli/test/commands/generate.test.ts
+++ b/packages/cli/test/commands/generate.test.ts
@@ -1,0 +1,25 @@
+import {Generate} from '../../src/commands/generate'
+import * as path from 'path'
+
+describe('`generate` command', () => {
+  it('properly extracts context from arguments', () => {
+    const getModelNameAndContext = Generate.prototype.getModelNameAndContext
+    expect(getModelNameAndContext('tasks', 'admin')).toEqual({
+      model: 'tasks',
+      context: 'admin',
+    })
+    expect(getModelNameAndContext('admin/tasks')).toEqual({
+      model: 'tasks',
+      context: 'admin',
+    })
+    expect(getModelNameAndContext('admin/projects/tasks')).toEqual({
+      model: 'tasks',
+      context: path.join('admin', 'projects'),
+    })
+    // this should fail on windows if generic filesystem-specific code makes it in
+    expect(getModelNameAndContext('admin\\projects\\tasks')).toEqual({
+      model: 'tasks',
+      context: path.join('admin', 'projects'),
+    })
+  })
+})

--- a/packages/cli/test/commands/generate.test.ts
+++ b/packages/cli/test/commands/generate.test.ts
@@ -12,10 +12,6 @@ describe('`generate` command', () => {
       model: 'tasks',
       context: 'admin',
     })
-    expect(getModelNameAndContext('admin\tasks')).toEqual({
-      model: 'tasks',
-      context: 'admin',
-    })
     expect(getModelNameAndContext('admin/projects/tasks')).toEqual({
       model: 'tasks',
       context: path.join('admin', 'projects'),

--- a/packages/cli/test/commands/generate.test.ts
+++ b/packages/cli/test/commands/generate.test.ts
@@ -12,6 +12,10 @@ describe('`generate` command', () => {
       model: 'tasks',
       context: 'admin',
     })
+    expect(getModelNameAndContext('admin\tasks')).toEqual({
+      model: 'tasks',
+      context: 'admin',
+    })
     expect(getModelNameAndContext('admin/projects/tasks')).toEqual({
       model: 'tasks',
       context: path.join('admin', 'projects'),

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -12,6 +12,7 @@ import babelTransformTypescript from '@babel/plugin-transform-typescript'
 import {ConflictChecker} from './conflict-checker'
 
 export interface GeneratorOptions {
+  context?: string
   destinationRoot?: string
   dryRun?: boolean
   useTs?: boolean

--- a/packages/generator/src/generators/mutation-generator.ts
+++ b/packages/generator/src/generators/mutation-generator.ts
@@ -22,6 +22,7 @@ export class MutationGenerator extends Generator<MutationGeneratorOptions> {
   }
 
   getTargetDirectory() {
-    return `app/${this.options.modelNames}/mutations`
+    const context = this.options.context ? `${this.options.context}/` : ''
+    return `app/${context}${this.options.modelNames}/mutations`
   }
 }

--- a/packages/generator/src/generators/page-generator.ts
+++ b/packages/generator/src/generators/page-generator.ts
@@ -23,6 +23,7 @@ export class PageGenerator extends Generator<PageGeneratorOptions> {
   }
 
   getTargetDirectory() {
-    return `app/${this.options.modelNames}/pages/${this.options.modelNames}`
+    const context = this.options.context ? `${this.options.context}/` : ''
+    return `app/${context}${this.options.modelNames}/pages/${this.options.modelNames}`
   }
 }

--- a/packages/generator/src/generators/query-generator.ts
+++ b/packages/generator/src/generators/query-generator.ts
@@ -22,6 +22,7 @@ export class QueryGenerator extends Generator<QueryGeneratorOptions> {
   }
 
   getTargetDirectory() {
-    return `app/${this.options.modelNames}/queries`
+    const context = this.options.context ? `${this.options.context}/` : ''
+    return `app/${context}${this.options.modelNames}/queries`
   }
 }


### PR DESCRIPTION
### Type: feature

Closes: https://github.com/blitz-js/blitz/issues/232

### What are the changes and their implications? :gear:

Adds a new CLI flag to support contextual file generation. Both Windows and UNIX paths are accepted, and you can pass the context in the model name rather than using the CLI flag if you'd like. That means all of the following are valid commands on any operating system:

* `blitz generate queries admin/tasks/todos`
* `blitz generate queries admin\tasks\todos`
* `blitz generate queries todos --context=admin/tasks`
* `blitz generate queries todos --context=admin\tasks`

All 4 of those output the exact same files - `app/admin/tasks/todos/queries/getTodo(s).ts`


### Checklist

- [x] Tests added for changes
- [x] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: No

