### PR TITLE
Update react-query to 1.5.8

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "@blitzjs/config": "0.15.0",
     "@blitzjs/display": "0.15.0",
     "pretty-ms": "6.0.1",
-    "react-query": "1.3.3",
+    "react-query": "1.5.8",
     "serialize-error": "6.0.0",
     "url": "0.11.0"
   },


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/689

### What are the changes and their implications?

Update react-query from 1.3.3 to 1.5.8. According to their changelog there are no breaking changes.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
