### PR TITLE
Fix `blitz db migrate` stuck on first production deploy

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -42,9 +42,11 @@ export const runPrismaGeneration = async ({silent = false} = {}) => {
 }
 
 const runMigrateUp = (prismaBin: string, resolve: (value?: unknown) => void) => {
-  const cp = spawn(prismaBin, ["migrate", "up", schemaArg, "--create-db", "--experimental"], {
-    stdio: "inherit",
-  })
+  const args = ["migrate", "up", schemaArg, "--create-db", "--experimental"]
+  if (process.env.NODE_ENV === "production") {
+    args.push("--auto-approve")
+  }
+  const cp = spawn(prismaBin, args, {stdio: "inherit"})
   cp.on("exit", async (code) => {
     if (code === 0) {
       await runPrismaGeneration()

--- a/packages/cli/test/commands/db.test.ts
+++ b/packages/cli/test/commands/db.test.ts
@@ -16,7 +16,8 @@ import {Db} from "../../src/commands/db"
 let schemaArg: string
 let prismaBin: string
 let migrateSaveParams: any[]
-let migrateUpParams: any[]
+let migrateUpDevParams: any[]
+let migrateUpProdParams: any[]
 beforeAll(async () => {
   schemaArg = `--schema=${path.join(process.cwd(), "db", "schema.prisma")}`
   prismaBin = await resolveBinAsync("@prisma/cli", "prisma")
@@ -26,14 +27,16 @@ beforeAll(async () => {
     ["migrate", "save", schemaArg, "--create-db", "--experimental"],
     {stdio: "inherit"},
   ]
-  migrateUpParams = [
+  migrateUpDevParams = [
     prismaBin,
     ["migrate", "up", schemaArg, "--create-db", "--experimental"],
     {stdio: "inherit"},
   ]
-  if (process.env.NODE_ENV === "production") {
-    migrateUpParams[1].push("--auto-approve")
-  }
+  migrateUpProdParams = [
+    prismaBin,
+    ["migrate", "up", schemaArg, "--create-db", "--experimental", "--auto-approve"],
+    {stdio: "inherit"},
+  ]
 })
 
 describe("Db command", () => {
@@ -52,7 +55,7 @@ describe("Db command", () => {
     // following expection is not working
     //expect(onSpy).toHaveBeenCalledWith(0);
 
-    expect(spawn).toBeCalledWith(...migrateUpParams)
+    expect(spawn).toBeCalledWith(...migrateUpDevParams)
   }
 
   function expectProductionDbMigrateOutcome() {
@@ -61,7 +64,7 @@ describe("Db command", () => {
     // following expection is not working
     //expect(onSpy).toHaveBeenCalledWith(0);
 
-    expect(spawn).toBeCalledWith(...migrateUpParams)
+    expect(spawn).toBeCalledWith(...migrateUpProdParams)
   }
 
   it("runs db help when no command given", async () => {

--- a/packages/cli/test/commands/db.test.ts
+++ b/packages/cli/test/commands/db.test.ts
@@ -31,6 +31,9 @@ beforeAll(async () => {
     ["migrate", "up", schemaArg, "--create-db", "--experimental"],
     {stdio: "inherit"},
   ]
+  if (process.env.NODE_ENV === "production") {
+    migrateUpParams[1].push("--auto-approve")
+  }
 })
 
 describe("Db command", () => {


### PR DESCRIPTION
### What are the changes and their implications?

This adds the `--auto-approve` flag when running prisma migrate in production.

### Checklist

- [x] Tests added for changes
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
