### PR TITLE
Add Blitz Recipe for Tailwind CSS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
   ignorePatterns: ["packages/cli/", "packages/generator/templates"],
   overrides: [
     {
-      files: ["examples/**", "packages/gui/**"],
+      files: ["examples/**", "packages/gui/**", "recipes/**"],
       rules: {
         "import/no-default-export": "off",
         "unicorn/filename-case": "off",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "workspaces": {
     "packages": [
       "packages/*",
-      "examples/*"
+      "examples/*",
+      "recipes/*"
     ],
     "nohoist": [
       "**/@prisma",

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -123,7 +123,7 @@ export class Install extends Command {
     process.chdir(recipeDir)
 
     const repoName = repoFullName.split("/")[1]
-    // `tar` top-level filder is `${repoName}-${defaultBranch}`, and then we want to get our recipe path
+    // `tar` top-level filter is `${repoName}-${defaultBranch}`, and then we want to get our recipe path
     // within that folder
     const extractPath = subdirectory ? [`${repoName}-${defaultBranch}/${subdirectory}`] : undefined
     const depth = subdirectory ? subdirectory.split("/").length + 1 : 1

--- a/packages/installer/src/recipe-builder.ts
+++ b/packages/installer/src/recipe-builder.ts
@@ -3,7 +3,18 @@ import * as AddDependencyExecutor from "./executors/add-dependency-executor"
 import * as NewFileExecutor from "./executors/new-file-executor"
 import * as TransformFileExecutor from "./executors/file-transform-executor"
 
-export function RecipeBuilder() {
+export interface RecipeBuilder {
+  setName(name: string): RecipeBuilder
+  setDescription(description: string): RecipeBuilder
+  setOwner(owner: string): RecipeBuilder
+  setRepoLink(repoLink: string): RecipeBuilder
+  addAddDependenciesStep(step: Omit<AddDependencyExecutor.Config, "stepType">): RecipeBuilder
+  addNewFilesStep(step: Omit<NewFileExecutor.Config, "stepType">): RecipeBuilder
+  addTransformFilesStep(step: Omit<TransformFileExecutor.Config, "stepType">): RecipeBuilder
+  build(): RecipeExecutor<any>
+}
+
+export function RecipeBuilder(): RecipeBuilder {
   const steps: ExecutorConfigUnion[] = []
   const meta: Partial<RecipeMeta> = {}
 

--- a/recipes/tailwind/index.ts
+++ b/recipes/tailwind/index.ts
@@ -1,0 +1,55 @@
+import {RecipeBuilder, paths, addImport} from "@blitzjs/installer"
+import {join} from "path"
+import {builders} from "ast-types/gen/builders"
+import {ASTNode} from "ast-types/lib/types"
+import {NamedTypes} from "ast-types/gen/namedTypes"
+
+export default RecipeBuilder()
+  .setName("Tailwind CSS")
+  .setDescription(
+    `Configure your Blitz app's styling with Tailwind CSS. This recipe will install all necessary dependencies and configure Tailwind for immediate use.`,
+  )
+  .setOwner("adam@markon.codes")
+  .setRepoLink("https://github.com/blitz-js/blitz")
+  .addAddDependenciesStep({
+    stepId: "addDeps",
+    stepName: "Add npm dependencies",
+    explanation: `Tailwind CSS rqeuires a couple of dependencies to get up and running.
+We'll install the Tailwind library itself, as well as PostCSS for removing unused styles from our production bundles.`,
+    packages: [
+      {name: "tailwindcss", version: "1"},
+      {name: "postcss-preset-env", version: "latest", isDevDep: true},
+    ],
+  })
+  .addNewFilesStep({
+    stepId: "addConfig",
+    stepName: "Add Tailwind CSS and PostCSS config files",
+    explanation: `In order to set up Tailwind CSS properly, we need to include a few configuration files. We'll configure Tailwind CSS to know where your app's pages live, and PostCSS for elimination of unused styles.
+
+These config files can be extended for additional customization, but for now we'll just give the minimum required to get started.`,
+    targetDirectory: ".",
+    templatePath: join(__dirname, "templates", "config"),
+    templateValues: {},
+  })
+  .addNewFilesStep({
+    stepId: "addStyles",
+    stepName: "Add base Tailwind CSS styles",
+    explanation: `Next, we need to actually create some stylesheets! These stylesheets can either be modified to include global styles for your app, or you can stick to just using classnames in your components.`,
+    targetDirectory: "./app",
+    templatePath: join(__dirname, "templates", "styles"),
+    templateValues: {},
+  })
+  .addTransformFilesStep({
+    stepId: "importStyles",
+    stepName: "Import stylesheets",
+    explanation: `Finaly, we can import the stylesheets we just created into our application. For now we'll put them in document.tsx, but if you'd like to only style a part of your app with tailwind you could import the styles lower down in your component tree.`,
+    singleFileSearch: paths.app(),
+    transform(ast: ASTNode, b: builders, t: NamedTypes) {
+      const stylesImport = b.importDeclaration([], b.literal("app/styles/index.css"))
+      if (t.File.check(ast)) {
+        return addImport(ast, b, t, stylesImport)!
+      }
+      throw new Error("Not given valid source file")
+    },
+  })
+  .build()

--- a/recipes/tailwind/package.json
+++ b/recipes/tailwind/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@blitzjs/recipe-tailwind",
+  "version": "0.16.5-canary.2",
+  "description": "The Blitz Recipe for installing Tailwind CSS",
+  "main": "index.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/blitz-js/blitz.git"
+  },
+  "keywords": [
+    "blitz",
+    "blitzjs"
+  ],
+  "author": "aem <adam@markon.codes>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/blitz-js/blitz/issues"
+  },
+  "homepage": "https://github.com/blitz-js/blitz#readme",
+  "dependencies": {
+    "@blitzjs/installer": "0.16.5-canary.2"
+  }
+}

--- a/recipes/tailwind/package.json
+++ b/recipes/tailwind/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blitzjs/recipe-tailwind",
-  "version": "0.16.5-canary.2",
+  "private": true,
+  "version": "0.0.1",
   "description": "The Blitz Recipe for installing Tailwind CSS",
   "main": "index.ts",
   "scripts": {
@@ -8,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/blitz-js/blitz.git"
+    "url": "https://github.com/blitz-js/blitz.git"
   },
   "keywords": [
     "blitz",
@@ -21,6 +22,6 @@
   },
   "homepage": "https://github.com/blitz-js/blitz#readme",
   "dependencies": {
-    "@blitzjs/installer": "0.16.5-canary.2"
+    "@blitzjs/installer": "0.16.5-canary.3"
   }
 }

--- a/recipes/tailwind/templates/config/postcss.config.js
+++ b/recipes/tailwind/templates/config/postcss.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["tailwindcss", "postcss-preset-env"],
+}

--- a/recipes/tailwind/templates/config/tailwind.config.js
+++ b/recipes/tailwind/templates/config/tailwind.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  purge: ["./app/*/pages/**/*.{js,jsx,ts,tsx}"],
+  theme: {},
+  variants: {},
+  plugins: [],
+}

--- a/recipes/tailwind/templates/styles/styles/button.css
+++ b/recipes/tailwind/templates/styles/styles/button.css
@@ -1,0 +1,3 @@
+.btn-blue {
+  @apply bg-blue-500 text-white font-bold py-2 px-4 rounded;
+}

--- a/recipes/tailwind/templates/styles/styles/index.css
+++ b/recipes/tailwind/templates/styles/styles/index.css
@@ -1,0 +1,23 @@
+@import "./button.css";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+.hero {
+  width: 100%;
+  color: #333;
+}
+
+.title {
+  margin: 0;
+  width: 100%;
+  padding-top: 80px;
+  line-height: 1.15;
+  font-size: 48px;
+}
+
+.title,
+.description {
+  text-align: center;
+}

--- a/recipes/tsconfig.json
+++ b/recipes/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["*/**/*.ts"]
+}


### PR DESCRIPTION
## What are the changes and their implications?

Introduces the first Blitz recipe! Continuing with the canonical example that we've been using for the duration of the recipes discussion, our first recipe will be for Tailwind CSS. This recipe will install the appropriate tailwind dependencies, add the base stylesheets, and import them into the target application. The only piece that's missing for this to be 100% prod-ready is that we're missing full dependency resolution (cc @merelinguist I know you've been poking at that). 

Once this is merged, it'll be accessible via `blitz install tailwind` (the recipe name for the CLI is based on the directory name under `/recipes`).

Working on writing up docs now! 