### PR TITLE
Fix experimental flags in blitz.config.js not being used

### DIFF
--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -18,6 +18,7 @@ export function withBlitz(nextConfig: any) {
       Object.assign({}, normalizedConfig, {
         experimental: {
           reactMode: "concurrent",
+          ...(nextConfig.experimental || {}),
         },
         webpack(config: any, options: Record<any, any>) {
           if (!options.isServer) {

--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -18,7 +18,7 @@ export function withBlitz(nextConfig: any) {
       Object.assign({}, normalizedConfig, {
         experimental: {
           reactMode: "concurrent",
-          ...(nextConfig.experimental || {}),
+          ...(normalizedConfig.experimental || {}),
         },
         webpack(config: any, options: Record<any, any>) {
           if (!options.isServer) {


### PR DESCRIPTION
Closes: #410

### What are the changes and their implications?

It adds an option to override the blitz default with `blitz.config.js`  experimental variables in the config. 

### Checklist

- [x] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes
