### PR TITLE
Possible fix for stuck at _manifest: Debounce manifest writing

### DIFF
--- a/packages/file-pipeline/src/index.ts
+++ b/packages/file-pipeline/src/index.ts
@@ -1,5 +1,5 @@
 export {transformFiles} from './transform-files'
-export {Stage} from './types'
+export {Stage, PipelineItem} from './types'
 export * from './events'
 export {transform} from './transform'
 export {FileCache} from './helpers/file-cache'

--- a/packages/server/src/stages/manifest/index.ts
+++ b/packages/server/src/stages/manifest/index.ts
@@ -1,5 +1,6 @@
 import File from 'vinyl'
-import {Stage, transform} from '@blitzjs/file-pipeline'
+import {Stage, PipelineItem, transform} from '@blitzjs/file-pipeline'
+import debounce from 'lodash/debounce'
 
 type ManifestVO = {
   keys: {[k: string]: string}
@@ -73,6 +74,10 @@ export const createStageManifest = (
 ) => {
   const stage: Stage = () => {
     const manifest = Manifest.create()
+    // Other options is to do a timeout
+    const debouncePushItem = debounce((push: (item: PipelineItem) => void, file: PipelineItem) => {
+      push(file)
+    }, 500)
 
     const stream = transform.file((file, {next, push}) => {
       push(file) // Send file on through to be written
@@ -89,7 +94,8 @@ export const createStageManifest = (
       }
 
       if (writeManifestFile) {
-        push(
+        debouncePushItem(
+          push,
           new File({
             // NOTE:  no need to for hash because this is a manifest
             //        and doesn't count as work

--- a/packages/server/src/stages/manifest/index.ts
+++ b/packages/server/src/stages/manifest/index.ts
@@ -74,7 +74,7 @@ export const createStageManifest = (
 ) => {
   const stage: Stage = () => {
     const manifest = Manifest.create()
-    // Other options is to do a timeout
+
     const debouncePushItem = debounce((push: (item: PipelineItem) => void, file: PipelineItem) => {
       push(file)
     }, 500)


### PR DESCRIPTION
This is related to #632 but may not close it

### What are the changes and their implications?

We should be only writing occasionally to `_manifest.json` this ensures we don't write to it too often. 

There is likely a highwatermark issue where a stream is getting corked due to too much throughput. This won't solve this underlying problem however it may alleviate 632. 

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
