### PR TITLE
Fix queries when Prisma isn't being used

### DIFF
--- a/packages/server/src/synchronizer/pipeline/rules/rpc/index.ts
+++ b/packages/server/src/synchronizer/pipeline/rules/rpc/index.ts
@@ -62,11 +62,15 @@ import resolver from '${resolverPath}'
 export default isomorphicRpc(resolver, '${resolverPath}') as typeof resolver
 `
 
+// Clarification: try/catch around db is to prevent query errors when not using blitz's inbuilt database (See #572)
 const rpcHandlerTemplate = (resolverPath: string, resolverType: string, resolverName: string) => `
 import {rpcHandler} from '@blitzjs/server'
 import resolver from '${resolverPath}'
-import db from 'db'
-export default rpcHandler('${resolverType}', '${resolverName}', resolver, () => db.connect())
+let db
+try {
+  db = require('db')
+}catch(err){}
+export default rpcHandler('${resolverType}', '${resolverName}', resolver, () => db && db.connect())
 `
 
 function removeExt(filePath: string) {


### PR DESCRIPTION
this should make it possible to use queries in blitz, **without** using blitz's inbuilt database system.

Closes: #572 

### What are the changes and their implications?
- I changed how `db` was being imported from an `import db from 'db'` statement to an undefined db declaration followed by a `require('db')` statement within a try/catch block. 
- I also altered the exported `rpcHandler` function call to ensure `db` has been defined before running `db.connect()`. 

This should allow users to fully remove the database portion of blitz if they're not planning on using it while still using queries with an external database or API. 

### Checklist

- [x] Tests added for changes _(N/A as far as I can tell)_
- [x] User facing changes documented _(N/A from a user perspective, from a maintainer perspective I referenced the issue and why changes were made in a comment above the `rpcHandlerTemplate` function)_ 

### Breaking change: yes/no
no

### Other information
This is my first contribution to blitz, and one of my first contributions to OS in general, I know it's a simple one but any feedback would be greatly appreciated. **Thank you so much for the opportunity to help out 🙏** 

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
