### PR TITLE
Fix `blitz start -p 1234` not throwing an error if port 1234 is already in use

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,4 +1,4 @@
-import {Command, flags} from "@oclif/command"
+import {Command} from "@oclif/command"
 import {build} from "@blitzjs/server"
 import {runPrismaGeneration} from "./db"
 
@@ -6,26 +6,11 @@ export class Build extends Command {
   static description = "Create a production build"
   static aliases = ["b"]
 
-  static flags = {
-    port: flags.integer({
-      char: "p",
-      description: "Set port number",
-      default: 3000,
-    }),
-    hostname: flags.string({
-      char: "H",
-      description: "Set server hostname",
-      default: "localhost",
-    }),
-  }
-
   async run() {
-    const {flags} = this.parse(Build)
+    // const {flags} = this.parse(Build)
 
     const config = {
       rootFolder: process.cwd(),
-      port: flags.port,
-      hostname: flags.hostname,
     }
 
     try {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -7,8 +7,6 @@ export class Build extends Command {
   static aliases = ["b"]
 
   async run() {
-    // const {flags} = this.parse(Build)
-
     const config = {
       rootFolder: process.cwd(),
     }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -7,6 +7,8 @@ export class Build extends Command {
   static aliases = ["b"]
 
   async run() {
+    // const {flags} = this.parse(Build)
+
     const config = {
       rootFolder: process.cwd(),
     }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -14,12 +14,10 @@ export class Start extends Command {
     port: flags.integer({
       char: "p",
       description: "Set port number",
-      default: 3000,
     }),
     hostname: flags.string({
       char: "H",
       description: "Set server hostname",
-      default: "localhost",
     }),
   }
 

--- a/packages/cli/test/commands/build.test.ts
+++ b/packages/cli/test/commands/build.test.ts
@@ -21,8 +21,6 @@ describe("Build command", () => {
 
   const options = {
     rootFolder: resolve(__dirname, "../../"),
-    port: 3000,
-    hostname: "localhost",
   }
 
   it("runs the build script", async () => {

--- a/packages/cli/test/commands/start.test.ts
+++ b/packages/cli/test/commands/start.test.ts
@@ -23,8 +23,6 @@ describe("Start command", () => {
 
   const options = {
     rootFolder: resolve(__dirname, "../../"),
-    port: 3000,
-    hostname: "localhost",
   }
 
   it("runs the dev script", async () => {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -7,8 +7,8 @@ type Synchronizer = typeof transformFiles
 
 export type ServerConfig = {
   rootFolder: string
-  port: number
-  hostname: string
+  port?: number
+  hostname?: string
   interceptNextErrors?: boolean
   devFolder?: string
   buildFolder?: string

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -3,6 +3,7 @@ import detect from "detect-port"
 import {Manifest} from "./stages/manifest"
 import {through} from "./streams"
 import {ServerConfig} from "config"
+import {log} from "@blitzjs/display"
 
 function createOutputTransformer(manifest: Manifest, devFolder: string) {
   const stream = through((data, _, next) => {
@@ -55,7 +56,8 @@ export async function nextStartDev(
 
   return new Promise((res, rej) => {
     if (config.port && availablePort !== config.port) {
-      rej(`Couldn't start server on port ${config.port} ::port already in use`)
+      log.error(`Couldn't start server on port ${config.port} because it's already in use`)
+      rej("")
     } else {
       spawn(nextBin, spawnCommand, {
         cwd,
@@ -88,7 +90,8 @@ export async function nextStart(nextBin: string, cwd: string, config: ServerConf
 
   return new Promise((res, rej) => {
     if (config.port && availablePort !== config.port) {
-      rej(`Couldn't start server on port ${config.port} ::port already in use`)
+      log.error(`Couldn't start server on port ${config.port} because it's already in use`)
+      rej("")
     } else {
       spawn(nextBin, spawnCommand, {
         cwd,

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -52,15 +52,15 @@ export async function nextStartDev(
   config: ServerConfig,
 ) {
   const transform = createOutputTransformer(manifest, devFolder).stream
-  const {spawnCommand, availablePort} = await createCommandAndPort(config, "dev")
+  const availablePort = await detect({port: config.port!, hostname: config.hostname!})
 
   return new Promise((res, rej) => {
-    if (availablePort && availablePort !== config.port) {
-      rej(`Couldn't start server on port ${config.port}::port already in use`)
-    } else {
-      spawn(nextBin, spawnCommand, {
-        cwd,
-        stdio: [process.stdin, transform.pipe(process.stdout), transform.pipe(process.stderr)],
+    spawn(nextBin, ['dev', '-p', `${availablePort}`, '-H', config.hostname!], {
+      cwd,
+      stdio: [process.stdin, transform.pipe(process.stdout), transform.pipe(process.stderr)],
+    })
+      .on('exit', (code: number) => {
+        code === 0 ? res() : rej(`'next dev' failed with status code: ${code}`)
       })
         .on("exit", (code: number) => {
           code === 0 ? res() : rej(`'next dev' failed with status code: ${code}`)
@@ -84,23 +84,13 @@ export function nextBuild(nextBin: string, cwd: string) {
 }
 
 export async function nextStart(nextBin: string, cwd: string, config: ServerConfig) {
-  const {spawnCommand, availablePort} = await createCommandAndPort(config, "start")
-
-  return new Promise((res, rej) => {
-    if (availablePort && availablePort !== config.port) {
-      rej(`Couldn't start server on port ${config.port} ::port already in use`)
-    } else {
-      spawn(nextBin, spawnCommand, {
-        cwd,
-        stdio: "inherit",
-      })
-        .on("exit", (code: number) => {
-          code === 0 ? res() : rej(`'next start' failed with status code: ${code}`)
-        })
-        .on("error", (err) => {
-          console.error(err)
-          rej(err)
-        })
-    }
-  })
+  const availablePort = await detect({port: config.port!, hostname: config.hostname!})
+  return Promise.resolve(
+    spawn(nextBin, ['start', '-p', `${availablePort}`, '-H', config.hostname!], {
+      cwd,
+      stdio: 'inherit',
+    }).on('error', (err) => {
+      console.error(err)
+    }),
+  )
 }

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -40,7 +40,7 @@ export async function nextStartDev(
   let spawnCommand: string[] = ["dev"]
   let availablePort: number
   if (config.port) {
-    availablePort = await detect({port: config.port, hostname: config.hostname})
+    availablePort = await detect({port: config.port})
     spawnCommand = spawnCommand.concat(["-p", `${config.port}`])
   }
   if (config.hostname) {
@@ -49,7 +49,7 @@ export async function nextStartDev(
 
   return new Promise((res, rej) => {
     if (availablePort && availablePort !== config.port) {
-      rej(`Couldn't start server on port ${config.port}`)
+      rej(`Couldn't start server on port ${config.port}::port already in use`)
     } else {
       spawn(nextBin, spawnCommand, {
         cwd,
@@ -80,7 +80,7 @@ export async function nextStart(nextBin: string, cwd: string, config: ServerConf
   let spawnCommand: string[] = ["start"]
   let availablePort: number
   if (config.port) {
-    availablePort = await detect({port: config.port, hostname: config.hostname})
+    availablePort = await detect({port: config.port})
     spawnCommand = spawnCommand.concat(["-p", `${config.port}`])
   }
   if (config.hostname) {
@@ -89,7 +89,7 @@ export async function nextStart(nextBin: string, cwd: string, config: ServerConf
 
   return new Promise((res, rej) => {
     if (availablePort && availablePort !== config.port) {
-      rej(`Couldn't start server on port ${config.port}`)
+      rej(`Couldn't start server on port ${config.port} ::port already in use`)
     } else {
       spawn(nextBin, spawnCommand, {
         cwd,

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -31,7 +31,7 @@ function createOutputTransformer(manifest: Manifest, devFolder: string) {
 
 async function createCommandAndPort(config: ServerConfig, command: string) {
   let spawnCommand: string[] = [command]
-  let availablePort: number | undefined
+  let availablePort: number
 
   availablePort = await detect({port: config.port ? config.port : 3000})
   spawnCommand = spawnCommand.concat(["-p", `${availablePort}`])
@@ -84,15 +84,7 @@ export function nextBuild(nextBin: string, cwd: string) {
 }
 
 export async function nextStart(nextBin: string, cwd: string, config: ServerConfig) {
-  let spawnCommand: string[] = ["start"]
-  let availablePort: number
-  if (config.port) {
-    availablePort = await detect({port: config.port})
-    spawnCommand = spawnCommand.concat(["-p", `${config.port}`])
-  }
-  if (config.hostname) {
-    spawnCommand = spawnCommand.concat(["-H", `${config.hostname}`])
-  }
+  const {spawnCommand, availablePort} = await createCommandAndPort(config, "start")
 
   return new Promise((res, rej) => {
     if (config.port && availablePort !== config.port) {

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -55,7 +55,7 @@ export async function nextStartDev(
   let spawnCommand: string[] = ["dev"]
   let availablePort: number
   if (config.port) {
-    availablePort = await detect({port: config.port, hostname: config.hostname})
+    availablePort = await detect({port: config.port})
     spawnCommand = spawnCommand.concat(["-p", `${config.port}`])
   }
   if (config.hostname) {
@@ -64,7 +64,7 @@ export async function nextStartDev(
 
   return new Promise((res, rej) => {
     if (availablePort && availablePort !== config.port) {
-      rej(`Couldn't start server on port ${config.port}`)
+      rej(`Couldn't start server on port ${config.port}::port already in use`)
     } else {
       spawn(nextBin, spawnCommand, {
         cwd,
@@ -95,7 +95,7 @@ export async function nextStart(nextBin: string, cwd: string, config: ServerConf
   let spawnCommand: string[] = ["start"]
   let availablePort: number
   if (config.port) {
-    availablePort = await detect({port: config.port, hostname: config.hostname})
+    availablePort = await detect({port: config.port})
     spawnCommand = spawnCommand.concat(["-p", `${config.port}`])
   }
   if (config.hostname) {
@@ -104,7 +104,7 @@ export async function nextStart(nextBin: string, cwd: string, config: ServerConf
 
   return new Promise((res, rej) => {
     if (availablePort && availablePort !== config.port) {
-      rej(`Couldn't start server on port ${config.port}`)
+      rej(`Couldn't start server on port ${config.port} ::port already in use`)
     } else {
       spawn(nextBin, spawnCommand, {
         cwd,

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -35,7 +35,7 @@ async function createCommandAndPort(config: ServerConfig, command: string) {
 
   if (config.port) {
     availablePort = await detect({port: config.port})
-    spawnCommand = spawnCommand.concat(["-p", `${availablePort}`])
+    spawnCommand = spawnCommand.concat(["-p", `${config.port}`])
   }
   if (config.hostname) {
     spawnCommand = spawnCommand.concat(["-H", `${config.hostname}`])
@@ -52,15 +52,7 @@ export async function nextStartDev(
   config: ServerConfig,
 ) {
   const transform = createOutputTransformer(manifest, devFolder).stream
-  let spawnCommand: string[] = ["dev"]
-  let availablePort: number
-  if (config.port) {
-    availablePort = await detect({port: config.port})
-    spawnCommand = spawnCommand.concat(["-p", `${config.port}`])
-  }
-  if (config.hostname) {
-    spawnCommand = spawnCommand.concat(["-H", `${config.hostname}`])
-  }
+  const {spawnCommand, availablePort} = await createCommandAndPort(config, "dev")
 
   return new Promise((res, rej) => {
     if (availablePort && availablePort !== config.port) {
@@ -92,15 +84,7 @@ export function nextBuild(nextBin: string, cwd: string) {
 }
 
 export async function nextStart(nextBin: string, cwd: string, config: ServerConfig) {
-  let spawnCommand: string[] = ["start"]
-  let availablePort: number
-  if (config.port) {
-    availablePort = await detect({port: config.port})
-    spawnCommand = spawnCommand.concat(["-p", `${config.port}`])
-  }
-  if (config.hostname) {
-    spawnCommand = spawnCommand.concat(["-H", `${config.hostname}`])
-  }
+  const {spawnCommand, availablePort} = await createCommandAndPort(config, "start")
 
   return new Promise((res, rej) => {
     if (availablePort && availablePort !== config.port) {
@@ -111,7 +95,7 @@ export async function nextStart(nextBin: string, cwd: string, config: ServerConf
         stdio: "inherit",
       })
         .on("exit", (code: number) => {
-          code === 0 ? res() : rej(`'next build' failed with status code: ${code}`)
+          code === 0 ? res() : rej(`'next start' failed with status code: ${code}`)
         })
         .on("error", (err) => {
           console.error(err)

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -52,17 +52,29 @@ export async function nextStartDev(
   config: ServerConfig,
 ) {
   const transform = createOutputTransformer(manifest, devFolder).stream
-  const availablePort = await detect({port: config.port!, hostname: config.hostname!})
+  let spawnCommand: string[] = ["dev"]
+  let availablePort: number
+  if (config.port) {
+    availablePort = await detect({port: config.port, hostname: config.hostname})
+    spawnCommand = spawnCommand.concat(["-p", `${config.port}`])
+  }
+  if (config.hostname) {
+    spawnCommand = spawnCommand.concat(["-H", `${config.hostname}`])
+  }
 
   return new Promise((res, rej) => {
-    spawn(nextBin, ["dev", "-p", `${availablePort}`, "-H", config.hostname!], {
-      cwd,
-      stdio: [process.stdin, transform.pipe(process.stdout), transform.pipe(process.stderr)],
-    })
-      .on("exit", (code: number) => {
-        code === 0 ? res() : rej(`'next dev' failed with status code: ${code}`)
+    if (availablePort && availablePort !== config.port) {
+      rej(`Couldn't start server on port ${config.port}`)
+    } else {
+      spawn(nextBin, spawnCommand, {
+        cwd,
+        stdio: [process.stdin, transform.pipe(process.stdout), transform.pipe(process.stderr)],
       })
-      .on("error", rej)
+        .on("exit", (code: number) => {
+          code === 0 ? res() : rej(`'next dev' failed with status code: ${code}`)
+        })
+        .on("error", rej)
+    }
   })
 }
 
@@ -80,13 +92,31 @@ export function nextBuild(nextBin: string, cwd: string) {
 }
 
 export async function nextStart(nextBin: string, cwd: string, config: ServerConfig) {
-  const availablePort = await detect({port: config.port!, hostname: config.hostname!})
-  return Promise.resolve(
-    spawn(nextBin, ["start", "-p", `${availablePort}`, "-H", config.hostname!], {
-      cwd,
-      stdio: "inherit",
-    }).on("error", (err) => {
-      console.error(err)
-    }),
-  )
+  let spawnCommand: string[] = ["start"]
+  let availablePort: number
+  if (config.port) {
+    availablePort = await detect({port: config.port, hostname: config.hostname})
+    spawnCommand = spawnCommand.concat(["-p", `${config.port}`])
+  }
+  if (config.hostname) {
+    spawnCommand = spawnCommand.concat(["-H", `${config.hostname}`])
+  }
+
+  return new Promise((res, rej) => {
+    if (availablePort && availablePort !== config.port) {
+      rej(`Couldn't start server on port ${config.port}`)
+    } else {
+      spawn(nextBin, spawnCommand, {
+        cwd,
+        stdio: "inherit",
+      })
+        .on("exit", (code: number) => {
+          code === 0 ? res() : rej(`'next build' failed with status code: ${code}`)
+        })
+        .on("error", (err) => {
+          console.error(err)
+          rej(err)
+        })
+    }
+  })
 }

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -37,10 +37,10 @@ export async function nextStartDev(
   config: ServerConfig,
 ) {
   const transform = createOutputTransformer(manifest, devFolder).stream
-  const availablePort = await detect({port: config.port, hostname: config.hostname})
+  const availablePort = await detect({port: config.port!, hostname: config.hostname!})
 
   return new Promise((res, rej) => {
-    spawn(nextBin, ["dev", "-p", `${availablePort}`, "-H", config.hostname], {
+    spawn(nextBin, ["dev", "-p", `${availablePort}`, "-H", config.hostname!], {
       cwd,
       stdio: [process.stdin, transform.pipe(process.stdout), transform.pipe(process.stderr)],
     })
@@ -65,9 +65,9 @@ export function nextBuild(nextBin: string, cwd: string) {
 }
 
 export async function nextStart(nextBin: string, cwd: string, config: ServerConfig) {
-  const availablePort = await detect({port: config.port, hostname: config.hostname})
+  const availablePort = await detect({port: config.port!, hostname: config.hostname!})
   return Promise.resolve(
-    spawn(nextBin, ["start", "-p", `${availablePort}`, "-H", config.hostname], {
+    spawn(nextBin, ["start", "-p", `${availablePort}`, "-H", config.hostname!], {
       cwd,
       stdio: "inherit",
     }).on("error", (err) => {

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -37,17 +37,29 @@ export async function nextStartDev(
   config: ServerConfig,
 ) {
   const transform = createOutputTransformer(manifest, devFolder).stream
-  const availablePort = await detect({port: config.port!, hostname: config.hostname!})
+  let spawnCommand: string[] = ["dev"]
+  let availablePort: number
+  if (config.port) {
+    availablePort = await detect({port: config.port, hostname: config.hostname})
+    spawnCommand = spawnCommand.concat(["-p", `${config.port}`])
+  }
+  if (config.hostname) {
+    spawnCommand = spawnCommand.concat(["-H", `${config.hostname}`])
+  }
 
   return new Promise((res, rej) => {
-    spawn(nextBin, ["dev", "-p", `${availablePort}`, "-H", config.hostname!], {
-      cwd,
-      stdio: [process.stdin, transform.pipe(process.stdout), transform.pipe(process.stderr)],
-    })
-      .on("exit", (code: number) => {
-        code === 0 ? res() : rej(`'next dev' failed with status code: ${code}`)
+    if (availablePort && availablePort !== config.port) {
+      rej(`Couldn't start server on port ${config.port}`)
+    } else {
+      spawn(nextBin, spawnCommand, {
+        cwd,
+        stdio: [process.stdin, transform.pipe(process.stdout), transform.pipe(process.stderr)],
       })
-      .on("error", rej)
+        .on("exit", (code: number) => {
+          code === 0 ? res() : rej(`'next dev' failed with status code: ${code}`)
+        })
+        .on("error", rej)
+    }
   })
 }
 
@@ -65,13 +77,31 @@ export function nextBuild(nextBin: string, cwd: string) {
 }
 
 export async function nextStart(nextBin: string, cwd: string, config: ServerConfig) {
-  const availablePort = await detect({port: config.port!, hostname: config.hostname!})
-  return Promise.resolve(
-    spawn(nextBin, ["start", "-p", `${availablePort}`, "-H", config.hostname!], {
-      cwd,
-      stdio: "inherit",
-    }).on("error", (err) => {
-      console.error(err)
-    }),
-  )
+  let spawnCommand: string[] = ["start"]
+  let availablePort: number
+  if (config.port) {
+    availablePort = await detect({port: config.port, hostname: config.hostname})
+    spawnCommand = spawnCommand.concat(["-p", `${config.port}`])
+  }
+  if (config.hostname) {
+    spawnCommand = spawnCommand.concat(["-H", `${config.hostname}`])
+  }
+
+  return new Promise((res, rej) => {
+    if (availablePort && availablePort !== config.port) {
+      rej(`Couldn't start server on port ${config.port}`)
+    } else {
+      spawn(nextBin, spawnCommand, {
+        cwd,
+        stdio: "inherit",
+      })
+        .on("exit", (code: number) => {
+          code === 0 ? res() : rej(`'next build' failed with status code: ${code}`)
+        })
+        .on("error", (err) => {
+          console.error(err)
+          rej(err)
+        })
+    }
+  })
 }


### PR DESCRIPTION
This PR closes the issue of having `port` and `hostname` flags in `build` command. 

Closes #624 
Closes #630 

### What are the changes and their implications?

 it changes the build command in `cli/build`  by removing `port` and `hostname` flags. it also changes the `next-utils` in `server` config to accept `undefined` values for flags `port` and `hostname`, adding `non null assertion`

### Checklist

- [x] Tests added for changes
- [ ] User facing changes documented

### Breaking change: no
