### PR TITLE
Fix some dependency install warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@types/node": "13.13.2",
     "@types/node-fetch": "2.5.7",
     "@types/parallel-transform": "1.1.0",
-    "@types/path-is-absolute": "1.0.0",
     "@types/prettier": "2.0.0",
     "@types/pump": "1.1.0",
     "@types/pumpify": "1.4.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,7 +44,6 @@
     "url": "https://github.com/blitz-js/blitz"
   },
   "dependencies": {
-    "@types/serialize-error": "4.0.1",
     "pretty-ms": "6.0.1",
     "react-query": "1.3.3",
     "serialize-error": "6.0.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -47,7 +47,6 @@
     "ora": "4.0.4",
     "parallel-transform": "1.2.0",
     "parse-gitignore": "1.0.1",
-    "path-is-absolute": "2.0.0",
     "pirates": "4.0.1",
     "pkg-dir": "4.2.0",
     "pumpify": "2.0.1",

--- a/packages/server/src/synchronizer/pipeline/helpers/agnostic-source.ts
+++ b/packages/server/src/synchronizer/pipeline/helpers/agnostic-source.ts
@@ -7,12 +7,11 @@ import File from 'vinyl'
 import chokidar from 'chokidar'
 import vinyl from 'vinyl-file'
 import {Stats} from 'fs'
-import {normalize, resolve} from 'path'
-import pathIsAbsolute from 'path-is-absolute'
+import {normalize, resolve, isAbsolute} from 'path'
 
 export const watch = (includePaths: string[] | string, options: chokidar.WatchOptions) => {
   function resolveFilepath(filepath: string) {
-    if (pathIsAbsolute(filepath)) {
+    if (isAbsolute(filepath)) {
       return normalize(filepath)
     }
     return resolve(options.cwd || process.cwd(), filepath)

--- a/packages/server/src/synchronizer/pipeline/helpers/agnostic-source.ts
+++ b/packages/server/src/synchronizer/pipeline/helpers/agnostic-source.ts
@@ -1,7 +1,6 @@
 import {through} from '../../streams'
 import vfs from 'vinyl-fs'
 import mergeStream from 'merge-stream'
-// import chokidar from 'chokidar'
 
 import File from 'vinyl'
 import chokidar from 'chokidar'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2975,13 +2975,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/serialize-error@4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@types/serialize-error/-/serialize-error-4.0.1.tgz#6c872b2eee28fef13533d36e2cfd5ae3baa0df3f"
-  integrity sha512-hb75EHpnDajMUIskN1q6kNgciFQ81NP8wnowIF3kDd/Mcux7fNXCZiJJ/jQXtBQ6T1gEZ7Jk2LSayzbNPLHDtg==
-  dependencies:
-    serialize-error "*"
-
 "@types/shelljs@^0.8.5":
   version "0.8.7"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.7.tgz#a2a606b185165abadf8b7995fea5e326e637088e"
@@ -14017,7 +14010,7 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-serialize-error@*, serialize-error@6.0.0:
+serialize-error@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-6.0.0.tgz#ccfb887a1dd1c48d6d52d7863b92544331fd752b"
   integrity sha512-3vmBkMZLQO+BR4RPHcyRGdE09XCF6cvxzk2N2qn8Er3F91cy8Qt7VvEbZBOpaL53qsBbe2cFOefU6tRY6WDelA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2875,11 +2875,6 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/path-is-absolute@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/path-is-absolute/-/path-is-absolute-1.0.0.tgz#af642f74c8216113d17c30154b83153acb758257"
-  integrity sha1-r2QvdMghYRPRfDAVS4MVOst1glc=
-
 "@types/pluralize@0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/pluralize/-/pluralize-0.0.29.tgz#6ffa33ed1fc8813c469b859681d09707eb40d03c"
@@ -11710,11 +11705,6 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
-
-path-is-absolute@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-2.0.0.tgz#cba416f4f3be5d068afe2083d9b3b3707414533d"
-  integrity sha512-ajROpjq1SLxJZsgSVCcVIt+ZebVH+PwJtPnVESjfg6JKwJGwAgHRC3zIcjvI0LnecjIHCJhtfNZ/Y/RregqyXg==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Closes: #229.

### What are the changes and their implications?

- Remove unneeded `@types/serialize-error` dependency => no implications, the library ships types.
- Replace `path-is-absolute` dependency (deprecated) in favour of `path.isAbsolute` => no implications, the change should be seamless.
- Remove commented (and duplicated) import => no implications, just useless code.

### Checklist

- [ ] Tests added for changes => nothing is tested over here, do we want to extract the `resolveFilepath` function and test it ? Probably not 🤔
- [x] User facing changes documented => no changes

### Breaking change: no

### Other information

--