### PR TITLE
Fix middleware error handling when using `next(error)`

### DIFF
--- a/packages/core/src/middleware.test.ts
+++ b/packages/core/src/middleware.test.ts
@@ -68,31 +68,34 @@ describe("handleRequestWithMiddleware", () => {
   it("middleware can throw", async () => {
     console.log = jest.fn()
     console.error = jest.fn()
+    const forbiddenMiddleware = jest.fn()
     const middleware: Middleware[] = [
       (_req, _res, _next) => {
         throw new Error("test")
       },
+      forbiddenMiddleware,
     ]
 
     await mockServer(middleware, async (url) => {
       const res = await fetch(url)
+      expect(forbiddenMiddleware).not.toBeCalled()
       expect(res.status).toBe(500)
     })
   })
 
   it("middleware can return error", async () => {
     console.log = jest.fn()
+    const forbiddenMiddleware = jest.fn()
     const middleware: Middleware[] = [
       (_req, _res, next) => {
         return next(new Error("test"))
       },
-      (_req, _res, _next) => {
-        throw new Error("Remaining middleware should not run if previous has error")
-      },
+      forbiddenMiddleware,
     ]
 
     await mockServer(middleware, async (url) => {
       const res = await fetch(url)
+      expect(forbiddenMiddleware).not.toBeCalled()
       expect(res.status).toBe(500)
     })
   })

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -109,7 +109,11 @@ export function compose(middleware: Middleware[]) {
     // last called middleware #
     let index = -1
 
-    function dispatch(i: number): Promise<void> {
+    function dispatch(i: number, error?: any): Promise<void> {
+      if (error) {
+        return Promise.reject(error)
+      }
+
       if (i <= index) throw new Error("next() called multiple times")
       index = i
 

--- a/packages/core/src/ssr-query.test.ts
+++ b/packages/core/src/ssr-query.test.ts
@@ -8,6 +8,7 @@ import {EnhancedResolverModule} from "./rpc"
 
 describe("ssrQuery", () => {
   it("works without middleware", async () => {
+    console.log = jest.fn()
     const resolverModule = (jest.fn().mockImplementation(async (input) => {
       await delay(1)
       return input
@@ -33,6 +34,7 @@ describe("ssrQuery", () => {
   })
 
   it("works with middleware", async () => {
+    console.log = jest.fn()
     const resolverModule = (jest.fn().mockImplementation(async (input) => {
       await delay(1)
       return input


### PR DESCRIPTION
### What are the changes and their implications?

There was a bug where calling `next(error)` got ignored and did not short circuit the request.

### Checklist

- [x] Tests added for changes
- [ ] N/A - PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
