### PR TITLE
Update blitz db cli command to default to --help if no command specified

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -159,6 +159,7 @@ ${chalk.bold("reset")}   Reset the database and run a fresh migration via Prisma
       name: "command",
       description: "Run specific db command",
       required: true,
+      default: "help",
     },
   ]
 
@@ -229,6 +230,8 @@ ${chalk.bold("reset")}   Reset the database and run a fresh migration via Prisma
           }
         }
       })
+    } else if (command === "help") {
+      await Db.run(["--help"])
     } else {
       this.log("\nUh oh, Blitz does not support that command.")
       this.log("You can try running a prisma command directly with:")

--- a/packages/cli/test/commands/db.test.ts
+++ b/packages/cli/test/commands/db.test.ts
@@ -61,6 +61,45 @@ describe("Db command", () => {
     expect(spawn).toBeCalledWith(...migrateUpParams)
   }
 
+  it("runs db help when no command given", async () => {
+    // When running the help command oclif exits with code 0
+    // Unfortantely it treats this as an exception and throws accordingly
+
+    // Get the db --help command output
+    let dbHelpCommandOutput = []
+    let dbHelpCommandExit
+    try {
+      jest.spyOn(global.console, "log").mockImplementation(
+        jest.fn((output: string) => {
+          dbHelpCommandOutput.push(output)
+        }),
+      )
+
+      await Db.run(["--help"])
+    } catch (e) {
+      dbHelpCommandExit = e
+    }
+
+    // Get the db command output
+    let dbCommandOutput = []
+    let dbCommandExit
+    try {
+      jest.spyOn(global.console, "log").mockImplementation(
+        jest.fn((output: string) => {
+          dbCommandOutput.push(output)
+        }),
+      )
+
+      await Db.run([])
+    } catch (e) {
+      dbCommandExit = e
+    }
+
+    // We expect the 2 outputs to be the same
+    expect(dbHelpCommandOutput).toEqual(dbCommandOutput)
+    expect(dbHelpCommandExit).toEqual(dbCommandExit)
+  })
+
   it("runs db migrate", async () => {
     await Db.run(["migrate"])
     expectDbMigrateOutcome()


### PR DESCRIPTION
Closes: #383 

### What are the changes and their implications?

This PR allows functionality for the cli command `blitz db` with no options specified to default to `blitz db --help` this allows the cli to better gracefully handle this case.

### Checklist

- [X] Tests added for changes
- [X] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
