### PR TITLE
Fix bug in installer package with log imports

### DIFF
--- a/packages/installer/src/executors/add-dependency-executor.ts
+++ b/packages/installer/src/executors/add-dependency-executor.ts
@@ -2,7 +2,7 @@ import {BaseExecutor, executorArgument, getExecutorArgument} from './executor'
 import * as fs from 'fs-extra'
 import * as path from 'path'
 import spawn from 'cross-spawn'
-import {log} from '@blitzjs/server/src/log'
+import {log} from '@blitzjs/server'
 
 interface NpmPackage {
   name: string

--- a/packages/installer/src/executors/executor.ts
+++ b/packages/installer/src/executors/executor.ts
@@ -1,4 +1,4 @@
-import {log} from '@blitzjs/server/src/log'
+import {log} from '@blitzjs/server'
 
 export interface BaseExecutor {
   stepId: string | number

--- a/packages/installer/src/executors/file-transform-executor.ts
+++ b/packages/installer/src/executors/file-transform-executor.ts
@@ -1,7 +1,7 @@
 import {BaseExecutor, executorArgument, getExecutorArgument} from './executor'
 import {filePrompt} from './file-prompt'
 import {transform, Transformer} from '../utils/transform'
-import {log} from '@blitzjs/server/src/log'
+import {log} from '@blitzjs/server'
 import {waitForConfirmation} from '../utils/wait-for-confirmation'
 import {createPatch} from 'diff'
 import chokidar from 'chokidar'

--- a/packages/installer/src/executors/new-file-executor.ts
+++ b/packages/installer/src/executors/new-file-executor.ts
@@ -1,6 +1,6 @@
 import {BaseExecutor, executorArgument, getExecutorArgument} from './executor'
 import {Generator, GeneratorOptions} from '@blitzjs/generator'
-import {log} from '@blitzjs/server/src/log'
+import {log} from '@blitzjs/server'
 import {waitForConfirmation} from '../utils/wait-for-confirmation'
 
 export interface NewFileExecutor extends BaseExecutor {

--- a/packages/installer/src/installer.ts
+++ b/packages/installer/src/installer.ts
@@ -9,7 +9,7 @@ import {
   isFileTransformExecutor,
   fileTransformExecutor,
 } from './executors/file-transform-executor'
-import {log} from '@blitzjs/server/src/log'
+import {log} from '@blitzjs/server'
 import {logExecutorFrontmatter} from './executors/executor'
 import {waitForConfirmation} from './utils/wait-for-confirmation'
 


### PR DESCRIPTION
Not totally sure why my VSCode keeps autocompleting `log` to `@blitzjs/server/src/log`, but it's breaking when published since TSDX outputs a single file.

@flybayer @Skn0tt 