### PR TITLE
[Page template] Forward submit event from form to parent event handler

### DIFF
--- a/packages/generator/templates/form/__ModelName__Form.tsx
+++ b/packages/generator/templates/form/__ModelName__Form.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 type __ModelName__FormProps = {
   initialValues: any
-  onSubmit: () => any
+  onSubmit: React.FormEventHandler<HTMLFormElement>
 }
 
 const __ModelName__Form: React.FC<__ModelName__FormProps> = ({initialValues, onSubmit}) => {
@@ -10,7 +10,7 @@ const __ModelName__Form: React.FC<__ModelName__FormProps> = ({initialValues, onS
     <form
       onSubmit={(event) => {
         event.preventDefault()
-        onSubmit()
+        onSubmit(event)
       }}>
       <div>Put your form fields here. But for now, just click submit</div>
       <div>{JSON.stringify(initialValues)}</div>


### PR DESCRIPTION
Closes: N/A

### What are the changes and their implications?

This updates the model form component template to forward the submit event from the generated `onSubmit` event handler to the parent so the parent has access to the event.

I ran into needing the event in the parent while updating the tutorial and rather than document how to do this part, I figured it would be better to just update the template since needing access to the event in the user's `onSubmit` handler is probably a common scenario.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
