### PR TITLE
Only parse typescript/js files for relative paths in file-pipeline

### DIFF
--- a/packages/server/src/stages/pages/pages.test.ts
+++ b/packages/server/src/stages/pages/pages.test.ts
@@ -1,26 +1,11 @@
 import {createStagePages} from '.'
-import through2 from 'through2'
 import File from 'vinyl'
-import {FileCache} from '@blitzjs/file-pipeline'
-import {StageConfig, StageArgs} from '@blitzjs/file-pipeline/dist/packages/file-pipeline/src/types'
 import {DuplicatePathError} from './errors'
 import {normalize} from 'path'
+import {mockStageArgs} from '../stage-test-utils'
 
 function getStreamWithInputCache(entries: string[]) {
-  const config: StageConfig = {dest: '', cwd: '', ignore: [], include: [], src: '', watch: false}
-  const args: StageArgs = {
-    getInputCache() {
-      return ({
-        toPaths() {
-          return entries
-        },
-      } as any) as FileCache
-    },
-    bus: through2.obj(),
-    input: through2.obj(),
-    config,
-  }
-  return createStagePages(args).stream
+  return createStagePages(mockStageArgs({entries})).stream
 }
 
 describe('createStagePages', () => {

--- a/packages/server/src/stages/relative/index.ts
+++ b/packages/server/src/stages/relative/index.ts
@@ -5,13 +5,13 @@ import slash from 'slash'
 /**
  * Returns a Stage that converts relative files paths to absolute
  */
-export const createStageRelative: Stage = () => {
+export const createStageRelative: Stage = ({config: {cwd}}) => {
   const stream = transform.file((file) => {
-    const cwd = process.cwd()
+    // const cwd = process.cwd()
     const filecontents = file.contents
     const filepath = file.path
 
-    if (!isInAppFolder(filepath, cwd) || filecontents === null) {
+    if (!isJavaScriptFile(filepath) || !isInAppFolder(filepath, cwd) || filecontents === null) {
       return file
     }
 
@@ -25,6 +25,8 @@ export const createStageRelative: Stage = () => {
 
   return {stream}
 }
+
+const isJavaScriptFile = (filepath: string) => filepath.match(/\.(ts|tsx|js|jsx)$/)
 
 const isInAppFolder = (s: string, cwd: string) => s.replace(cwd + path.sep, '').indexOf('app') === 0
 

--- a/packages/server/src/stages/relative/relative.test.ts
+++ b/packages/server/src/stages/relative/relative.test.ts
@@ -1,0 +1,72 @@
+import {createStageRelative} from '.'
+import {mockStageArgs} from '../stage-test-utils'
+import File from 'vinyl'
+import {testStreamItems} from '../stage-test-utils'
+import {normalize} from 'path'
+describe('relative', () => {
+  test('test relative stream', () => {
+    const expected = [
+      {
+        path: normalize('/projects/blitz/blitz/app/users/pages.ts'),
+        contents: `import {getFoo} from 'app/foo/bar';    
+  import from "app/thing/bar"
+  import from 'app/thing/bar'`,
+      },
+      {
+        path: normalize('/projects/blitz/blitz/app/users/foo.jpeg'),
+        contents: `import {getFoo} from 'app/foo/bar';    
+  import from "../thing/bar"
+  import from '../thing/bar'`,
+      },
+      {
+        path: normalize('/projects/blitz/blitz/app/users/bar.tsx'),
+        contents: `import {getFoo} from 'app/foo/bar';    
+  import from "app/thing/bar"
+  import from 'app/thing/bar'`,
+      },
+      {
+        path: normalize('/projects/blitz/blitz/app/users/baz.js'),
+        contents: `import {getFoo} from 'app/foo/bar';    
+  import from "app/thing/bar"
+  import from 'app/thing/bar'`,
+      },
+    ]
+
+    const files = [
+      {
+        path: normalize('/projects/blitz/blitz/app/users/pages.ts'),
+        contents: `import {getFoo} from 'app/foo/bar';    
+  import from "../thing/bar"
+  import from '../thing/bar'`,
+      },
+      {
+        path: normalize('/projects/blitz/blitz/app/users/foo.jpeg'),
+        contents: `import {getFoo} from 'app/foo/bar';    
+  import from "../thing/bar"
+  import from '../thing/bar'`,
+      },
+      {
+        path: normalize('/projects/blitz/blitz/app/users/bar.tsx'),
+        contents: `import {getFoo} from 'app/foo/bar';    
+  import from "../thing/bar"
+  import from '../thing/bar'`,
+      },
+      {
+        path: normalize('/projects/blitz/blitz/app/users/baz.js'),
+        contents: `import {getFoo} from 'app/foo/bar';    
+  import from "../thing/bar"
+  import from '../thing/bar'`,
+      },
+    ]
+    const {stream} = createStageRelative(mockStageArgs({cwd: normalize('/projects/blitz/blitz')}))
+
+    files.forEach(({path, contents}) => {
+      stream.write(new File({path, contents: Buffer.from(contents)}))
+    })
+
+    testStreamItems(stream, expected, ({path, contents}: File) => ({
+      path,
+      contents: contents?.toString() || '',
+    }))
+  })
+})

--- a/packages/server/src/stages/stage-test-utils.ts
+++ b/packages/server/src/stages/stage-test-utils.ts
@@ -1,0 +1,46 @@
+import {StageConfig, StageArgs} from '@blitzjs/file-pipeline/dist/packages/file-pipeline/src/types'
+import {FileCache} from '@blitzjs/file-pipeline'
+
+import {through, pipeline} from '../streams'
+
+export function mockStageArgs(a: {entries?: string[]; cwd?: string}): StageArgs {
+  const config: StageConfig = {dest: '', cwd: a.cwd || '', ignore: [], include: [], src: '', watch: false}
+  return {
+    getInputCache() {
+      return ({
+        toPaths() {
+          return a.entries || []
+        },
+      } as any) as FileCache
+    },
+    bus: through.obj(),
+    input: through.obj(),
+    config,
+  }
+}
+
+const defaultLogger = (file: any) => (typeof file === 'string' ? file : file.path)
+export function testStreamItems(
+  stream: NodeJS.ReadWriteStream,
+  expected: any[],
+  logger: (a: any) => any = defaultLogger,
+) {
+  return new Promise((done) => {
+    const log: string[] = []
+
+    const st = pipeline(
+      stream,
+      through.obj((item, _, next) => {
+        log.push(logger(item))
+        if (log.length === expected.length) {
+          expect(log).toEqual(expected)
+          st.end()
+          setImmediate(() => {
+            done()
+          })
+        }
+        next(null, item)
+      }),
+    )
+  })
+}


### PR DESCRIPTION
Closes: #642

### What are the changes and their implications?

The relative stage was parsing all files looking for relative paths to make absolute. This skips non typescript/javascript files so that images are not corrupted.

### Checklist

- [x] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
