### PR TITLE
Allow function config in withBlitz

### DIFF
--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -1,39 +1,45 @@
 const withPlugins = require('next-compose-plugins')
 const withTM = require('next-transpile-modules')(['@blitzjs/core'])
 
-export function withBlitz(nextConfig: Record<any, any> = {}) {
-  const plugins = []
-  if (process.env.NODE_ENV === 'development') {
-    // This is needed during monorepo development so that examples auto reload when packages change
-    plugins.push(withTM)
+export function withBlitz(nextConfig: any) {
+  return (phase: string, nextOpts: any) => {
+    // Need to grab the normalized config based on the phase we are in incase we are given a functional config to extend
+    const normalizedConfig = typeof nextConfig === 'function' ? nextConfig(phase, nextOpts) : nextConfig
+
+    const plugins = []
+    if (process.env.NODE_ENV === 'development') {
+      // This is needed during monorepo development so that examples auto reload when packages change
+      plugins.push(withTM)
+    }
+
+    return withPlugins(
+      plugins,
+      Object.assign({}, normalizedConfig, {
+        experimental: {
+          reactMode: 'concurrent',
+        },
+        webpack(config: any, options: Record<any, any>) {
+          if (!options.isServer) {
+            config.module = config.module || {}
+            config.module.rules = config.module.rules || []
+            config.module.rules.push({test: /_rpc/, use: {loader: 'null-loader'}})
+            config.module.rules.push({test: /@prisma[\\/]client/, use: {loader: 'null-loader'}})
+          }
+
+          // This is needed because, for an unknown reason, the next build fails when
+          // importing directly from the `blitz` package, complaining about child_process
+          // Somehow our server code is getting into the next build that way.
+          // This alias eliminates that problem.
+          // Anyone is welcome to investigate this further sometime
+          config.resolve.alias.blitz = '@blitzjs/core'
+
+          if (typeof normalizedConfig.webpack === 'function') {
+            return normalizedConfig.webpack(config, options)
+          }
+
+          return config
+        },
+      }),
+    )(phase, nextOpts)
   }
-
-  return withPlugins(
-    plugins,
-    Object.assign({}, nextConfig, {
-      experimental: {
-        reactMode: 'concurrent',
-      },
-      webpack(config: any, options: Record<any, any>) {
-        if (!options.isServer) {
-          config.module = config.module || {}
-          config.module.rules = config.module.rules || []
-          config.module.rules.push({test: /_rpc/, use: {loader: 'null-loader'}})
-          config.module.rules.push({test: /@prisma[\\/]client/, use: {loader: 'null-loader'}})
-        }
-
-        // This is needed because, for an unknown reason, the next build fails when
-        // importing directly from the `blitz` package, complaining about child_process
-        // Somehow our server code is getting into the next build that way.
-        // This alias eliminates that problem.
-        // Anyone is welcome to investigate this further sometime
-        config.resolve.alias.blitz = '@blitzjs/core'
-
-        if (typeof nextConfig.webpack === 'function') {
-          return nextConfig.webpack(config, options)
-        }
-        return config
-      },
-    }),
-  )
 }

--- a/packages/server/test/with-blitz.test.ts
+++ b/packages/server/test/with-blitz.test.ts
@@ -2,11 +2,29 @@ import {withBlitz} from '../src'
 
 describe('withBlitz', () => {
   it('alters the webpack config as expected', () => {
-    const nextConfigFn = withBlitz({})
+    const nextConfigFn = withBlitz({
+      foo: 'bar',
+    })
     const newNext = nextConfigFn('', {defaultConfig: {}})
     const newNextWithoutWebpack = Object.assign({}, newNext, {webpack: null})
 
     expect(newNextWithoutWebpack).toStrictEqual({
+      foo: 'bar',
+      experimental: {
+        reactMode: 'concurrent',
+      },
+      webpack: null,
+    })
+  })
+
+  it('can handle functional next configs', () => {
+    const nextConfigFn = withBlitz((phase: any) => ({phase, foo: 'bar'}))
+    const newNext = nextConfigFn('foo', {defaultConfig: {}})
+    const newNextWithoutWebpack = Object.assign({}, newNext, {webpack: null})
+
+    expect(newNextWithoutWebpack).toStrictEqual({
+      phase: 'foo',
+      foo: 'bar',
       experimental: {
         reactMode: 'concurrent',
       },


### PR DESCRIPTION
Closes: #598 

### What are the changes and their implications?

* Users can export Next.js function configs in `blitz.config.js`

### Checklist

- [x] Tests added for changes
- [x] User facing changes documented

### Breaking change: no

### Other information

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
