### PR TITLE
Start gui cli command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,7 @@
     "/lib"
   ],
   "dependencies": {
+    "@blitzjs/gui": "0.13.0",
     "@blitzjs/display": "0.13.0",
     "@blitzjs/repl": "0.13.0",
     "@oclif/command": "1.5.20",

--- a/packages/cli/src/check-before-running.ts
+++ b/packages/cli/src/check-before-running.ts
@@ -3,11 +3,11 @@ import chalk from 'chalk'
 
 import {isBlitzRoot, IsBlitzRootError} from './utils/is-blitz-root'
 
-const whitelistGlobal = ['-h', '--help', 'help', 'new']
+const globalCommands = ['-h', '--help', 'help', 'new', 'gui']
 
 export const hook: Hook<'init'> = async function (options) {
   const {id} = options
-  if (id && whitelistGlobal.includes(id)) return
+  if (id && globalCommands.includes(id)) return
 
   const {err, message, depth} = await isBlitzRoot()
 

--- a/packages/cli/src/commands/gui.ts
+++ b/packages/cli/src/commands/gui.ts
@@ -5,6 +5,7 @@ import spawn from 'cross-spawn'
 export class GUI extends Command {
   static description = 'Runs the Blitz GUI'
   static aliases = ['ui']
+  static hidden = true
 
   async run() {
     log.branded('You started the Blitz GUI')

--- a/packages/cli/src/commands/gui.ts
+++ b/packages/cli/src/commands/gui.ts
@@ -13,8 +13,6 @@ export class GUI extends Command {
       stdio: 'ignore',
     })
 
-    console.log(startGUIResult)
-
     if (startGUIResult.status !== 0) {
       log.warning('Failed to start Blitz GUI.')
     }

--- a/packages/cli/src/commands/gui.ts
+++ b/packages/cli/src/commands/gui.ts
@@ -1,0 +1,22 @@
+import {Command} from '@oclif/command'
+import {log} from '@blitzjs/display'
+import spawn from 'cross-spawn'
+
+export class GUI extends Command {
+  static description = 'Runs the Blitz GUI'
+  static aliases = ['ui']
+
+  async run() {
+    log.branded('You started the Blitz GUI')
+
+    const startGUIResult = spawn.sync('@blitzjs/gui', ['start'], {
+      stdio: 'ignore',
+    })
+
+    console.log(startGUIResult)
+
+    if (startGUIResult.status !== 0) {
+      log.warning('Failed to start Blitz GUI.')
+    }
+  }
+}

--- a/packages/cli/test/commands/gui.test.ts
+++ b/packages/cli/test/commands/gui.test.ts
@@ -1,0 +1,52 @@
+import spawn from 'cross-spawn'
+import {log} from '@blitzjs/display'
+
+import {GUI} from '../../src/commands/gui'
+
+jest.spyOn(global.console, 'log').mockImplementation()
+
+// Mocks the log output
+jest.mock(
+  '@blitzjs/display',
+  jest.fn(() => {
+    return {
+      log: {
+        branded: jest.fn(),
+        warning: jest.fn(),
+      },
+    }
+  }),
+)
+
+// Mocks spawn
+jest.mock('cross-spawn', () => {
+  return {
+    sync: jest.fn().mockImplementation(() => {
+      return {status: 0}
+    }),
+  }
+})
+
+describe('GUI Command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('calls @blitzjs/gui', async () => {
+    await GUI.run()
+
+    expect(spawn.sync).toHaveBeenCalledWith('@blitzjs/gui', ['start'], {stdio: 'ignore'})
+  })
+
+  describe('when@blitzjs/gui fails', () => {
+    it('logs warn', async () => {
+      // @ts-ignore (TS complains about reassign)
+      spawn.sync = jest.fn().mockImplementation(() => {
+        return {status: 1}
+      })
+      await GUI.run()
+
+      expect(log.warning).toHaveBeenCalledWith('Failed to start Blitz GUI.')
+    })
+  })
+})


### PR DESCRIPTION
Closes: #620

### What are the changes and their implications?
Adds a `cli` command to start the Blitz `gui` app.

### Checklist
- [x] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

### Question

Added the new command and I can run `blitz gui` using the linked cli. However, after I do `blitz new` it will not make that new command available in the project just created. I believe that's because the project will use the npm `cli` version, right?

Not sure how to workaround this problem. I am currently not able to test `blitz gui` inside a newly created project because of this limitation so I cannot guarantee it is working fine 🤔 .

Curious on everyone's thoughts/tips on that. 
