### PR TITLE
Fix `blitz console` loading freeze

### DIFF
--- a/packages/repl/src/utils/load-blitz.ts
+++ b/packages/repl/src/utils/load-blitz.ts
@@ -5,25 +5,26 @@ import pkgDir from 'pkg-dir'
 
 const projectRoot = pkgDir.sync() || process.cwd()
 
-export function getBlitzModulePaths() {
-  return [
-    ...globby.sync(
-      [
-        'app/**/{queries,mutations}/*.{js,ts,tsx}',
-        '**/utils/*.{js,ts,tsx}',
-        'jobs/**/*.{js,ts,tsx}',
-        'integrations/**/*.{js,ts,tsx}',
-      ],
-      {cwd: projectRoot, gitignore: true},
-    ),
-    'db',
-  ].map((p) => path.join(projectRoot, p))
+export async function getBlitzModulePaths() {
+  const paths = await globby(
+    [
+      'app/**/{queries,mutations}/*.{js,ts,tsx}',
+      '**/utils/*.{js,ts,tsx}',
+      'jobs/**/*.{js,ts,tsx}',
+      'integrations/**/*.{js,ts,tsx}',
+    ],
+    {cwd: projectRoot, gitignore: true},
+  )
+  paths.push('db')
+
+  return [...paths.map((p) => path.join(projectRoot, p))]
 }
 
-export const loadBlitz = () => {
+export const loadBlitz = async () => {
+  const paths = await getBlitzModulePaths()
   return Object.assign(
     {},
-    ...getBlitzModulePaths().map((modulePath) => {
+    ...paths.map((modulePath) => {
       let name = path.parse(modulePath).name
       if (name === 'index') {
         const dirs = path.dirname(modulePath).split(path.sep)

--- a/packages/repl/test/repl.test.ts
+++ b/packages/repl/test/repl.test.ts
@@ -35,8 +35,8 @@ describe('Console command', () => {
     jest.spyOn(repl, 'start').mockReturnValue(mockRepl)
     jest.spyOn(chokidar, 'watch').mockReturnValue(mockWatcher)
     jest.spyOn(mockRepl, 'on').mockReturnValue(mockRepl)
-    jest.spyOn(loadBlitzFunctions, 'getBlitzModulePaths').mockReturnValue(pathToModulesMock)
-    jest.spyOn(loadBlitzFunctions, 'loadBlitz').mockReturnValue(loadBlitzMock)
+    jest.spyOn(loadBlitzFunctions, 'getBlitzModulePaths').mockResolvedValue(pathToModulesMock)
+    jest.spyOn(loadBlitzFunctions, 'loadBlitz').mockResolvedValue(loadBlitzMock)
   })
 
   it('starts REPL', async () => {
@@ -59,7 +59,7 @@ describe('Console command', () => {
   it('watches for modules changes', async () => {
     await runRepl({})
     expect(loadBlitzFunctions.getBlitzModulePaths).toBeCalled()
-    expect(chokidar.watch).toBeCalledWith(pathToModulesMock)
+    expect(chokidar.watch).toBeCalledWith(pathToModulesMock, {ignoreInitial: true})
   })
 
   it('calls loadBlitz', async () => {


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/579

### What are the changes and their implications?

I've identified two issues, that I addressed:

* The slowdown was caused by [`globby.sync`](https://github.com/jportela/blitz/commit/8abfd55faa73a2780a88ac5b7dccd681532d8c06#diff-55211f3adece9b5e1a19c1252a19369dL8-R20) on [`loadBlitz`](https://github.com/jportela/blitz/commit/8abfd55faa73a2780a88ac5b7dccd681532d8c06#diff-72f8daee91d07356f0891c0979903245L57). This operation takes ~300ms on my machine and it freezes input on the console. I've changed that to an async equivalent
* I've also set [`ignoreInitial: true`](https://github.com/jportela/blitz/commit/8abfd55faa73a2780a88ac5b7dccd681532d8c06#diff-72f8daee91d07356f0891c0979903245R58) for `chokidar`, since it was triggering `add` and `addDir` events for directories that it discovered while it loaded, which is not necessary in this case, since we already load the modules before watching (at least this was my interpretation of https://github.com/paulmillr/chokidar#path-filtering )

Feel free to suggest changes to this approach. We could, for example, block the console interaction while loading Blitz modules (and show a Spinner while doing it), but I don't think that's necessary at all.

### Checklist

- [ ] Tests added for changes
- [ ] User facing changes documented

### Breaking change: no

### Other information

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
