### PR TITLE
Improve JSON readability on generated show page

### DIFF
--- a/packages/generator/templates/page/__modelIdParam__.tsx
+++ b/packages/generator/templates/page/__modelIdParam__.tsx
@@ -14,7 +14,7 @@ export const __ModelName__: React.FC = () => {
   return (
     <div>
       <h1>__ModelName__ {__modelName__.id}</h1>
-      <pre>{JSON.stringify(__modelName__)}</pre>
+      <pre>{JSON.stringify(__modelName__, null, 2)}</pre>
 
       {process.env.parentModel ? (
         <Link


### PR DESCRIPTION
### What are the changes and their implications?

Super small edit to make the JSON of the fields data on generated show pages more readable by default. Everyone will replace this in their app anyway, but makes the getting started experience slightly nicer.

| Before | After |
| --- | --- |
| <img width="1447" alt="Screen Shot 2020-05-24 at 4 04 51 PM" src="https://user-images.githubusercontent.com/5074763/82763857-9cf4b100-9dd8-11ea-8ec7-c22db2890f46.png"> | <img width="1447" alt="Screen Shot 2020-05-24 at 4 06 58 PM" src="https://user-images.githubusercontent.com/5074763/82763858-9d8d4780-9dd8-11ea-9216-be7c691175d4.png"> |

### Checklist

- [ ] Tests added for changes
- [ ] User facing changes documented

### Breaking change: yes/no

no

### Other information

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
