### PR TITLE
Fix bug preventing use of next-compose-plugins

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,7 @@
 import pkgDir from "pkg-dir"
 import {join} from "path"
 import {existsSync} from "fs"
+import {PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_SERVER} from "next/constants"
 
 const configFiles = ["blitz.config.js", "next.config.js"]
 /**
@@ -20,7 +21,9 @@ export const getConfig = (reload?: boolean): Record<string, unknown> => {
       const file = require(path)
       let contents
       if (typeof file === "function") {
-        contents = file()
+        const phase =
+          process.env.NODE_ENV === "production" ? PHASE_PRODUCTION_SERVER : PHASE_DEVELOPMENT_SERVER
+        contents = file(phase, {})
       } else {
         contents = file
       }


### PR DESCRIPTION


### What are the changes and their implications?

This fixes the following error:

Client:
```
Error: Failed to parse json from request ...
```
Server:
```
TypeError: Cannot destructure property 'defaultConfig' of 'undefined' as it is undefined.
    at /Users/simon/Code/philharmonic/node_modules/next-compose-plugins/lib/index.js:18:3
...
```

With a config like this:

```
const withPlugins = require("next-compose-plugins")
const withTM = require("next-transpile-modules")(["heroicons"])
module.exports = withPlugins([withTM], {
  webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
    // Note: we provide webpack above so you should not `require` it
    // Perform customizations to webpack config
    // Important: return the modified config
    return config
  },
  webpackDevMiddleware: (config) => {
    // Perform customizations to webpack dev middleware config
    // Important: return the modified config
    return config
  },
})
```

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
