### PR TITLE
Fix latest version prisma when running blitz new

### DIFF
--- a/packages/generator/src/utils/fetch-latest-version-for.ts
+++ b/packages/generator/src/utils/fetch-latest-version-for.ts
@@ -19,7 +19,7 @@ export const fetchLatestVersionsFor = async <T extends Record<string, string>>(
       async ([dep, version]): Promise<[string, string]> => {
         let skipFetch = false
 
-        if (!version.match(/\d.x/)) skipFetch = true
+        if (!version.match(/\d.x/) && !dep.match(/@prisma\/\w+/)) skipFetch = true
 
         // We pin experimental versions to ensure they work, so don't auto update experimental
         if (version.match(/experimental/)) skipFetch = true

--- a/packages/generator/src/utils/get-latest-version.ts
+++ b/packages/generator/src/utils/get-latest-version.ts
@@ -17,7 +17,8 @@ export const getLatestVersion = async (
   dependency: string,
   templateVersion: string = '',
 ): Promise<Fallbackable<string>> => {
-  const major = templateVersion.replace('.x', '')
+  const toBeReplaced = templateVersion.substring(templateVersion.indexOf('.'))
+  const major = templateVersion.replace(toBeReplaced, '')
 
   try {
     const [allVersions, latestDistVersion] = await Promise.all([


### PR DESCRIPTION
Closes:  #647 

### What are the changes and their implications?

A new regex's been added in such a way that when running the generator using blitz new, new remote versions are fetched for prisma's packages.

When fetching latest versions of dependencies, major versions of Prisma's packages were not  detected properly since passed "template version" didn't match `/\d.x/` but `2.0.0-beta-*` instead. 

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
