### PR TITLE
Fix buggy global/local CLI resolution code

### DIFF
--- a/packages/blitz/package.json
+++ b/packages/blitz/package.json
@@ -45,8 +45,7 @@
     "@blitzjs/server": "0.16.1",
     "os-name": "3.1.0",
     "pkg-dir": "4.2.0",
-    "resolve-from": "5.0.0",
-    "resolve-global": "1.0.0"
+    "resolve-from": "5.0.0"
   },
   "keywords": [
     "blitz",


### PR DESCRIPTION
Closes: #729 

### What are the changes and their implications?

This drastically cleans up the hacky code for switching between global and local execution of the CLI package.

When blitz cli is used inside a blitz project, it uses the locally installed version of blitz. The code for doing that was buggy. This fixes that.

**Also,** this makes the blitz cli use the development version if the cli is globally linked!! This makes it very easy to test dev versions of blitz with apps that aren't in the blitz monorepo.


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
