### PR TITLE
Change auth example to use a shared <Form> component that abstracts the actual form library

### DIFF
--- a/examples/auth/app/auth/components/LoginForm.tsx
+++ b/examples/auth/app/auth/components/LoginForm.tsx
@@ -1,8 +1,8 @@
 import React from "react"
 import {LabeledTextField} from "app/components/LabeledTextField"
-import {Form} from "react-final-form"
-import {FORM_ERROR} from "final-form"
+import {Form, FORM_ERROR} from "app/components/Form"
 import login from "app/auth/mutations/login"
+import {LoginInput, LoginInputType} from "app/auth/validations"
 
 type LoginFormProps = {
   onSuccess?: () => void
@@ -13,14 +13,9 @@ export const LoginForm = (props: LoginFormProps) => {
     <div>
       <h1>Login</h1>
 
-      <Form
+      <Form<LoginInputType>
+        schema={LoginInput}
         initialValues={{email: undefined, password: undefined}}
-        validate={(values) => {
-          const errors: {email?: string; password?: string} = {}
-          if (!values.email) errors.email = "Required"
-          if (!values.password) errors.password = "Required"
-          return errors
-        }}
         onSubmit={async (values) => {
           try {
             await login({email: values.email, password: values.password})
@@ -36,34 +31,11 @@ export const LoginForm = (props: LoginFormProps) => {
             }
           }
         }}
-        render={({handleSubmit, submitting, submitError}) => (
-          <form onSubmit={handleSubmit} className="login-form">
-            <LabeledTextField name="email" label="Email" placeholder="Email" />
-            <LabeledTextField
-              name="password"
-              label="Password"
-              placeholder="Password"
-              type="password"
-            />
-
-            {submitError && (
-              <div role="alert" style={{color: "red"}}>
-                {submitError}
-              </div>
-            )}
-
-            <button type="submit" disabled={submitting}>
-              Log In
-            </button>
-
-            <style global jsx>{`
-              .login-form > * + * {
-                margin-top: 1rem;
-              }
-            `}</style>
-          </form>
-        )}
-      />
+        submitText="Log In"
+      >
+        <LabeledTextField name="email" label="Email" placeholder="Email" />
+        <LabeledTextField name="password" label="Password" placeholder="Password" type="password" />
+      </Form>
     </div>
   )
 }

--- a/examples/auth/app/auth/components/LoginForm.tsx
+++ b/examples/auth/app/auth/components/LoginForm.tsx
@@ -14,6 +14,7 @@ export const LoginForm = (props: LoginFormProps) => {
       <h1>Login</h1>
 
       <Form<LoginInputType>
+        submitText="Log In"
         schema={LoginInput}
         initialValues={{email: undefined, password: undefined}}
         onSubmit={async (values) => {
@@ -31,7 +32,6 @@ export const LoginForm = (props: LoginFormProps) => {
             }
           }
         }}
-        submitText="Log In"
       >
         <LabeledTextField name="email" label="Email" placeholder="Email" />
         <LabeledTextField name="password" label="Password" placeholder="Password" type="password" />

--- a/examples/auth/app/auth/mutations/login.ts
+++ b/examples/auth/app/auth/mutations/login.ts
@@ -1,16 +1,8 @@
 import {SessionContext} from "blitz"
 import {authenticateUser} from "app/auth"
-import * as z from "zod"
+import {LoginInput, LoginInputType} from "../validations"
 
-export const LoginInput = z.object({
-  email: z.string(),
-  password: z.string(),
-})
-
-export default async function login(
-  input: z.infer<typeof LoginInput>,
-  ctx: {session?: SessionContext} = {},
-) {
+export default async function login(input: LoginInputType, ctx: {session?: SessionContext} = {}) {
   // This throws an error if input is invalid
   const {email, password} = LoginInput.parse(input)
 

--- a/examples/auth/app/auth/mutations/signup.ts
+++ b/examples/auth/app/auth/mutations/signup.ts
@@ -8,7 +8,10 @@ export default async function signup(input: SignupInputType, ctx: {session?: Ses
   const {email, password} = SignupInput.parse(input)
 
   const hashedPassword = await hashPassword(password)
-  const user = await db.user.create({data: {email, hashedPassword, role: "user"}})
+  const user = await db.user.create({
+    data: {email, hashedPassword, role: "user"},
+    select: {id: true, name: true, email: true, role: true},
+  })
 
   await ctx.session!.create({userId: user.id, roles: [user.role]})
 

--- a/examples/auth/app/auth/mutations/signup.ts
+++ b/examples/auth/app/auth/mutations/signup.ts
@@ -1,13 +1,9 @@
 import db from "db"
 import {SessionContext} from "blitz"
 import {hashPassword} from "app/auth"
-import * as z from "zod"
-import {SignupInput} from "app/auth/validations"
+import {SignupInput, SignupInputType} from "app/auth/validations"
 
-export default async function signup(
-  input: z.infer<typeof SignupInput>,
-  ctx: {session?: SessionContext} = {},
-) {
+export default async function signup(input: SignupInputType, ctx: {session?: SessionContext} = {}) {
   // This throws an error if input is invalid
   const {email, password} = SignupInput.parse(input)
 

--- a/examples/auth/app/auth/pages/login.tsx
+++ b/examples/auth/app/auth/pages/login.tsx
@@ -13,7 +13,7 @@ const SignupPage: BlitzPage = () => {
       </Head>
 
       <div>
-        <LoginForm onSuccess={() => router.push("/ssr")} />
+        <LoginForm onSuccess={() => router.push("/")} />
       </div>
     </>
   )

--- a/examples/auth/app/auth/pages/signup.tsx
+++ b/examples/auth/app/auth/pages/signup.tsx
@@ -1,10 +1,9 @@
 import React from "react"
 import {Head, useRouter, BlitzPage} from "blitz"
+import {Form, FORM_ERROR} from "app/components/Form"
 import {LabeledTextField} from "app/components/LabeledTextField"
-import {Form} from "react-final-form"
-import {FORM_ERROR} from "final-form"
 import signup from "app/auth/mutations/signup"
-import {SignupInput} from "app/auth/validations"
+import {SignupInput, SignupInputType} from "app/auth/validations"
 
 const SignupPage: BlitzPage = () => {
   const router = useRouter()
@@ -19,14 +18,9 @@ const SignupPage: BlitzPage = () => {
       <div>
         <h1>Create an Account</h1>
 
-        <Form
-          validate={(values) => {
-            try {
-              SignupInput.parse(values)
-            } catch (error) {
-              return error.formErrors.fieldErrors
-            }
-          }}
+        <Form<SignupInputType>
+          submitText="Create Account"
+          schema={SignupInput}
           onSubmit={async (values) => {
             try {
               await signup({email: values.email, password: values.password})
@@ -40,34 +34,15 @@ const SignupPage: BlitzPage = () => {
               }
             }
           }}
-          render={({handleSubmit, submitting, submitError}) => (
-            <form onSubmit={handleSubmit} className="signup-form">
-              <LabeledTextField name="email" label="Email" placeholder="Email" />
-              <LabeledTextField
-                name="password"
-                label="Password"
-                placeholder="Password"
-                type="password"
-              />
-
-              {submitError && (
-                <div role="alert" style={{color: "red"}}>
-                  {submitError}
-                </div>
-              )}
-
-              <button type="submit" disabled={submitting}>
-                Create Account
-              </button>
-
-              <style global jsx>{`
-                .signup-form > * + * {
-                  margin-top: 1rem;
-                }
-              `}</style>
-            </form>
-          )}
-        />
+        >
+          <LabeledTextField name="email" label="Email" placeholder="Email" />
+          <LabeledTextField
+            name="password"
+            label="Password"
+            placeholder="Password"
+            type="password"
+          />
+        </Form>
       </div>
     </>
   )

--- a/examples/auth/app/auth/validations.ts
+++ b/examples/auth/app/auth/validations.ts
@@ -4,3 +4,10 @@ export const SignupInput = z.object({
   email: z.string().email(),
   password: z.string().min(10).max(100),
 })
+export type SignupInputType = z.infer<typeof SignupInput>
+
+export const LoginInput = z.object({
+  email: z.string().email(),
+  password: z.string(),
+})
+export type LoginInputType = z.infer<typeof LoginInput>

--- a/examples/auth/app/components/Form.tsx
+++ b/examples/auth/app/components/Form.tsx
@@ -1,0 +1,61 @@
+import React, {ReactNode, PropsWithoutRef} from "react"
+import {Form as FinalForm, FormProps as FinalFormProps} from "react-final-form"
+import * as z from "zod"
+export {FORM_ERROR} from "final-form"
+
+type FormProps<FormValues> = {
+  /** All your form fields */
+  children: ReactNode
+  /** Text to display in the submit button */
+  submitText: string
+  onSubmit: FinalFormProps<FormValues>["onSubmit"]
+  initialValues?: FinalFormProps<FormValues>["initialValues"]
+  schema?: z.ZodType<any, any>
+} & Omit<PropsWithoutRef<JSX.IntrinsicElements["form"]>, "onSubmit">
+
+export function Form<FormValues extends Record<string, unknown>>({
+  children,
+  submitText,
+  schema,
+  onSubmit,
+  ...props
+}: FormProps<FormValues>) {
+  return (
+    <FinalForm<FormValues>
+      validate={(values) => {
+        if (!schema) return
+        try {
+          schema.parse(values)
+        } catch (error) {
+          return error.formErrors.fieldErrors
+        }
+      }}
+      onSubmit={onSubmit}
+      render={({handleSubmit, submitting, submitError}) => (
+        <form onSubmit={handleSubmit} className="form" {...props}>
+          {/* Form fields supplied as children are rendered here */}
+          {children}
+
+          {submitError && (
+            <div role="alert" style={{color: "red"}}>
+              {submitError}
+            </div>
+          )}
+
+          <button type="submit" disabled={submitting}>
+            {submitText}
+          </button>
+
+          <style global jsx>{`
+            .form > * + * {
+              margin-top: 1rem;
+            }
+          `}</style>
+        </form>
+      )}
+      {...props}
+    />
+  )
+}
+
+export default Form

--- a/examples/auth/app/components/Form.tsx
+++ b/examples/auth/app/components/Form.tsx
@@ -17,11 +17,13 @@ export function Form<FormValues extends Record<string, unknown>>({
   children,
   submitText,
   schema,
+  initialValues,
   onSubmit,
   ...props
 }: FormProps<FormValues>) {
   return (
     <FinalForm<FormValues>
+      initialValues={initialValues}
       validate={(values) => {
         if (!schema) return
         try {
@@ -53,7 +55,6 @@ export function Form<FormValues extends Record<string, unknown>>({
           `}</style>
         </form>
       )}
-      {...props}
     />
   )
 }

--- a/examples/auth/app/components/LabeledTextField.tsx
+++ b/examples/auth/app/components/LabeledTextField.tsx
@@ -36,6 +36,15 @@ export const LabeledTextField = React.forwardRef<HTMLInputElement, LabeledTextFi
             display: flex;
             flex-direction: column;
             align-items: start;
+            font-size: 1rem;
+          }
+          input {
+            font-size: 1rem;
+            padding: 0.25rem 0.5rem;
+            border-radius: 3px;
+            border: 1px solid purple;
+            appearance: none;
+            margin-top: 0.5rem;
           }
         `}</style>
       </div>

--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -37,7 +37,7 @@
     "react-dom": "0.0.0-experimental-33c3af284",
     "react-final-form": "6.5.1",
     "secure-password": "4.0.0",
-    "zod": "1.10.0-alpha.2"
+    "zod": "1.10.0"
   },
   "devDependencies": {
     "@types/react": "16.9.38",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17783,7 +17783,7 @@ yoga-layout-prebuilt@^1.9.3:
   dependencies:
     "@types/yoga-layout" "1.9.2"
 
-zod@1.10.0-alpha.2:
-  version "1.10.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-1.10.0-alpha.2.tgz#4f1f6b5219e2cf337c3536b58e4c3e15786d52aa"
-  integrity sha512-82h3X4ml17UPcYyKmyOguySiL5uXhcJP1s5xB668xS9AKFD9K0XqJS9AOgcM0dZ4nhLEpGF2sNW6plpz9YWlcQ==
+zod@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-1.10.0.tgz#175286f09d480ac604014245d7215f67959b0d7a"
+  integrity sha512-u06UhgHEUzLN26qDI7Ei9sqWdiQjQnrjEJtAXmAHF3fH35sOkPmdAl4FNZOgsigv2Jki6yrx5wivQyYXB4B+aA==


### PR DESCRIPTION
### What are the changes and their implications?

Change auth example to use a shared <Form> component that abstracts the actual form library