### PR TITLE
Prevent `blitz db migrate` from attempting to create new migration files in production

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -54,6 +54,8 @@ export const runMigrate = async () => {
   const prismaBin = await getPrismaBin()
   return new Promise((resolve) => {
     if (process.env.NODE_ENV === 'production') {
+      runMigrateUp(prismaBin, resolve)
+    } else {
       const cp = spawn(prismaBin, ['migrate', 'save', schemaArg, '--create-db', '--experimental'], {
         stdio: 'inherit',
       })
@@ -64,8 +66,6 @@ export const runMigrate = async () => {
           process.exit(1)
         }
       })
-    } else {
-      runMigrateUp(prismaBin, resolve)
     }
   })
 }

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -53,9 +53,7 @@ const runMigrateUp = (prismaBin: string, resolve: (value?: unknown) => void) => 
 export const runMigrate = async () => {
   const prismaBin = await getPrismaBin()
   return new Promise((resolve) => {
-    if (process.env.NODE_ENV !== 'production') {
-      runMigrateUp(prismaBin, resolve)
-    } else {
+    if (process.env.NODE_ENV === 'production') {
       const cp = spawn(prismaBin, ['migrate', 'save', schemaArg, '--create-db', '--experimental'], {
         stdio: 'inherit',
       })
@@ -66,6 +64,8 @@ export const runMigrate = async () => {
           process.exit(1)
         }
       })
+    } else {
+      runMigrateUp(prismaBin, resolve)
     }
   })
 }

--- a/packages/cli/test/commands/db.test.ts
+++ b/packages/cli/test/commands/db.test.ts
@@ -38,7 +38,20 @@ describe('Db command', () => {
     jest.clearAllMocks()
   })
 
+  afterEach(() => {
+    process.env.NODE_ENV = 'test'
+  })
+
   function expectDbMigrateOutcome() {
+    expect(spawn.mock.calls.length).toBe(2)
+
+    // following expection is not working
+    //expect(onSpy).toHaveBeenCalledWith(0);
+
+    expect(spawn).toBeCalledWith(...migrateUpParams)
+  }
+
+  function expectProductionDbMigrateOutcome() {
     expect(spawn).toBeCalledWith(...migrateSaveParams)
     expect(spawn.mock.calls.length).toBe(3)
 
@@ -53,9 +66,21 @@ describe('Db command', () => {
     expectDbMigrateOutcome()
   })
 
+  it('runs db migrate in the production environment.', async () => {
+    process.env.NODE_ENV = 'production'
+    await Db.run(['migrate'])
+    expectProductionDbMigrateOutcome()
+  })
+
   it('runs db migrate (alias)', async () => {
     await Db.run(['m'])
     expectDbMigrateOutcome()
+  })
+
+  it('runs db migrate (alias) in the production environment.', async () => {
+    process.env.NODE_ENV = 'production'
+    await Db.run(['m'])
+    expectProductionDbMigrateOutcome()
   })
 
   it('runs db introspect', async () => {

--- a/packages/cli/test/commands/db.test.ts
+++ b/packages/cli/test/commands/db.test.ts
@@ -43,7 +43,8 @@ describe('Db command', () => {
   })
 
   function expectDbMigrateOutcome() {
-    expect(spawn.mock.calls.length).toBe(2)
+    expect(spawn).toBeCalledWith(...migrateSaveParams)
+    expect(spawn.mock.calls.length).toBe(3)
 
     // following expection is not working
     //expect(onSpy).toHaveBeenCalledWith(0);
@@ -52,8 +53,7 @@ describe('Db command', () => {
   }
 
   function expectProductionDbMigrateOutcome() {
-    expect(spawn).toBeCalledWith(...migrateSaveParams)
-    expect(spawn.mock.calls.length).toBe(3)
+    expect(spawn.mock.calls.length).toBe(2)
 
     // following expection is not working
     //expect(onSpy).toHaveBeenCalledWith(0);


### PR DESCRIPTION
This PR closes the issue of Prevent `blitz db migrate` from attempting to create new migration files in production. #670 

### What are the changes and their implications?
- Prevent `blitz db migrate` from attempting to create new migration files in production.
- Added test code for Db command.

### Checklist

- [x] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
