### PR TITLE
Switch to url safe CSRF tokens

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -33,6 +33,7 @@
     "b64-lite": "1.4.0",
     "cookie": "0.4.1",
     "cross-spawn": "7.0.2",
+    "nanoid": "3.1.10",
     "date-fns": "2.14.0",
     "detect-port": "1.3.0",
     "fast-glob": "3.2.2",

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -1,6 +1,6 @@
-import crypto from "crypto"
 import hasha, {HashaInput} from "hasha"
 import cookie from "cookie"
+import {nanoid} from "nanoid"
 import {sign as jwtSign, verify as jwtVerify} from "jsonwebtoken"
 import {
   BlitzApiRequest,
@@ -568,7 +568,7 @@ export async function setPublicData(
 // --------------------------------
 const hash = (input: HashaInput = "") => hasha(input, {algorithm: "sha256"})
 
-export const generateToken = () => crypto.randomBytes(32).toString("base64")
+export const generateToken = () => nanoid(32)
 
 export const generateEssentialSessionHandle = () => {
   return generateToken() + HANDLE_SEPARATOR + SESSION_TYPE_OPAQUE_TOKEN_SIMPLE

--- a/yarn.lock
+++ b/yarn.lock
@@ -11791,6 +11791,11 @@ nanoassert@^1.0.0:
   resolved "https://registry.yarnpkg.com/nanoassert/-/nanoassert-1.1.0.tgz#4f3152e09540fde28c76f44b19bbcd1d5a42478d"
   integrity sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40=
 
+nanoid@3.1.10:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.10.tgz#69a8a52b77892de0d11cede96bc9762852145bc4"
+  integrity sha512-iZFMXKeXWkxzlfmMfM91gw7YhN2sdJtixY+eZh9V6QWJWTOiurhpKhBMgr82pfzgSqglQgqYSCowEYsz8D++6w==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
### What are the changes and their implications?

Non-url safe csrf tokens where causing some problems. This switches to use nanoid for safe token generation.

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
