### PR TITLE
Fix global middleware not running with `blitz start --production`

### DIFF
--- a/examples/store/app/pages/index.tsx
+++ b/examples/store/app/pages/index.tsx
@@ -1,4 +1,13 @@
-import {Head, Link} from "blitz"
+import React, {Suspense} from "react"
+import {Head, Link, useQuery} from "blitz"
+import getReferer from "app/queries/getReferer"
+
+const Referer = () => {
+  // This is here mainly as an integration test for global middleware
+  const [referer] = useQuery(getReferer, {})
+
+  return <div id="referer">Referer: {referer}</div>
+}
 
 const Home = () => (
   <div className="container">
@@ -48,6 +57,9 @@ const Home = () => (
       >
         Powered by Blitz.js
       </a>
+      <Suspense fallback={null}>
+        <Referer />
+      </Suspense>
     </footer>
 
     <style jsx>{`
@@ -74,6 +86,7 @@ const Home = () => (
         height: 100px;
         border-top: 1px solid #eaeaea;
         display: flex;
+        flex-direction: column;
         justify-content: center;
         align-items: center;
       }

--- a/examples/store/app/queries/getReferer.ts
+++ b/examples/store/app/queries/getReferer.ts
@@ -1,0 +1,3 @@
+export default function getReferer(_, ctx: any = {}) {
+  return ctx.referer
+}

--- a/examples/store/cypress/integration/index.test.ts
+++ b/examples/store/cypress/integration/index.test.ts
@@ -6,6 +6,7 @@ describe("index page", () => {
   it("Has title and H1", () => {
     cy.contains("h1", "Blitz Store Example")
     cy.title().should("eq", "Blitz Example Store")
+    cy.get("#referer").contains("http://localhost:3099")
   })
 
   it("goes to products page", () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -2,7 +2,7 @@ import pkgDir from "pkg-dir"
 import {join} from "path"
 import {existsSync} from "fs"
 
-const configFiles = ["next.config.js"]
+const configFiles = ["blitz.config.js", "next.config.js"]
 /**
  * @param {boolean | undefined} reload - reimport config files to reset global cache
  */
@@ -24,7 +24,10 @@ export const getConfig = (reload?: boolean): Record<string, unknown> => {
       } else {
         contents = file
       }
-      blitzConfig = contents
+      blitzConfig = {
+        ...blitzConfig,
+        ...contents,
+      }
     }
   }
 


### PR DESCRIPTION
### What are the changes and their implications?

Fixes global http middleware not running with `blitz start --production`

### Checklist

- [x] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
