### PR TITLE
Fix git commit error during `blitz new`

### DIFF
--- a/packages/generator/src/utils/fetch-latest-version-for.ts
+++ b/packages/generator/src/utils/fetch-latest-version-for.ts
@@ -10,8 +10,19 @@ export const fetchLatestVersionsFor = async <T extends Record<string, string>>(
 
   const updated = await Promise.all(
     entries.map(async ([dep, version]) => {
+      let skipFetch = false
+
+      if (!version.match(/\d.x/)) skipFetch = true
+
       // We pin experimental versions to ensure they work, so don't auto update experimental
-      if (version.match(/\d.x/) && !version.match(/experimental/)) {
+      if (version.match(/experimental/)) skipFetch = true
+
+      // TODO: remove once 2.32.1+ is released
+      if (version.match(/typescript-eslint/)) skipFetch = true
+
+      if (skipFetch) {
+        return [dep, version]
+      } else {
         const {value: latestVersion, isFallback} = await getLatestVersion(dep, version)
 
         if (isFallback) {
@@ -19,8 +30,6 @@ export const fetchLatestVersionsFor = async <T extends Record<string, string>>(
         }
 
         return [dep, latestVersion]
-      } else {
-        return [dep, version]
       }
     }),
   )

--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -35,8 +35,8 @@
   },
   "devDependencies": {
     "@types/react": "16.x",
-    "@typescript-eslint/eslint-plugin": "2.x",
-    "@typescript-eslint/parser": "2.x",
+    "@typescript-eslint/eslint-plugin": "2.31.0",
+    "@typescript-eslint/parser": "2.31.0",
     "babel-eslint": "10.x",
     "eslint": "6.x",
     "eslint-config-react-app": "5.x",


### PR DESCRIPTION
Closes: #496

### What are the changes and their implications?

`@typescript-eslint/eslint-plugin` has a breaking change in a minor version. See #496 for details.

This temporarily pins that to the working version.

