### PR TITLE
Add spinner for Prettier formatting during 'blitz new'

### DIFF
--- a/packages/generator/src/generators/app-generator.ts
+++ b/packages/generator/src/generators/app-generator.ts
@@ -149,9 +149,16 @@ export class AppGenerator extends Generator<AppGeneratorOptions> {
       }
 
       // Ensure the generated files are formatted with the installed prettier version
+      const formattingSpinner = log.spinner(log.withBrand('Formatting your code')).start()
       const prettierResult = runLocalNodeCLI('prettier --loglevel silent --write .')
       if (prettierResult.status !== 0) {
-        throw new Error('Failed running prettier')
+        formattingSpinner.fail(
+          chalk.yellow.bold(
+            "We had an error running Prettier, but don't worry your app will still run fine :)",
+          ),
+        )
+      } else {
+        formattingSpinner.succeed()
       }
     } else {
       console.log('') // New line needed


### PR DESCRIPTION
Closes: #672

### What are the changes and their implications?
Added a new spinner for prettier formatting on `blitz new`. I also removed the error that was previously thrown which prevented the `Your new Blitz app is ready! Next steps:` message from appearing. I think it makes sense to still show this message since a prettier failure doesn't prevent the app from running.

Example of a successful run:
<img width="625" alt="image" src="https://user-images.githubusercontent.com/23707137/84579365-6e616900-adcd-11ea-8176-886fc4f9485f.png">


I used the error message copy which @flybayer suggested in the issue.  I wasn't sure which styling to use for the error message (since it's an error, but nothing fatal). The current commit uses the first one of the following examples, but I'm interested in what others think is best.

![image](https://user-images.githubusercontent.com/23707137/84579282-d6637f80-adcc-11ea-9f58-92b6f04e9e05.png)
![image](https://user-images.githubusercontent.com/23707137/84579289-e11e1480-adcc-11ea-8721-26e026f28d49.png)
![image](https://user-images.githubusercontent.com/23707137/84579292-e5e2c880-adcc-11ea-907b-090003aa114b.png)


### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
