### PR TITLE
Rename `NextScript` to `BlitzScript`

### DIFF
--- a/examples/plain-js/app/pages/_document.js
+++ b/examples/plain-js/app/pages/_document.js
@@ -3,7 +3,7 @@ import {
   Html,
   DocumentHead,
   Main,
-  NextScript,
+  BlitzScript,
   /*DocumentContext*/
 } from "blitz"
 
@@ -19,7 +19,7 @@ class MyDocument extends Document {
         <DocumentHead />
         <body>
           <Main />
-          <NextScript />
+          <BlitzScript />
         </body>
       </Html>
     )

--- a/examples/store/app/pages/_document.tsx
+++ b/examples/store/app/pages/_document.tsx
@@ -1,4 +1,4 @@
-import { Document, Html, DocumentHead, Main, NextScript, DocumentContext } from "@blitzjs/core"
+import { Document, Html, DocumentHead, Main, BlitzScript, DocumentContext } from "@blitzjs/core"
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
@@ -12,7 +12,7 @@ class MyDocument extends Document {
         <DocumentHead />
         <body>
           <Main />
-          <NextScript />
+          <BlitzScript />
         </body>
       </Html>
     )

--- a/examples/tailwind/app/pages/_document.tsx
+++ b/examples/tailwind/app/pages/_document.tsx
@@ -1,4 +1,4 @@
-import { Document, Html, DocumentHead, Main, NextScript /*DocumentContext*/ } from "@blitzjs/core"
+import { Document, Html, DocumentHead, Main, BlitzScript /*DocumentContext*/ } from "@blitzjs/core"
 
 class MyDocument extends Document {
   // Only uncomment if you need to customize this behaviour
@@ -13,7 +13,7 @@ class MyDocument extends Document {
         <DocumentHead />
         <body>
           <Main />
-          <NextScript />
+          <BlitzScript />
         </body>
       </Html>
     )

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,7 +28,7 @@ export {
   Html,
   Head as DocumentHead,
   Main,
-  NextScript,
+  BlitzScript,
   DocumentContext,
   DocumentInitialProps,
 } from 'next/document'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,7 +28,7 @@ export {
   Html,
   Head as DocumentHead,
   Main,
-  BlitzScript,
+  NextScript as BlitzScript,
   DocumentContext,
   DocumentInitialProps,
 } from 'next/document'

--- a/packages/generator/templates/app/app/pages/_document.tsx
+++ b/packages/generator/templates/app/app/pages/_document.tsx
@@ -1,4 +1,4 @@
-import {Document, Html, DocumentHead, Main, NextScript /*DocumentContext*/} from 'blitz'
+import {Document, Html, DocumentHead, Main, BlitzScript /*DocumentContext*/} from 'blitz'
 
 class MyDocument extends Document {
   // Only uncomment if you need to customize this behaviour
@@ -13,7 +13,7 @@ class MyDocument extends Document {
         <DocumentHead />
         <body>
           <Main />
-          <NextScript />
+          <BlitzScript />
         </body>
       </Html>
     )


### PR DESCRIPTION
This PR closes the issue of Renaming `NextScript` to `BlitzScript`. #635

### What are the changes and their implications?

It updates the name of the export in the `core` package and also its imports in the `examples` and in the `generator` package

### Checklist

- [ ] Tests added for changes
- [ ] User facing changes documented

### Breaking change: yes

### Other information

If there is anything still to be changed that was not defined on the issue just let me know and I will update the Pull Request :)
