### PR TITLE
Fix broken cli when using npm where global blitz version used instead of local

### DIFF
--- a/examples/plain-js/package.json
+++ b/examples/plain-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plain-js",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "scripts": {
     "start": "blitz start",
     "build": "blitz db migrate && blitz build",
@@ -31,7 +31,7 @@
   "dependencies": {
     "@prisma/cli": "2.0.0",
     "@prisma/client": "2.0.0",
-    "blitz": "0.15.2-canary.0",
+    "blitz": "0.15.2-canary.1",
     "react": "0.0.0-experimental-33c3af284",
     "react-dom": "0.0.0-experimental-33c3af284"
   },

--- a/examples/store/cypress/support/index.js
+++ b/examples/store/cypress/support/index.js
@@ -12,9 +12,14 @@
 // You can read more here:
 // https://on.cypress.io/configuration
 // ***********************************************************
+import * as Cypress from "cypress"
 
 // Import commands.js using ES2015 syntax:
 import "./commands"
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+Cypress.Screenshot.defaults({
+  screenshotOnRunFailure: false,
+})

--- a/examples/store/cypress/support/index.js
+++ b/examples/store/cypress/support/index.js
@@ -12,7 +12,6 @@
 // You can read more here:
 // https://on.cypress.io/configuration
 // ***********************************************************
-import * as Cypress from "cypress"
 
 // Import commands.js using ES2015 syntax:
 import "./commands"

--- a/examples/store/package.json
+++ b/examples/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "store",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "private": true,
   "scripts": {
     "build": "blitz db migrate && blitz build",
@@ -18,7 +18,7 @@
   "dependencies": {
     "@prisma/cli": "2.0.0",
     "@prisma/client": "2.0.0",
-    "blitz": "0.15.2-canary.0",
+    "blitz": "0.15.2-canary.1",
     "final-form": "4.19.1",
     "react": "0.0.0-experimental-33c3af284",
     "react-dom": "0.0.0-experimental-33c3af284",

--- a/examples/tailwind/package.json
+++ b/examples/tailwind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "scripts": {
     "build": "blitz db migrate && blitz build",
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts,.tsx .",
@@ -30,7 +30,7 @@
   "dependencies": {
     "@prisma/cli": "2.0.0",
     "@prisma/client": "2.0.0",
-    "blitz": "0.15.2-canary.0",
+    "blitz": "0.15.2-canary.1",
     "react": "0.0.0-experimental-33c3af284",
     "react-dom": "0.0.0-experimental-33c3af284",
     "typescript": "3.8.3"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,

--- a/packages/blitz/package.json
+++ b/packages/blitz/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blitz",
   "description": "Blitz is a Rails-like framework for monolithic, full-stack React apps — built on Next.js",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "license": "MIT",
   "scripts": {
     "clean": "rimraf dist",
@@ -39,10 +39,10 @@
     "url": "https://github.com/blitz-js/blitz"
   },
   "dependencies": {
-    "@blitzjs/cli": "0.15.2-canary.0",
-    "@blitzjs/core": "0.15.2-canary.0",
-    "@blitzjs/generator": "0.15.2-canary.0",
-    "@blitzjs/server": "0.15.2-canary.0",
+    "@blitzjs/cli": "0.15.2-canary.1",
+    "@blitzjs/core": "0.15.2-canary.1",
+    "@blitzjs/generator": "0.15.2-canary.1",
+    "@blitzjs/server": "0.15.2-canary.1",
     "os-name": "3.1.0",
     "pkg-dir": "4.2.0",
     "resolve-from": "5.0.0",

--- a/packages/blitz/src/bin/cli.ts
+++ b/packages/blitz/src/bin/cli.ts
@@ -14,7 +14,8 @@ console.log(
 
 let usageType: "local" | "monorepo" | "global" | "global-linked"
 
-const localCLIPkgPath = path.resolve(process.cwd(), "node_modules", "@blitzjs/cli")
+const localCLIPkgPath1 = path.resolve(process.cwd(), "node_modules", "@blitzjs/cli")
+const localCLIPkgPath2 = path.resolve(process.cwd(), "node_modules/blitz/node_modules/@blitzjs/cli")
 const monorepoCLIPkgPath = path.resolve(process.cwd(), "../..", "node_modules", "@blitzjs/cli")
 const globalCLIPkgPath = resolveFrom(__dirname, "@blitzjs/cli")
 const globalLinkedPath = path.resolve(pkgDir.sync(__dirname), "../../lerna.json")
@@ -33,9 +34,12 @@ function getBlitzPkgJsonPath() {
 }
 
 let pkgPath
-if (fs.existsSync(localCLIPkgPath)) {
+if (fs.existsSync(localCLIPkgPath1)) {
   usageType = "local"
-  pkgPath = localCLIPkgPath
+  pkgPath = localCLIPkgPath1
+} else if (fs.existsSync(localCLIPkgPath2)) {
+  usageType = "local"
+  pkgPath = localCLIPkgPath2
 } else if (fs.existsSync(monorepoCLIPkgPath)) {
   usageType = "monorepo"
   pkgPath = monorepoCLIPkgPath

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blitzjs/cli",
   "description": "Blitz.js CLI",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "license": "MIT",
   "scripts": {
     "b": "./bin/run",
@@ -30,8 +30,8 @@
     "/lib"
   ],
   "dependencies": {
-    "@blitzjs/display": "0.15.2-canary.0",
-    "@blitzjs/repl": "0.15.2-canary.0",
+    "@blitzjs/display": "0.15.2-canary.1",
+    "@blitzjs/repl": "0.15.2-canary.1",
     "@oclif/command": "1.5.20",
     "@oclif/config": "1.15.1",
     "@oclif/plugin-help": "2.2.3",
@@ -53,9 +53,9 @@
     "tsconfig-paths": "3.9.0"
   },
   "devDependencies": {
-    "@blitzjs/generator": "0.15.2-canary.0",
-    "@blitzjs/installer": "0.15.2-canary.0",
-    "@blitzjs/server": "0.15.2-canary.0",
+    "@blitzjs/generator": "0.15.2-canary.1",
+    "@blitzjs/installer": "0.15.2-canary.1",
+    "@blitzjs/server": "0.15.2-canary.1",
     "@oclif/dev-cli": "1.22.2",
     "@oclif/test": "1.2.5",
     "@prisma/cli": "2.0.0-beta.3",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,7 +7,7 @@
     "config"
   ],
   "author": "Fran Zekan <zekan.fran369@gmail.com>",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "license": "MIT",
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blitzjs/core",
   "description": "Blitz.js core functionality",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "license": "MIT",
   "scripts": {
     "clean": "rimraf dist",
@@ -40,8 +40,8 @@
     "url": "https://github.com/blitz-js/blitz"
   },
   "dependencies": {
-    "@blitzjs/config": "0.15.2-canary.0",
-    "@blitzjs/display": "0.15.2-canary.0",
+    "@blitzjs/config": "0.15.2-canary.1",
+    "@blitzjs/display": "0.15.2-canary.1",
     "pretty-ms": "6.0.1",
     "react-query": "1.5.8",
     "serialize-error": "6.0.0",

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blitzjs/display",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "description": "Display package for the Blitz CLI",
   "homepage": "https://github.com/blitz-js/blitz#readme",
   "license": "MIT",

--- a/packages/file-pipeline/package.json
+++ b/packages/file-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blitzjs/file-pipeline",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "description": "Display package for the Blitz CLI",
   "homepage": "https://github.com/blitz-js/blitz#readme",
   "license": "MIT",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blitzjs/generator",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "description": "File generation for the Blitz CLI",
   "homepage": "https://github.com/blitz-js/blitz#readme",
   "license": "MIT",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@babel/core": "7.9.0",
     "@babel/plugin-transform-typescript": "7.9.4",
-    "@blitzjs/display": "0.15.2-canary.0",
+    "@blitzjs/display": "0.15.2-canary.1",
     "ast-types": "0.13.3",
     "chalk": "4.0.0",
     "cross-spawn": "7.0.2",

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -190,7 +190,11 @@ export abstract class Generator<
       if (this.useTs) {
         options.parser = "babel-ts"
       }
-      templatedFile = this.prettier.format(templatedFile, options)
+      try {
+        templatedFile = this.prettier.format(templatedFile, options)
+      } catch (error) {
+        log.warning(`Failed trying to run prettier:` + error)
+      }
     }
     return templatedFile
   }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blitzjs/gui",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "scripts": {
     "start": "blitz start"
   },

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blitzjs/installer",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "description": "Package installation for the Blitz CLI",
   "homepage": "https://github.com/blitz-js/blitz#readme",
   "license": "MIT",
@@ -36,8 +36,8 @@
   "dependencies": {
     "@babel/core": "7.9.0",
     "@babel/plugin-transform-typescript": "7.9.4",
-    "@blitzjs/display": "0.15.2-canary.0",
-    "@blitzjs/generator": "0.15.2-canary.0",
+    "@blitzjs/display": "0.15.2-canary.1",
+    "@blitzjs/generator": "0.15.2-canary.1",
     "ast-types": "0.13.3",
     "chokidar": "3.3.1",
     "cross-spawn": "7.0.2",

--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blitzjs/repl",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "description": "Repl package for Blitz CLI",
   "homepage": "https://github.com/blitz-js/blitz/packages/repl/#readme",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blitzjs/server",
   "description": "Blitz.js server functionality",
-  "version": "0.15.2-canary.0",
+  "version": "0.15.2-canary.1",
   "license": "MIT",
   "bin": {
     "next-patched": "./bin/next-patched"
@@ -28,8 +28,8 @@
   "module": "dist/server.esm.js",
   "types": "dist/packages/server/src/index.d.ts",
   "dependencies": {
-    "@blitzjs/display": "0.15.2-canary.0",
-    "@blitzjs/file-pipeline": "0.15.2-canary.0",
+    "@blitzjs/display": "0.15.2-canary.1",
+    "@blitzjs/file-pipeline": "0.15.2-canary.1",
     "cross-spawn": "7.0.2",
     "detect-port": "1.3.0",
     "fast-glob": "3.2.2",
@@ -59,7 +59,7 @@
     "vinyl-fs": "3.0.3"
   },
   "devDependencies": {
-    "@blitzjs/core": "0.15.2-canary.0"
+    "@blitzjs/core": "0.15.2-canary.1"
   },
   "gitHead": "d3b9fce0bdd251c2b1890793b0aa1cd77c1c0922"
 }


### PR DESCRIPTION
### What are the changes and their implications?

This fixes a bug where `blitz -vV` will return `debug: global` when run inside a blitz project. This means it's using the globally installed blitz package.

This also was causing the following error when running `blitz generate`:

```
✕ Error generating __modelIdParam__/edit.tsx
✕ Error: Couldn't resolve parser "babel-ts"
```

So I also added a try/catch around prettier in the generator to ensure that a prettier failure doesn't block file generation.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
