### PR TITLE
[GUI] Fallback to NPM when Yarn isn't installed

### DIFF
--- a/packages/gui/app/mutations/createProject.ts
+++ b/packages/gui/app/mutations/createProject.ts
@@ -1,4 +1,5 @@
 import {existsSync} from 'fs'
+import hasbin from 'hasbin'
 
 import {AppGenerator} from '@blitzjs/generator'
 import db, {ProjectCreateArgs} from 'db'
@@ -20,7 +21,7 @@ const createProject = async ({data}: CreateProjectInput) => {
     appName: name,
     dryRun: false,
     useTs: true,
-    yarn: true,
+    yarn: hasbin.sync('yarn'),
     version: pkg.version,
     skipInstall: false,
   })

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -10,11 +10,11 @@
     "@prisma/client": "2.0.0-beta.7",
     "blitz": "0.12.0",
     "fast-glob": "3.2.2",
+    "hasbin": "1.2.3",
     "heroicons-react": "^1.0.15",
     "react": "experimental",
     "react-dom": "experimental",
-    "typescript": "3.9.3",
-    "hasbin": "1.2.3"
+    "typescript": "3.9.3"
   },
   "devDependencies": {
     "@tailwindcss/ui": "0.3.0",

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -13,7 +13,8 @@
     "heroicons-react": "^1.0.15",
     "react": "experimental",
     "react-dom": "experimental",
-    "typescript": "3.9.3"
+    "typescript": "3.9.3",
+    "hasbin": "1.2.3"
   },
   "devDependencies": {
     "@tailwindcss/ui": "0.3.0",

--- a/packages/gui/types/index.d.ts
+++ b/packages/gui/types/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'hasbin'


### PR DESCRIPTION
Closes: #606 

### What are the changes and their implications?

Uses `hasbin` to determine if Yarn is installed and uses that as the default. Otherwise, it falls back to using NPM.

### Checklist

- [ ] Tests added for changes
- [ ] User facing changes documented

### Breaking change: no

### Other information

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
