### PR TITLE
Fix 'blitz db reset' command

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -76,7 +76,7 @@ export async function resetPostgres(connectionString: string, db: any): Promise<
     await db.raw('GRANT ALL ON schema public TO postgres;')
     await db.raw('GRANT ALL ON schema public TO public;')
     // run migration
-    //await runMigrate()
+    await runMigrate()
     log.success('Your database has been reset.')
     process.exit(0)
   } catch (err) {
@@ -103,7 +103,7 @@ export async function resetMysql(connectionString: string, db: any): Promise<voi
 }
 
 export async function resetSqlite(connectionString: string): Promise<void> {
-  const dbPath: string = connectionString.replace(/^(?:\.\.\/)+/, '')
+  const dbPath: string = connectionString.replace(/^(?:\.\.[\\/])+/, '')
   const unlink = promisify(fs.unlink)
   try {
     // delete database from folder
@@ -196,7 +196,9 @@ ${chalk.bold('reset')}   Reset the database and run a fresh migration via Prisma
         message: 'Are you sure you want to reset your database and erase ALL data?',
       }).then((res) => {
         if (res.confirm) {
-          const db = require(path.join(projectRoot, 'db')).default
+          const prismaClientPath = require.resolve('@prisma/client', {paths: [projectRoot]})
+          const {PrismaClient} = require(prismaClientPath)
+          const db = new PrismaClient()
           const dataSource: any = db.internalDatasources[0]
           const connectorType: string = dataSource.connectorType
           const connectionString: string = dataSource.url.value


### PR DESCRIPTION
### Type: bug fix <!-- feature, bug fix, refactor, tests, etc -->

Closes: #401

### What are the changes and their implications? :gear:

- Updated database path regex to support Windows
- Instantiated own DB client rather than trying to require from `<projectRoot>/db/index.ts` (code is JS at runtime, can't require TS)
- Uncommented DB migration instruction for PostgreSQL reset

### Checklist

- [ ] Tests added for changes
- [ ] Any added terminal logging uses `packages/server/src/log.ts`

### Breaking change: no <!-- yes or no -->

N/A

### Other information

Before: `Error: Cannot find module 'C:/dev/test/myapp/db'`
After: `✔ Your database has been reset.`

Confirmed locally with PostgreSQL and SQLite on Windows 10 and macOS Catalina.

/cc @johncantrell97 just saw you were working on this - not sure if you had something in the works, but I can close this if so!