### PR TITLE
Fix Blitz Console in plain JS projects

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "cross-spawn": "7.0.2",
     "dotenv": "8.2.0",
     "enquirer": "2.3.4",
+    "esm": "3.2.25",
     "globby": "11.0.0",
     "got": "11.1.3",
     "has-yarn": "2.1.0",

--- a/packages/cli/src/utils/module.ts
+++ b/packages/cli/src/utils/module.ts
@@ -1,8 +1,10 @@
+const esmRequire = require('esm')(module)
+
 const invalidateCache = (module: string) => {
   delete require.cache[require.resolve(module)]
 }
 
 export const forceRequire = (module: string) => {
   invalidateCache(module)
-  return require(module)
+  return esmRequire(module)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6862,6 +6862,11 @@ eslint@6.8.0, eslint@^6.1.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
+esm@3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+
 espree@^6.1.1, espree@^6.1.2:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"


### PR DESCRIPTION
Closes: #461 

### What are the changes and their implications?

- Added `esm` dependency.
- Changed `require` to required function provided by `esm` dependency. I don't know the internals of `esm` but of course it may be slower to load the code into the console as it needs an extra step (but no other solution I would say 🤷‍♂️). 

### Breaking change: no