### PR TITLE
Breaking: Upgrade React Query to v2

### DIFF
--- a/examples/store/app/products/pages/products/infinite.tsx
+++ b/examples/store/app/products/pages/products/infinite.tsx
@@ -22,7 +22,7 @@ const Products = () => {
       ))}
 
       <div>
-        <button onClick={() => fetchMore()} disabled={!canFetchMore || isFetchingMore}>
+        <button onClick={() => fetchMore()} disabled={!canFetchMore || !!isFetchingMore}>
           {isFetchingMore ? "Loading more..." : canFetchMore ? "Load More" : "Nothing more to load"}
         </button>
       </div>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "@blitzjs/config": "0.15.3",
     "@blitzjs/display": "0.15.3",
     "pretty-ms": "6.0.1",
-    "react-query": "^2.4.4",
+    "react-query": "2.4.4",
     "serialize-error": "6.0.0",
     "url": "0.11.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "@blitzjs/config": "0.15.3",
     "@blitzjs/display": "0.15.3",
     "pretty-ms": "6.0.1",
-    "react-query": "1.5.8",
+    "react-query": "^2.4.4",
     "serialize-error": "6.0.0",
     "url": "0.11.0"
   },

--- a/packages/core/src/use-infinite-query.ts
+++ b/packages/core/src/use-infinite-query.ts
@@ -31,7 +31,7 @@ export function useInfiniteQuery<T extends QueryFn>(
   const queryRpcFn = (queryFn as unknown) as EnhancedRpcFunction
 
   const {data, ...queryRest} = useInfiniteReactQuery({
-    queryKey: () => [
+    queryKey: [
       queryRpcFn._meta.apiUrl,
       typeof params === "function" ? (params as Function)() : params,
     ],

--- a/packages/core/src/use-paginated-query.ts
+++ b/packages/core/src/use-paginated-query.ts
@@ -31,7 +31,7 @@ export function usePaginatedQuery<T extends QueryFn>(
   const queryRpcFn = (queryFn as unknown) as EnhancedRpcFunction
 
   const {resolvedData, ...queryRest} = usePaginatedReactQuery({
-    queryKey: () => [
+    queryKey: [
       queryRpcFn._meta.apiUrl,
       typeof params === "function" ? (params as Function)() : params,
     ],

--- a/packages/core/src/use-query.ts
+++ b/packages/core/src/use-query.ts
@@ -24,7 +24,7 @@ export function useQuery<T extends QueryFn>(
   const queryRpcFn = (queryFn as unknown) as EnhancedRpcFunction
 
   const {data, ...queryRest} = useReactQuery({
-    queryKey: () => [
+    queryKey: [
       queryRpcFn._meta.apiUrl,
       typeof params === "function" ? (params as Function)() : params,
     ],

--- a/packages/core/src/utils/query-cache.ts
+++ b/packages/core/src/utils/query-cache.ts
@@ -12,7 +12,7 @@ export const getQueryCacheFunctions = <T>(queryKey: string): QueryCacheFunctions
   mutate: (newData, opts = {refetch: true}) => {
     queryCache.setQueryData(queryKey, newData)
     if (opts.refetch) {
-      return queryCache.refetchQueries(queryKey, {force: true})
+      return queryCache.invalidateQueries(queryKey, {refetchActive: true})
     }
     return null
   },

--- a/packages/core/test/query-cache.test.ts
+++ b/packages/core/test/query-cache.test.ts
@@ -5,7 +5,7 @@ jest.mock("react-query")
 
 describe("getQueryCacheFunctions", () => {
   it("returns a mutate function with working options", () => {
-    const spyRefetchQueries = jest.spyOn(queryCache, "refetchQueries")
+    const spyRefetchQueries = jest.spyOn(queryCache, "invalidateQueries")
     const {mutate} = getQueryCacheFunctions("testQueryKey")
     expect(mutate).toBeTruthy()
     mutate({newData: true})

--- a/packages/core/test/use-query.test.tsx
+++ b/packages/core/test/use-query.test.tsx
@@ -51,27 +51,5 @@ describe("useQuery", () => {
         expect(res.data).toBe("TEST")
       })
     })
-
-    it("should work on dependent query", async () => {
-      // dependent queries are canceled if the params function throws
-      let params: Function = () => {
-        throw new Error("not ready yet")
-      }
-
-      const [res, rerender] = setupHook(() => params(), upcase)
-      await screen.findByText("Missing Dependency")
-
-      // eslint-disable-next-line require-await
-      await act(async () => {
-        // simulates the dependency becoming available
-        params = () => "test"
-        rerender()
-      })
-
-      await act(async () => {
-        await screen.findByText("Ready")
-        expect(res.data).toBe("TEST")
-      })
-    })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -13986,10 +13986,10 @@ react-query@1.3.3:
     "@scarf/scarf" "^1.0.0"
     ts-toolbelt "^6.4.2"
 
-react-query@1.5.8:
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-1.5.8.tgz#80cd99cb279d1ff0ac64122761d95a3e4b014d49"
-  integrity sha512-tQIndH00/pJ21jCIche2jwcoflNGPrSBx0m9MxuDEbTwbQztp5dCzN+3/tKWk6dRw2jrhsV78KhoeYrR21SkZQ==
+react-query@^2.4.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.4.4.tgz#31cb61738f2534fe51eb3921afd3a57abefa3f07"
+  integrity sha512-rDGMj4KHFt+D83Aq076rmAZDnfsVcArrOYQusO7EgIbMa9ioeppJ/fdSGiGH+tfShB4o+8xpKBxpHFjuLnitQw==
   dependencies:
     "@scarf/scarf" "^1.0.6"
     ts-toolbelt "^6.9.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13986,7 +13986,7 @@ react-query@1.3.3:
     "@scarf/scarf" "^1.0.0"
     ts-toolbelt "^6.4.2"
 
-react-query@^2.4.4:
+react-query@2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.4.4.tgz#31cb61738f2534fe51eb3921afd3a57abefa3f07"
   integrity sha512-rDGMj4KHFt+D83Aq076rmAZDnfsVcArrOYQusO7EgIbMa9ioeppJ/fdSGiGH+tfShB4o+8xpKBxpHFjuLnitQw==


### PR DESCRIPTION
This PR closes the issue of Upgrade React Query to v2. #712 

### What are the changes and their implications?
- To update React Query, I have fixed the implementation to accommodate some breaking changes.

**Affected Change List**
1. The new way to do dependent queries to instead use the enabled config flag. You should move your conditions in your key to the enabled option
    - Before
    ```useQuery(ready && queryKey, queryFn) ```
    - After
    ```useQuery(queryKey, queryFn, { enabled: ready })```
2. If you use functions as query keys that can potentially throw, you should migrate their logic to the enabled config option and use optional chaining to cast them to a boolean
    - Before
    ```useQuery(() => ['user', user.id], queryFn) ```
    - After
    ```useQuery(['user', user?.id], queryFn, { enabled: user?.id })```
3. `refetchQueries` has been renamed to `invalidateQueries`. You will need make this rename change for your app to continue working propertly. The name change comes due to some differences in what the function does.
    - Before, any queries that matched the `queryKey` used in `refetchQueries(queryKey)` and were also stale, would be refetched... even queries that were inactive and not rendered on the screen. This resulted in quite a few queries being refetched regardless of their immediate necessity.
    - Now, with invalidateQueries, only queries that are actively rendered will be refetched, while any other matching queries will forcefully be marked as stale.
4. The type of `isFetchingMore` in `InfiniteQueryResult` has been changed from `boolean` to `false | 'previous' | 'next'`.

### Checklist

- [ ] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes: https://github.com/blitz-js/blitzjs.com/pull/108

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
