### PR TITLE
Fix `examples/store` code style issues

### DIFF
--- a/examples/store/.eslintrc.js
+++ b/examples/store/.eslintrc.js
@@ -1,13 +1,13 @@
 module.exports = {
-  extends: ['react-app', 'plugin:jsx-a11y/recommended'],
-  plugins: ['jsx-a11y', 'cypress'],
+  extends: ["react-app", "plugin:jsx-a11y/recommended"],
+  plugins: ["jsx-a11y", "cypress"],
   rules: {
-    'import/no-anonymous-default-export': 'error',
-    'import/no-webpack-loader-syntax': 'off',
-    'react/react-in-jsx-scope': 'off', // React is always in scope with Blitz
-    'jsx-a11y/anchor-is-valid': 'off', //Doesn't play well with Blitz/Next <Link> usage
+    "import/no-anonymous-default-export": "error",
+    "import/no-webpack-loader-syntax": "off",
+    "react/react-in-jsx-scope": "off", // React is always in scope with Blitz
+    "jsx-a11y/anchor-is-valid": "off", //Doesn't play well with Blitz/Next <Link> usage
   },
   env: {
-    'cypress/globals': true,
+    "cypress/globals": true,
   },
 }

--- a/examples/store/app/admin/pages/admin/index.tsx
+++ b/examples/store/app/admin/pages/admin/index.tsx
@@ -1,4 +1,4 @@
-import {Link} from 'blitz'
+import { Link } from "blitz"
 
 function StoreAdminPage() {
   return (

--- a/examples/store/app/admin/pages/admin/products/[id].tsx
+++ b/examples/store/app/admin/pages/admin/products/[id].tsx
@@ -1,14 +1,14 @@
-import {Suspense} from 'react'
-import {Link, useRouter, useQuery} from 'blitz'
-import getProduct from 'app/products/queries/getProduct'
-import ProductForm from 'app/products/components/ProductForm'
+import { Suspense } from "react"
+import { Link, useRouter, useQuery } from "blitz"
+import getProduct from "app/products/queries/getProduct"
+import ProductForm from "app/products/components/ProductForm"
 
 function Product() {
   const router = useRouter()
   const id = parseInt(router?.query.id as string)
-  const [product] = useQuery(getProduct, {where: {id}})
+  const [product] = useQuery(getProduct, { where: { id } })
 
-  return <ProductForm product={product} onSuccess={() => router.push('/admin/products')} />
+  return <ProductForm product={product} onSuccess={() => router.push("/admin/products")} />
 }
 
 function EditProductPage() {

--- a/examples/store/app/admin/pages/admin/products/new.tsx
+++ b/examples/store/app/admin/pages/admin/products/new.tsx
@@ -1,5 +1,5 @@
-import {Link, useRouter} from 'blitz'
-import ProductForm from 'app/products/components/ProductForm'
+import { Link, useRouter } from "blitz"
+import ProductForm from "app/products/components/ProductForm"
 
 function AdminNewProductPage() {
   const router = useRouter()
@@ -12,7 +12,7 @@ function AdminNewProductPage() {
         </Link>
       </p>
       <div>
-        <ProductForm onSuccess={() => router.push('/admin/products')} />
+        <ProductForm onSuccess={() => router.push("/admin/products")} />
       </div>
     </div>
   )

--- a/examples/store/app/components/ErrorBoundary.tsx
+++ b/examples/store/app/components/ErrorBoundary.tsx
@@ -1,7 +1,9 @@
-import React from 'react'
+import React from "react"
 
-export default class ErrorBoundary extends React.Component<{fallback: (error: any) => React.ReactNode}> {
-  state = {hasError: false, error: null}
+export default class ErrorBoundary extends React.Component<{
+  fallback: (error: any) => React.ReactNode
+}> {
+  state = { hasError: false, error: null }
 
   static getDerivedStateFromError(error: any) {
     return {

--- a/examples/store/app/pages/_document.tsx
+++ b/examples/store/app/pages/_document.tsx
@@ -1,9 +1,9 @@
-import {Document, Html, DocumentHead, Main, NextScript, DocumentContext} from '@blitzjs/core'
+import { Document, Html, DocumentHead, Main, NextScript, DocumentContext } from "@blitzjs/core"
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
     const initialProps = await Document.getInitialProps(ctx)
-    return {...initialProps}
+    return { ...initialProps }
   }
 
   render() {

--- a/examples/store/app/pages/index.tsx
+++ b/examples/store/app/pages/index.tsx
@@ -1,4 +1,4 @@
-import {Head, Link} from 'blitz'
+import { Head, Link } from "blitz"
 
 const Home = () => (
   <div className="container">
@@ -8,7 +8,7 @@ const Home = () => (
     </Head>
 
     <main>
-      <h1 className="title" style={{marginBottom: 24}}>
+      <h1 className="title" style={{ marginBottom: 24 }}>
         Blitz Store Example
       </h1>
       <ul>
@@ -39,7 +39,8 @@ const Home = () => (
       <a
         href="https://blitzjs.com?utm_source=blitz-new&utm_medium=app-template&utm_campaign=blitz-new"
         target="_blank"
-        rel="noopener noreferrer">
+        rel="noopener noreferrer"
+      >
         Powered by Blitz.js
       </a>
     </footer>
@@ -175,8 +176,8 @@ const Home = () => (
       body {
         padding: 0;
         margin: 0;
-        font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans,
-          Droid Sans, Helvetica Neue, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
+          Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
       }
 
       * {

--- a/examples/store/app/products/components/ProductForm.tsx
+++ b/examples/store/app/products/components/ProductForm.tsx
@@ -1,7 +1,7 @@
-import {Form, Field} from 'react-final-form'
-import {Product, ProductCreateInput, ProductUpdateInput} from 'db'
-import createProduct from '../mutations/createProduct'
-import updateProduct from '../mutations/updateProduct'
+import { Form, Field } from "react-final-form"
+import { Product, ProductCreateInput, ProductUpdateInput } from "db"
+import createProduct from "../mutations/createProduct"
+import updateProduct from "../mutations/updateProduct"
 
 type ProductInput = ProductCreateInput | ProductUpdateInput
 
@@ -15,58 +15,62 @@ type ProductFormProps = {
   onSuccess: (product: Product) => any
 }
 
-function ProductForm({product, style, onSuccess, ...props}: ProductFormProps) {
+function ProductForm({ product, style, onSuccess, ...props }: ProductFormProps) {
   return (
     <Form
-      initialValues={product || {name: null, handle: null, description: null, price: null}}
+      initialValues={product || { name: null, handle: null, description: null, price: null }}
       onSubmit={async (data: ProductInput) => {
         if (isNew(data)) {
           try {
-            const product = await createProduct({data})
+            const product = await createProduct({ data })
             onSuccess(product)
           } catch (error) {
-            alert('Error creating product ' + JSON.stringify(error, null, 2))
+            alert("Error creating product " + JSON.stringify(error, null, 2))
           }
         } else {
           try {
-            const product = await updateProduct({where: {id: data.id}, data})
+            const product = await updateProduct({ where: { id: data.id }, data })
             onSuccess(product)
           } catch (error) {
-            alert('Error updating product ' + JSON.stringify(error, null, 2))
+            alert("Error updating product " + JSON.stringify(error, null, 2))
           }
         }
       }}
-      render={({handleSubmit}) => (
-        <form onSubmit={handleSubmit} style={{maxWidth: 400, ...style}} {...props}>
-          <div style={{marginBottom: 16}}>
-            <label style={{display: 'flex', flexDirection: 'column'}}>
+      render={({ handleSubmit }) => (
+        <form onSubmit={handleSubmit} style={{ maxWidth: 400, ...style }} {...props}>
+          <div style={{ marginBottom: 16 }}>
+            <label style={{ display: "flex", flexDirection: "column" }}>
               Product Name
               <Field name="name" component="input" />
             </label>
           </div>
 
-          <div style={{marginBottom: 16}}>
-            <label style={{display: 'flex', flexDirection: 'column'}}>
+          <div style={{ marginBottom: 16 }}>
+            <label style={{ display: "flex", flexDirection: "column" }}>
               Handle
               <Field name="handle" component="input" />
             </label>
           </div>
 
-          <div style={{marginBottom: 16}}>
-            <label style={{display: 'flex', flexDirection: 'column'}}>
+          <div style={{ marginBottom: 16 }}>
+            <label style={{ display: "flex", flexDirection: "column" }}>
               Description
               <Field name="description" component="textarea" />
             </label>
           </div>
 
-          <div style={{marginBottom: 16}}>
-            <label style={{display: 'flex', flexDirection: 'column'}}>
+          <div style={{ marginBottom: 16 }}>
+            <label style={{ display: "flex", flexDirection: "column" }}>
               Price
-              <Field name="price" component="input" parse={(value) => (value ? parseInt(value) : null)} />
+              <Field
+                name="price"
+                component="input"
+                parse={(value) => (value ? parseInt(value) : null)}
+              />
             </label>
           </div>
 
-          <button>{product ? 'Update' : 'Create'} Product</button>
+          <button>{product ? "Update" : "Create"} Product</button>
         </form>
       )}
     />

--- a/examples/store/blitz.config.js
+++ b/examples/store/blitz.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  webpack: (config, {buildId, dev, isServer, defaultLoaders, webpack}) => {
+  webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
     // Note: we provide webpack above so you should not `require` it
     // Perform customizations to webpack config
     // Important: return the modified config

--- a/examples/store/cypress/integration/admin/index.test.ts
+++ b/examples/store/cypress/integration/admin/index.test.ts
@@ -1,16 +1,16 @@
-describe('admin#index page', () => {
+describe("admin#index page", () => {
   beforeEach(() => {
-    cy.visit('/admin')
+    cy.visit("/admin")
   })
 
-  it('Has H1', () => {
-    cy.visit('/admin')
-    cy.contains('h1', 'Store Admin')
+  it("Has H1", () => {
+    cy.visit("/admin")
+    cy.contains("h1", "Store Admin")
   })
 
-  it('goes to admin/products page', () => {
-    cy.contains('a', 'Manage Products').click()
-    cy.location('pathname').should('equal', '/admin/products')
+  it("goes to admin/products page", () => {
+    cy.contains("a", "Manage Products").click()
+    cy.location("pathname").should("equal", "/admin/products")
   })
 })
 

--- a/examples/store/cypress/integration/admin/products/edit.test.ts
+++ b/examples/store/cypress/integration/admin/products/edit.test.ts
@@ -1,49 +1,49 @@
-import {insert, data, fields} from './helper'
+import { insert, data, fields } from "./helper"
 
-describe('admin/products/[handle] page', () => {
+describe("admin/products/[handle] page", () => {
   beforeEach(() => {
     insert()
 
-    cy.visit('/admin/products')
-    cy.get('ul > li:last-child a').click()
+    cy.visit("/admin/products")
+    cy.get("ul > li:last-child a").click()
   })
 
-  it('Has h1 and link back', () => {
-    cy.contains('h1', 'Edit Product')
-    cy.get('p > a').first().contains('Manage Products').click()
-    cy.location('pathname').should('equal', '/admin/products')
+  it("Has h1 and link back", () => {
+    cy.contains("h1", "Edit Product")
+    cy.get("p > a").first().contains("Manage Products").click()
+    cy.location("pathname").should("equal", "/admin/products")
   })
 
-  it('Has all fields, change ProductName', () => {
-    cy.get('form > div > label').as('inputs')
-    cy.get('@inputs').should('have.length', 4)
+  it("Has all fields, change ProductName", () => {
+    cy.get("form > div > label").as("inputs")
+    cy.get("@inputs").should("have.length", 4)
 
     const random = Math.round(Math.random() * 100000).toString()
 
     const count = {}
     for (let i = 0; i < data.length; i++) {
-      const {label, type} = fields[i]
-      const [element, inputType] = type.split('|')
+      const { label, type } = fields[i]
+      const [element, inputType] = type.split("|")
       let item = data[i]
 
       if (count[element] === undefined) count[element] = 0
       if (inputType) {
-        cy.get('@inputs').get(element).eq(count[element]).should('have.attr', 'type', inputType)
+        cy.get("@inputs").get(element).eq(count[element]).should("have.attr", "type", inputType)
       }
 
       item += random
 
-      cy.get('@inputs').eq(i).contains(label)
-      cy.get('@inputs').get(element).eq(count[element]).clear().type(item)
-      cy.get('@inputs').get(element).eq(count[element]).should('have.value', item)
+      cy.get("@inputs").eq(i).contains(label)
+      cy.get("@inputs").get(element).eq(count[element]).clear().type(item)
+      cy.get("@inputs").get(element).eq(count[element]).should("have.value", item)
 
       count[element]++
     }
 
-    cy.get('button').click()
+    cy.get("button").click()
 
-    cy.location('pathname').should('equal', '/admin/products')
-    cy.get('ul > li:last-child').contains(data[0] + random)
+    cy.location("pathname").should("equal", "/admin/products")
+    cy.get("ul > li:last-child").contains(data[0] + random)
   })
 })
 

--- a/examples/store/cypress/integration/admin/products/helper.ts
+++ b/examples/store/cypress/integration/admin/products/helper.ts
@@ -1,45 +1,45 @@
 export const fields = [
-  {label: 'Product Name', type: 'input|', uniq: true},
-  {label: 'Handle', type: 'input|', uniq: true},
-  {label: 'Description', type: 'textarea|'},
-  {label: 'Price', type: 'input|'}, // TODO: Add input type here input|number
+  { label: "Product Name", type: "input|", uniq: true },
+  { label: "Handle", type: "input|", uniq: true },
+  { label: "Description", type: "textarea|" },
+  { label: "Price", type: "input|" }, // TODO: Add input type here input|number
 ]
-export const data = ['Apples', 'apples', 'Fresh apples', '32']
+export const data = ["Apples", "apples", "Fresh apples", "32"]
 
 export const insert = (): string => {
-  cy.visit('/admin/products/new')
-  cy.get('form > div > label').as('inputs')
-  cy.get('@inputs').should('have.length', 4)
+  cy.visit("/admin/products/new")
+  cy.get("form > div > label").as("inputs")
+  cy.get("@inputs").should("have.length", 4)
 
   const random = Math.round(Math.random() * 100000).toString()
   const name = data[0] + random
 
   const count = {}
   for (let i = 0; i < data.length; i++) {
-    const {label, type, uniq} = fields[i]
-    const [element, inputType] = type.split('|')
+    const { label, type, uniq } = fields[i]
+    const [element, inputType] = type.split("|")
     let item = data[i]
 
     if (count[element] === undefined) count[element] = 0
     if (inputType) {
-      cy.get('@inputs').get(element).eq(count[element]).should('have.attr', 'type', inputType)
+      cy.get("@inputs").get(element).eq(count[element]).should("have.attr", "type", inputType)
     }
 
     if (uniq) {
       item += random
     }
 
-    cy.get('@inputs').eq(i).contains(label)
-    cy.get('@inputs').eq(i).type(item)
-    cy.get('@inputs').get(element).eq(count[element]).should('have.value', item)
+    cy.get("@inputs").eq(i).contains(label)
+    cy.get("@inputs").eq(i).type(item)
+    cy.get("@inputs").get(element).eq(count[element]).should("have.value", item)
 
     count[element]++
   }
 
-  cy.get('button').click()
+  cy.get("button").click()
 
-  cy.location('pathname').should('equal', '/admin/products')
-  cy.get('ul > li:first-child').contains(name)
+  cy.location("pathname").should("equal", "/admin/products")
+  cy.get("ul > li:first-child").contains(name)
 
   return name
 }

--- a/examples/store/cypress/integration/admin/products/index.test.ts
+++ b/examples/store/cypress/integration/admin/products/index.test.ts
@@ -1,28 +1,28 @@
-import {insert} from './helper'
+import { insert } from "./helper"
 
-describe('admin/products page', () => {
+describe("admin/products page", () => {
   beforeEach(() => {
-    cy.visit('/admin/products')
+    cy.visit("/admin/products")
   })
 
-  it('Has H1', () => {
-    cy.contains('h1', 'Products')
+  it("Has H1", () => {
+    cy.contains("h1", "Products")
   })
 
-  it('goes to new product page', () => {
-    cy.get('p > a').first().contains('Create Product').click()
-    cy.location('pathname').should('equal', '/admin/products/new')
+  it("goes to new product page", () => {
+    cy.get("p > a").first().contains("Create Product").click()
+    cy.location("pathname").should("equal", "/admin/products/new")
   })
 
-  it('goes to bas product page', () => {
-    cy.get('p > a').last().contains('Admin').click()
-    cy.location('pathname').should('equal', '/admin')
+  it("goes to bas product page", () => {
+    cy.get("p > a").last().contains("Admin").click()
+    cy.location("pathname").should("equal", "/admin")
   })
 
   // This is kind of redundant because this logic is handled in insert()
-  it('shows latest created product', () => {
+  it("shows latest created product", () => {
     const name = insert()
-    cy.get('ul > li').contains(name)
+    cy.get("ul > li").contains(name)
   })
 })
 

--- a/examples/store/cypress/integration/admin/products/new.test.ts
+++ b/examples/store/cypress/integration/admin/products/new.test.ts
@@ -1,17 +1,17 @@
-import {insert} from './helper'
+import { insert } from "./helper"
 
-describe('admin/products/new page', () => {
+describe("admin/products/new page", () => {
   beforeEach(() => {
-    cy.visit('/admin/products/new')
+    cy.visit("/admin/products/new")
   })
 
-  it('Has h1 and link back', () => {
-    cy.contains('h1', 'Create a New Product')
-    cy.get('p > a').first().contains('Manage Products').click()
-    cy.location('pathname').should('equal', '/admin/products')
+  it("Has h1 and link back", () => {
+    cy.contains("h1", "Create a New Product")
+    cy.get("p > a").first().contains("Manage Products").click()
+    cy.location("pathname").should("equal", "/admin/products")
   })
 
-  it('Fills fields and creates product', () => {
+  it("Fills fields and creates product", () => {
     insert()
   })
 })

--- a/examples/store/cypress/integration/index.test.ts
+++ b/examples/store/cypress/integration/index.test.ts
@@ -1,21 +1,21 @@
-describe('index page', () => {
+describe("index page", () => {
   beforeEach(() => {
-    cy.visit('/')
+    cy.visit("/")
   })
 
-  it('Has title and H1', () => {
-    cy.contains('h1', 'Blitz Store Example')
-    cy.title().should('eq', 'Blitz Example Store')
+  it("Has title and H1", () => {
+    cy.contains("h1", "Blitz Store Example")
+    cy.title().should("eq", "Blitz Example Store")
   })
 
-  it('goes to products page', () => {
-    cy.contains('a', 'Static Product Listings').click()
-    cy.location('pathname').should('equal', '/products')
+  it("goes to products page", () => {
+    cy.contains("a", "Static Product Listings").click()
+    cy.location("pathname").should("equal", "/products")
   })
 
-  it('goes to admin page', () => {
-    cy.contains('a', 'Admin Section (client-rendered)').click()
-    cy.location('pathname').should('equal', '/admin/products')
+  it("goes to admin page", () => {
+    cy.contains("a", "Admin Section (client-rendered)").click()
+    cy.location("pathname").should("equal", "/admin/products")
   })
 })
 

--- a/examples/store/cypress/integration/products.test.ts
+++ b/examples/store/cypress/integration/products.test.ts
@@ -1,56 +1,56 @@
-describe('products#index page', () => {
-  it('Has H1', () => {
-    cy.visit('/products')
-    cy.contains('h1', 'Products')
+describe("products#index page", () => {
+  it("Has H1", () => {
+    cy.visit("/products")
+    cy.contains("h1", "Products")
   })
 })
 
-describe('products#show page', () => {
+describe("products#show page", () => {
   beforeEach(() => {
-    cy.visit('/products')
+    cy.visit("/products")
   })
 
-  it('goes to product page', () => {
-    cy.get('#products > p > a').first().click()
-    cy.location('pathname').should('match', /\/products\/\S+$/)
+  it("goes to product page", () => {
+    cy.get("#products > p > a").first().click()
+    cy.location("pathname").should("match", /\/products\/\S+$/)
   })
 
-  it('has price and title', () => {
-    cy.get('#products > p > a').first().click()
-    cy.location('pathname').should('match', /\/products\/\S+$/)
+  it("has price and title", () => {
+    cy.get("#products > p > a").first().click()
+    cy.location("pathname").should("match", /\/products\/\S+$/)
 
-    cy.get('p').should('have.length', 2)
-    cy.get('p')
+    cy.get("p").should("have.length", 2)
+    cy.get("p")
       .last()
       .contains(/Price: \$[0-9]*/)
 
-    cy.get('h1').should('have.length', 1)
+    cy.get("h1").should("have.length", 1)
   })
 
-  it('goes to back to products page', () => {
-    cy.get('#products > p > a').first().click()
-    cy.location('pathname').should('match', /\/products\/\S+$/)
+  it("goes to back to products page", () => {
+    cy.get("#products > p > a").first().click()
+    cy.location("pathname").should("match", /\/products\/\S+$/)
 
-    cy.get('a').first().click()
-    cy.location('pathname').should('equal', '/products')
+    cy.get("a").first().click()
+    cy.location("pathname").should("equal", "/products")
   })
 })
 
-describe('products#ssr page', () => {
+describe("products#ssr page", () => {
   beforeEach(() => {
-    cy.visit('/products/ssr')
+    cy.visit("/products/ssr")
   })
 
-  it('has title', () => {
-    cy.get('h1').contains('Products')
+  it("has title", () => {
+    cy.get("h1").contains("Products")
   })
 
-  it('goes to back to products page', () => {
-    cy.get('#products > p > a').first().click()
-    cy.location('pathname').should('not.match', /\/products\/ssr$/)
+  it("goes to back to products page", () => {
+    cy.get("#products > p > a").first().click()
+    cy.location("pathname").should("not.match", /\/products\/ssr$/)
 
-    cy.get('a').first().click()
-    cy.location('pathname').should('equal', '/products')
+    cy.get("a").first().click()
+    cy.location("pathname").should("equal", "/products")
   })
 })
 

--- a/examples/store/cypress/support/index.js
+++ b/examples/store/cypress/support/index.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import "./commands"
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')


### PR DESCRIPTION
### What are the changes and their implications?
The files in `examples/store` directory were styled with the wrong prettier config. This PR applies the right config on those files, and it will make future PR's cleaner.

### Breaking change: yes/no
No.

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->