### PR TITLE
Fix typo in model genereation output

### DIFF
--- a/packages/generator/src/generators/model-generator.ts
+++ b/packages/generator/src/generators/model-generator.ts
@@ -41,7 +41,7 @@ export class ModelGenerator extends Generator<ModelGeneratorOptions> {
         this.fs.append(path.resolve('db/schema.prisma'), `\n${modelDefinition.toString()}\n`)
       }
       log.success(
-        `Model for '${this.options.modelName}'${this.options.dryRun ? '' : 'created successfully'}:\n`,
+        `Model for '${this.options.modelName}'${this.options.dryRun ? '' : ' created successfully'}:\n`,
       )
       modelDefinition.toString().split('\n').map(log.progress)
       log.info('\nNow run ' + log.variable('blitz db migrate') + ' to add this model to your database\n')


### PR DESCRIPTION
Closes: N/A

### What are the changes and their implications?

Adds a space between the model name and "created successfully" in the console output when generating models. My greatest contribution to any project ever? I don't like to toot my own horn but some might say so, sure.

Before:

```
✔ Model for 'question'created successfully:
```

After:

```
✔ Model for 'question' created successfully:
```

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
