### PR TITLE
Fix blitz new failing because of prettier babel-ts error

### DIFF
--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -36,6 +36,8 @@ export abstract class Generator<T extends GeneratorOptions = GeneratorOptions> e
   private useTs: boolean
   private prettier: typeof import('prettier') | undefined
 
+  prettierDisabled: boolean = false
+
   abstract sourceRoot: string
 
   constructor(protected readonly options: T) {
@@ -91,11 +93,17 @@ export abstract class Generator<T extends GeneratorOptions = GeneratorOptions> e
       )
     }
 
-    if (prettierExtensions.test(pathEnding) && typeof templatedFile === 'string' && this.prettier) {
-      templatedFile = this.prettier.format(templatedFile, {
-        parser: 'babel-ts',
-        ...prettierOptions,
-      })
+    if (
+      prettierExtensions.test(pathEnding) &&
+      typeof templatedFile === 'string' &&
+      this.prettier &&
+      !this.prettierDisabled
+    ) {
+      const options: Record<any, any> = {...prettierOptions}
+      if (this.useTs) {
+        options.parser = 'babel-ts'
+      }
+      templatedFile = this.prettier.format(templatedFile, options)
     }
     return templatedFile
   }

--- a/packages/generator/src/generators/app-generator.ts
+++ b/packages/generator/src/generators/app-generator.ts
@@ -18,6 +18,8 @@ export interface AppGeneratorOptions extends GeneratorOptions {
 
 export class AppGenerator extends Generator<AppGeneratorOptions> {
   sourceRoot: string = resolve(__dirname, './templates/app')
+  // Disable file-level prettier because we manually run prettier at the end
+  prettierDisabled = true
 
   filesToIgnore() {
     if (!this.options.useTs) {


### PR DESCRIPTION

### What are the changes and their implications?

The new prettier transform in the generator is breaking blitz new when published to npm. This disables it for new apps generation since we manually run prettier at the end.