### PR TITLE
Support Optimistic UI Updates: Add refetch option to useQuery mutate()

### DIFF
--- a/packages/core/src/utils/query-cache.ts
+++ b/packages/core/src/utils/query-cache.ts
@@ -11,9 +11,9 @@ export interface QueryCacheFunctions<T> {
 export const getQueryCacheFunctions = <T>(queryKey: string): QueryCacheFunctions<T> => ({
   mutate: (newData, opts = {refetch: true}) => {
     queryCache.setQueryData(queryKey, newData)
-    if (opts.refetch) {
-      return queryCache.refetchQueries(queryKey, {force: true})
+    if (!opts.refetch) {
+      return null
     }
-    return null
+    return queryCache.refetchQueries(queryKey, {force: true})
   },
 })

--- a/packages/core/src/utils/query-cache.ts
+++ b/packages/core/src/utils/query-cache.ts
@@ -1,12 +1,15 @@
 import {queryCache} from "react-query"
 
 export interface QueryCacheFunctions<T> {
-  mutate: (newData: T | ((oldData: T | undefined) => T)) => void
+  mutate: (newData: T | ((oldData: T | undefined) => T), refetch?: boolean) => void
 }
 
 export const getQueryCacheFunctions = <T>(queryKey: string): QueryCacheFunctions<T> => ({
-  mutate: (newData) => {
+  mutate: (newData, refetch = true) => {
     queryCache.setQueryData(queryKey, newData)
-    return queryCache.refetchQueries(queryKey, {force: true})
+    if (refetch) {
+      return queryCache.refetchQueries(queryKey, {force: true})
+    }
+    return null
   },
 })

--- a/packages/core/src/utils/query-cache.ts
+++ b/packages/core/src/utils/query-cache.ts
@@ -11,9 +11,9 @@ export interface QueryCacheFunctions<T> {
 export const getQueryCacheFunctions = <T>(queryKey: string): QueryCacheFunctions<T> => ({
   mutate: (newData, opts = {refetch: true}) => {
     queryCache.setQueryData(queryKey, newData)
-    if (!opts.refetch) {
-      return null
+    if (opts.refetch) {
+      return queryCache.refetchQueries(queryKey, {force: true})
     }
-    return queryCache.refetchQueries(queryKey, {force: true})
+    return null
   },
 })

--- a/packages/core/src/utils/query-cache.ts
+++ b/packages/core/src/utils/query-cache.ts
@@ -1,13 +1,17 @@
 import {queryCache} from "react-query"
 
+type MutateOptions = {
+  refetch?: boolean
+}
+
 export interface QueryCacheFunctions<T> {
-  mutate: (newData: T | ((oldData: T | undefined) => T), refetch?: boolean) => void
+  mutate: (newData: T | ((oldData: T | undefined) => T), opts?: MutateOptions) => void
 }
 
 export const getQueryCacheFunctions = <T>(queryKey: string): QueryCacheFunctions<T> => ({
-  mutate: (newData, refetch = true) => {
+  mutate: (newData, opts = {refetch: true}) => {
     queryCache.setQueryData(queryKey, newData)
-    if (refetch) {
+    if (opts.refetch) {
       return queryCache.refetchQueries(queryKey, {force: true})
     }
     return null

--- a/packages/core/test/query-cache.test.ts
+++ b/packages/core/test/query-cache.test.ts
@@ -1,0 +1,18 @@
+import {getQueryCacheFunctions} from "../src/utils/query-cache"
+import {queryCache} from "react-query"
+
+jest.mock("react-query")
+
+describe("getQueryCacheFunctions", () => {
+  it("returns a mutate function with working options", () => {
+    const spyRefetchQueries = jest.spyOn(queryCache, "refetchQueries")
+    const {mutate} = getQueryCacheFunctions("testQueryKey")
+    expect(mutate).toBeTruthy()
+    mutate({newData: true})
+    expect(spyRefetchQueries).toBeCalledTimes(1)
+    mutate({newData: true}, {refetch: false})
+    expect(spyRefetchQueries).toBeCalledTimes(1)
+    mutate({newData: true}, {refetch: true})
+    expect(spyRefetchQueries).toBeCalledTimes(2)
+  })
+})


### PR DESCRIPTION
Closes: #626 

### What are the changes and their implications?
Adds an optional options argument to the mutate function returned from useQuery. This allows refetching data after a local mutation to be disabled, enabling some basic optimistic UI patterns.

### Checklist

- [x] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes: https://github.com/blitz-js/blitzjs.com/pull/100

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
