### PR TITLE
Add instructions to deploy to Render.com to the USER_GUIDE

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -256,14 +256,18 @@ Blitz uses the `blitz.config.js` config file at the root of your project. This i
 
 ### Deploy to Production
 
-1. You need a production Postgres database. It's easy to set this up on [Digital Ocean](https://www.digitalocean.com/products/managed-databases-postgresql/?refcode=466ad3d3063d).
-2. For deploying serverless, you also need a connection pool. This is also relatively easy to set up on Digital Ocean.
-   1. [Read the Digital Ocean docs on setting up your connection pool](https://www.digitalocean.com/docs/databases/postgresql/how-to/manage-connection-pools/#creating-a-connection-pool?refcode=466ad3d3063d)
-   2. Ensure you set your "Pool Mode" to be "Session" instead of "Transaction" (because of a bug in Prisma)
-3. You need your entire database connection string. If you need, [read the Prisma docs on this](https://www.prisma.io/docs/reference/database-connectors/postgresql#connection-details).
-   1. If deploying to serverless with a connection pool, make sure you get the connection string to your connection pool, not directly to the DB.
-4. You need to change the defined datasource in `db/schema.prisma` from SQLite to Postgres
-5. Change your build script in package.json to be `blitz db migrate && blitz build` so that the production DB will be migrated on each deploy
+You first need to change the defined datasource in `db/schema.prisma` from SQLite to Postgres
+
+```diff
+-datasource sqlite {
+-  provider = "sqlite"
+- url      = "file:./db.sqlite"
+-
++datasource postgresql {
++  provider = "postgresql"
++  url      = env("DATABASE_URL")
++}
+```
 
 #### Server
 
@@ -314,8 +318,15 @@ databases:
 
 Assuming you already have a Vercel account and the `now` cli installed, you can do the following:
 
-1. Add your DB url as a secret environment variable by running `now secrets add @database-url "DATABASE_CONNECTION_STRING"`
-2. Add a `now.json` at your project root with
+1. You need a production Postgres database. It's easy to set this up on [Digital Ocean](https://www.digitalocean.com/products/managed-databases-postgresql/?refcode=466ad3d3063d).
+2. For deploying serverless, you also need a connection pool. This is also relatively easy to set up on Digital Ocean.
+   1. [Read the Digital Ocean docs on setting up your connection pool](https://www.digitalocean.com/docs/databases/postgresql/how-to/manage-connection-pools/#creating-a-connection-pool?refcode=466ad3d3063d)
+   2. Ensure you set your "Pool Mode" to be "Session" instead of "Transaction" (because of a bug in Prisma)
+3. You need your entire database connection string. If you need, [read the Prisma docs on this](https://www.prisma.io/docs/reference/database-connectors/postgresql#connection-details).
+   1. If deploying to serverless with a connection pool, make sure you get the connection string to your connection pool, not directly to the DB.
+4. Change your build script in package.json to be `blitz db migrate && blitz build` so that the production DB will be migrated on each deploy
+5. Add your DB url as a secret environment variable by running `now secrets add @database-url "DATABASE_CONNECTION_STRING"`
+6. Add a `now.json` at your project root with
 
 ```json
 {
@@ -330,8 +341,8 @@ Assuming you already have a Vercel account and the `now` cli installed, you can 
 }
 ```
 
-3. Add `next` as a devDependency at the same version that Blitz includes (this is a temporary workaround until Blitz has first class support (very soon!))
-4. Run `now`
+7. Add `next` as a devDependency at the same version that Blitz includes (this is a temporary workaround until Blitz has first class support (very soon!))
+8. Run `now`
 
 Once working and deployed to production, your app should be very stable because it’s running Next.js which is already battle-tested.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -285,7 +285,7 @@ Without database:
 // render.yaml
 services:
   - type: web
-    name: blitz-on-render
+    name: myapp
     env: node
     plan: starter
     buildCommand: yarn
@@ -298,7 +298,7 @@ With postgres database:
 // render.yaml
 services:
   - type: web
-    name: blitz-on-render
+    name: myapp
     env: node
     plan: starter
     buildCommand: yarn; blitz db migrate
@@ -306,11 +306,11 @@ services:
     envVars:
       - key: DATABASE_URL
         fromDatabase:
-          name: blitz-on-render-db
+          name: myapp-db
           property: connectionString
 
 databases:
-  - name: blitz-on-render-db
+  - name: myapp-db
     plan: starter
 ```
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -265,6 +265,51 @@ Blitz uses the `blitz.config.js` config file at the root of your project. This i
 4. You need to change the defined datasource in `db/schema.prisma` from SQLite to Postgres
 5. Change your build script in package.json to be `blitz db migrate && blitz build` so that the production DB will be migrated on each deploy
 
+#### Server
+
+1. Add one of the render.yaml files shown below
+2. Push code to your github repo
+3. Log in to [Render.com](https://render.com)
+4. Click on the "YAML" menu item, then click the "New from YAML" button
+5. Connect your github account then select your blitz app repo
+6. Click approve
+7. Your server + database will be automatically configured and started. Each git push will trigger a new deploy
+
+Without database:
+
+```yaml
+// render.yaml
+services:
+  - type: web
+    name: blitz-on-render
+    env: node
+    plan: starter
+    buildCommand: yarn
+    startCommand: yarn blitz start --production -H 0.0.0.0
+```
+
+With postgres database:
+
+```yaml
+// render.yaml
+services:
+  - type: web
+    name: blitz-on-render
+    env: node
+    plan: starter
+    buildCommand: yarn; blitz db migrate
+    startCommand: yarn blitz start --production -H 0.0.0.0
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: blitz-on-render-db
+          property: connectionString
+
+databases:
+  - name: blitz-on-render-db
+    plan: starter
+```
+
 #### Serverless
 
 Assuming you already have a Vercel account and the `now` cli installed, you can do the following:
@@ -285,15 +330,10 @@ Assuming you already have a Vercel account and the `now` cli installed, you can 
 }
 ```
 
-3. Run `now`
+3. Add `next` as a devDependency at the same version that Blitz includes (this is a temporary workaround until Blitz has first class support (very soon!))
+4. Run `now`
 
 Once working and deployed to production, your app should be very stable because it’s running Next.js which is already battle-tested.
-
-#### Traditional, Long-Running Server
-
-You can deploy a Blitz app like a regular Node or Express project.
-
-`blitz start --production` will start your app in production mode. Make sure you provide the `DATABASE_URL` environment variable for your production database.
 
 <br>
 


### PR DESCRIPTION

### What are the changes and their implications?

Add instructions to deploy to Render.com to the USER_GUIDE

Deploying to Render is currently much easier than to Vercel because of the database integration.

