### PR TITLE
Fix 'blitz help' not working from global cli

### DIFF
--- a/packages/cli/src/check-before-running.ts
+++ b/packages/cli/src/check-before-running.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 
 import {isBlitzRoot, IsBlitzRootError} from './utils/is-blitz-root'
 
-const whitelistGlobal = ['new']
+const whitelistGlobal = ['-h', '--help', 'help', 'new']
 
 export const hook: Hook<'init'> = async function (options) {
   const {id} = options


### PR DESCRIPTION
Closes: #612

### What are the changes and their implications?

Adds `help`, `-h`, and `--help` to the universally allowed global commands so you can access the help regardless of whether you're in a Blitz project directory or not.

### Checklist

- [ ] Tests added for changes
- [ ] User facing changes documented

### Breaking change: yes/no

no

### Other information

I don't know oclif, so maybe there is a slicker way to include the aliases (`-h`, `--help`) without explicitly listing them?
