### PR TITLE
Tidy up tests in server

### DIFF
--- a/packages/server/test/api-routes.test.ts
+++ b/packages/server/test/api-routes.test.ts
@@ -1,36 +1,31 @@
 /* eslint-disable import/first */
 
-const nextUtilsMock = {
-  nextStartDev: jest.fn().mockReturnValue(Promise.resolve()),
-  nextBuild: jest.fn().mockReturnValue(Promise.resolve()),
-}
-// Quieten reporter
-jest.doMock('../src/reporter', () => ({
-  reporter: {copy: jest.fn(), remove: jest.fn()},
-}))
+import {multiMock} from './utils/multi-mock'
+import {resolve} from 'path'
 
-// Assume next works
-jest.doMock('../src/next-utils', () => nextUtilsMock)
-
-// Mock where the next bin is
-jest.doMock('../src/resolve-bin-async', () => ({
-  resolveBinAsync: jest.fn().mockReturnValue(Promise.resolve('')),
-}))
+const mocks = multiMock(
+  {
+    'next-utils': {
+      nextStartDev: jest.fn().mockReturnValue(Promise.resolve()),
+      nextBuild: jest.fn().mockReturnValue(Promise.resolve()),
+    },
+    'resolve-bin-async': {
+      resolveBinAsync: jest.fn().mockReturnValue(Promise.resolve('')),
+    },
+  },
+  resolve(__dirname, '../src'),
+)
 
 // Import with mocks applied
 import {dev} from '../src/dev'
 import {directoryTree} from './utils/tree-utils'
-
-import mockfs from 'mock-fs'
-import {resolve} from 'path'
-
 describe('Dev command', () => {
   const rootFolder = resolve('')
   const buildFolder = resolve(rootFolder, '.blitz-build')
   const devFolder = resolve(rootFolder, '.blitz-rules')
 
   beforeEach(async () => {
-    mockfs({
+    mocks.mockFs({
       app: {
         api: {
           'bar.ts': 'test',
@@ -55,12 +50,11 @@ describe('Dev command', () => {
   })
 
   afterEach(() => {
-    mockfs.restore()
+    mocks.mockFs.restore()
   })
 
   it('should copy the correct files to the dev folder', async () => {
-    const tree = directoryTree(devFolder)
-    expect(tree).toEqual({
+    expect(directoryTree(devFolder)).toEqual({
       name: '.blitz-rules',
       children: [
         {name: 'blitz.config.js'},

--- a/packages/server/test/build.test.ts
+++ b/packages/server/test/build.test.ts
@@ -1,26 +1,22 @@
 /* eslint-disable import/first */
+import {multiMock} from './utils/multi-mock'
+import {resolve} from 'path'
 
-const nextUtilsMock = {
-  nextBuild: jest.fn().mockReturnValue(Promise.resolve()),
-}
-// Quieten reporter
-jest.doMock('../src/reporter', () => ({
-  reporter: {copy: jest.fn(), remove: jest.fn()},
-}))
-
-// Assume next works
-jest.doMock('../src/next-utils', () => nextUtilsMock)
-
-// Mock where the next bin is
-jest.doMock('../src/resolve-bin-async', () => ({
-  resolveBinAsync: jest.fn().mockReturnValue(Promise.resolve('')),
-}))
+const mocks = multiMock(
+  {
+    'next-utils': {
+      nextBuild: jest.fn().mockReturnValue(Promise.resolve()),
+    },
+    'resolve-bin-async': {
+      resolveBinAsync: jest.fn().mockReturnValue(Promise.resolve('')),
+    },
+  },
+  resolve(__dirname, '../src'),
+)
 
 // Import with mocks applied
 import {build} from '../src/build'
 import {directoryTree} from './utils/tree-utils'
-import mockfs from 'mock-fs'
-import {resolve} from 'path'
 
 describe('Build command', () => {
   const rootFolder = resolve('build')
@@ -28,7 +24,7 @@ describe('Build command', () => {
   const devFolder = resolve(rootFolder, '.blitz')
 
   beforeEach(async () => {
-    mockfs({
+    mocks.mockFs({
       build: {
         '.now': '',
         one: '',
@@ -47,12 +43,11 @@ describe('Build command', () => {
   })
 
   afterEach(() => {
-    mockfs.restore()
+    mocks.mockFs.restore()
   })
 
   it('should copy the correct files to the build folder', async () => {
-    const tree = directoryTree(rootFolder)
-    expect(tree).toEqual({
+    expect(directoryTree(rootFolder)).toEqual({
       children: [
         {
           children: [

--- a/packages/server/test/dev.test.ts
+++ b/packages/server/test/dev.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/first */
 
 import {multiMock} from './utils/multi-mock'
-import {resolve} from 'path'
+import {resolve, join} from 'path'
 const mocks = multiMock(
   {
     'next-utils': {
@@ -19,7 +19,6 @@ const mocks = multiMock(
 import {dev} from '../src/dev'
 import {Manifest} from '../src/synchronizer/pipeline/rules/manifest/index'
 import {directoryTree} from './utils/tree-utils'
-import {join} from 'path'
 
 const originalLog = console.log
 describe('Dev command', () => {

--- a/packages/server/test/dev.test.ts
+++ b/packages/server/test/dev.test.ts
@@ -1,31 +1,27 @@
 /* eslint-disable import/first */
 
-import {join, resolve} from 'path'
-
-const nextUtilsMock = {
-  nextStartDev: jest.fn().mockReturnValue(Promise.resolve()),
-  nextBuild: jest.fn().mockReturnValue(Promise.resolve()),
-}
-// Quieten reporter
-jest.doMock('../src/reporter', () => ({
-  reporter: {copy: jest.fn(), remove: jest.fn()},
-}))
-
-// Assume next works
-jest.doMock('../src/next-utils', () => nextUtilsMock)
-const originalLog = console.log
-
-// Mock where the next bin is
-jest.doMock('../src/resolve-bin-async', () => ({
-  resolveBinAsync: jest.fn().mockImplementation((...a) => join(...a)), // just join the paths
-}))
+import {multiMock} from './utils/multi-mock'
+import {resolve} from 'path'
+const mocks = multiMock(
+  {
+    'next-utils': {
+      nextStartDev: jest.fn().mockReturnValue(Promise.resolve()),
+      nextBuild: jest.fn().mockReturnValue(Promise.resolve()),
+    },
+    'resolve-bin-async': {
+      resolveBinAsync: jest.fn().mockImplementation((...a) => join(...a)), // just join the paths
+    },
+  },
+  resolve(__dirname, '../src'),
+)
 
 // Import with mocks applied
 import {dev} from '../src/dev'
 import {Manifest} from '../src/synchronizer/pipeline/rules/manifest/index'
 import {directoryTree} from './utils/tree-utils'
-import mockfs from 'mock-fs'
+import {join} from 'path'
 
+const originalLog = console.log
 describe('Dev command', () => {
   let rootFolder: string
   let buildFolder: string
@@ -44,11 +40,11 @@ describe('Dev command', () => {
 
   describe('throw in nextStartDev', () => {
     beforeEach(() => {
-      nextUtilsMock.nextStartDev.mockRejectedValue('pow')
+      mocks['next-utils'].nextStartDev.mockRejectedValue('pow')
     })
 
     afterEach(() => {
-      nextUtilsMock.nextStartDev.mockReturnValue(Promise.resolve())
+      mocks['next-utils'].nextStartDev.mockReturnValue(Promise.resolve())
     })
 
     it('should blow up', (done) => {
@@ -76,12 +72,12 @@ describe('Dev command', () => {
       rootFolder = resolve('bad')
       buildFolder = resolve(rootFolder, '.blitz')
       devFolder = resolve(rootFolder, '.blitz')
-      mockfs({
+      mocks.mockFs({
         'bad/next.config.js': 'yo',
       })
     })
     afterEach(() => {
-      mockfs.restore()
+      mocks.mockFs.restore()
     })
 
     it('should fail when passed a next.config.js', async () => {
@@ -113,11 +109,11 @@ describe('Dev command', () => {
       devFolder = resolve(rootFolder, '.blitz-dev')
     })
     afterEach(() => {
-      mockfs.restore()
+      mocks.mockFs.restore()
     })
 
     it('should copy the correct files to the dev folder', async () => {
-      mockfs({
+      mocks.mockFs({
         'dev/.now': '',
         'dev/one': '',
         'dev/two': '',
@@ -131,8 +127,7 @@ describe('Dev command', () => {
         port: 3000,
         hostname: 'localhost',
       })
-      const tree = directoryTree(rootFolder)
-      expect(tree).toEqual({
+      expect(directoryTree(rootFolder)).toEqual({
         children: [
           {
             children: [{name: 'blitz.config.js'}, {name: 'next.config.js'}, {name: 'one'}, {name: 'two'}],
@@ -147,7 +142,7 @@ describe('Dev command', () => {
     })
 
     it('calls spawn with the patched next cli bin', async () => {
-      mockfs(
+      mocks.mockFs(
         {
           'dev/@blitzjs/server/next-patched': '',
         },
@@ -164,11 +159,11 @@ describe('Dev command', () => {
       })
       const nextPatched = resolve(rootFolder, '@blitzjs/server', 'next-patched')
       const blitzDev = join(rootFolder, '.blitz-dev')
-      expect(nextUtilsMock.nextStartDev.mock.calls[0].length).toBe(5)
-      expect(nextUtilsMock.nextStartDev.mock.calls[0][0]).toBe(nextPatched)
-      expect(nextUtilsMock.nextStartDev.mock.calls[0][1]).toBe(blitzDev)
-      expect(nextUtilsMock.nextStartDev.mock.calls[0][4]).toHaveProperty('port')
-      expect(nextUtilsMock.nextStartDev.mock.calls[0][4]).toHaveProperty('hostname')
+      expect(mocks['next-utils'].nextStartDev.mock.calls[0].length).toBe(5)
+      expect(mocks['next-utils'].nextStartDev.mock.calls[0][0]).toBe(nextPatched)
+      expect(mocks['next-utils'].nextStartDev.mock.calls[0][1]).toBe(blitzDev)
+      expect(mocks['next-utils'].nextStartDev.mock.calls[0][4]).toHaveProperty('port')
+      expect(mocks['next-utils'].nextStartDev.mock.calls[0][4]).toHaveProperty('hostname')
     })
   })
 })

--- a/packages/server/test/rules.test.ts
+++ b/packages/server/test/rules.test.ts
@@ -1,29 +1,23 @@
 /* eslint-disable import/first */
 
-const nextUtilsMock = {
-  nextStartDev: jest.fn().mockReturnValue(Promise.resolve()),
-  nextBuild: jest.fn().mockReturnValue(Promise.resolve()),
-}
-// Quieten reporter
-jest.doMock('../src/reporter', () => ({
-  reporter: {copy: jest.fn(), remove: jest.fn()},
-}))
-
-// Assume next works
-jest.doMock('../src/next-utils', () => nextUtilsMock)
-
-// Mock where the next bin is
-jest.doMock('../src/resolve-bin-async', () => ({
-  resolveBinAsync: jest.fn().mockReturnValue(Promise.resolve('')),
-}))
+import {multiMock} from './utils/multi-mock'
+import {resolve} from 'path'
+const mocks = multiMock(
+  {
+    'next-utils': {
+      nextStartDev: jest.fn().mockReturnValue(Promise.resolve()),
+      nextBuild: jest.fn().mockReturnValue(Promise.resolve()),
+    },
+    'resolve-bin-async': {
+      resolveBinAsync: jest.fn().mockReturnValue(Promise.resolve('')),
+    },
+  },
+  resolve(__dirname, '../src'),
+)
 
 // Import with mocks applied
 import {dev} from '../src/dev'
-import {resolve} from 'path'
-
 import {directoryTree} from './utils/tree-utils'
-
-import mockfs from 'mock-fs'
 
 describe('Dev command', () => {
   const rootFolder = resolve('')
@@ -31,7 +25,7 @@ describe('Dev command', () => {
   const devFolder = resolve(rootFolder, '.blitz-rules')
 
   beforeEach(async () => {
-    mockfs({
+    mocks.mockFs({
       'app/posts/pages/foo.tsx': '',
       'pages/bar.tsx': '',
     })
@@ -48,12 +42,11 @@ describe('Dev command', () => {
   })
 
   afterEach(() => {
-    mockfs.restore()
+    mocks.mockFs.restore()
   })
 
   it('should copy the correct files to the dev folder', async () => {
-    const tree = directoryTree(devFolder)
-    expect(tree).toEqual({
+    expect(directoryTree(devFolder)).toEqual({
       name: '.blitz-rules',
       children: [
         {name: 'blitz.config.js'},

--- a/packages/server/test/utils/multi-mock.ts
+++ b/packages/server/test/utils/multi-mock.ts
@@ -1,0 +1,31 @@
+import mockFileSystem from 'mock-fs'
+
+const mockFs = (...args: any[]) => {
+  // Fixes an issue with mockFs around console log in tests and dependencies
+  // https://github.com/facebook/jest/issues/5792#issuecomment-377861996
+  console.log('')
+  mockFileSystem(...args)
+}
+
+// We may need to add more methods here if we need them
+mockFs.restore = mockFileSystem.restore
+
+/**
+ * Mock multiple dependencies at once for a test. Returns a mock
+ * object containing the references to your mock functions you can use
+ * to test against.
+ *
+ * Use this at the start of your test before anything else.
+ * @param mocks Object representing the the require mocks you want
+ * @returns mocks utility object
+ */
+
+export function multiMock<T extends Record<string, any>>(mocks: T, cwd: string = process.cwd()) {
+  const {join} = jest.requireActual('path')
+  Object.entries(mocks).forEach(([path, obj]) => {
+    const moduleName = join(cwd, path)
+    jest.doMock(moduleName, () => obj)
+  })
+
+  return Object.assign(mocks, {mockFs})
+}

--- a/packages/server/test/utils/multi-mock.ts
+++ b/packages/server/test/utils/multi-mock.ts
@@ -2,6 +2,8 @@ import mockFileSystem from 'mock-fs'
 
 const mockFs = (...args: any[]) => {
   // Fixes an issue with mockFs around console log in tests and dependencies
+  // This is a magic workaround until mock-fs provides an overlay functionality
+  // Tried using union fs and memfs but it wasn't working properly
   // https://github.com/facebook/jest/issues/5792#issuecomment-377861996
   console.log('')
   mockFileSystem(...args)

--- a/packages/server/test/vercel-now.test.ts
+++ b/packages/server/test/vercel-now.test.ts
@@ -1,29 +1,23 @@
 /* eslint-disable import/first */
 
-const nextUtilsMock = {
-  nextStartDev: jest.fn().mockReturnValue(Promise.resolve()),
-  nextBuild: jest.fn().mockReturnValue(Promise.resolve()),
-}
-// Quieten reporter
-jest.doMock('../src/reporter', () => ({
-  reporter: {copy: jest.fn(), remove: jest.fn()},
-}))
-
-// Assume next works
-jest.doMock('../src/next-utils', () => nextUtilsMock)
-
-// Mock where the next bin is
-jest.doMock('../src/resolve-bin-async', () => ({
-  resolveBinAsync: jest.fn().mockReturnValue(Promise.resolve('')),
-}))
+import {multiMock} from './utils/multi-mock'
+import {resolve} from 'path'
+const mocks = multiMock(
+  {
+    'next-utils': {
+      nextStartDev: jest.fn().mockReturnValue(Promise.resolve()),
+      nextBuild: jest.fn().mockReturnValue(Promise.resolve()),
+    },
+    'resolve-bin-async': {
+      resolveBinAsync: jest.fn().mockReturnValue(Promise.resolve('')),
+    },
+  },
+  resolve(__dirname, '../src'),
+)
 
 // Import with mocks applied
 import {build} from '../src/build'
-import {resolve} from 'path'
-
 import {directoryTree} from './utils/tree-utils'
-
-import mockfs from 'mock-fs'
 
 describe('Build command Vercel', () => {
   const rootFolder = resolve('')
@@ -32,7 +26,7 @@ describe('Build command Vercel', () => {
 
   beforeEach(async () => {
     process.env.NOW_BUILDER = '1'
-    mockfs({
+    mocks.mockFs({
       'app/posts/pages/foo.tsx': '',
       'pages/bar.tsx': '',
       'next.config.js': 'module.exports = {target: "experimental-serverless-trace"}',
@@ -50,12 +44,11 @@ describe('Build command Vercel', () => {
 
   afterEach(() => {
     delete process.env.NOW_BUILDER
-    mockfs.restore()
+    mocks.mockFs.restore()
   })
 
   it('should copy the correct files to the build folder', async () => {
-    const tree = directoryTree(buildFolder)
-    expect(tree).toEqual({
+    expect(directoryTree(buildFolder)).toEqual({
       name: '.blitz-build',
       children: [
         {name: 'blitz.config.js'},


### PR DESCRIPTION
Closes: #352 

### What are the changes and their implications?

Found a workaround for mock-fs to resolve the issue with `console.log`.

This creates a new `multiMock` function that enables clearer mocking syntax for tests.

### Checklist

- [x] Tests added for changes
- [x] User facing changes documented

### Breaking change: no

### Other information

Tried various approaches including unionfs with memfs but found issues with vinyl compatibility. Investigated using a jest native approach but centralizing `mock-fs` and fixing the issue with console.log appears to be the easiest win here. 

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
