### PR TITLE
Update fork sync script to add upstream remote

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,7 @@ yarn test
 #### Sync your fork
 
 ```sh
+git remote add upstream git@github.com:blitz-js/blitz.git
 ./scripts/fetchRemote.sh
 git merge upstream/canary
 ```


### PR DESCRIPTION
### What are the changes and their implications?

Running `./scripts/fetchRemote.sh` without setting a remote named `upstream` will throw an error:

```
fatal: 'upstream' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

This adds a step for contributors to add the remote first before running the script. 

### Checklist

- [ ] Tests added for changes
- [ ] User facing changes documented

### Breaking change: no

### Other information

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
