### PR TITLE
Fix cannot read property 'getSession' of undefined

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,8 @@
     "clean": "rimraf dist",
     "wait:file-pipeline": "wait-on ../file-pipeline/dist/packages/file-pipeline/src/index.d.ts",
     "wait:core": "wait-on ../core/dist/packages/core/src/index.d.ts",
-    "predev": "yarn wait:core && yarn wait:file-pipeline",
+    "wait:config": "wait-on ../config/dist/packages/config/src/index.d.ts",
+    "predev": "yarn wait:config && yarn wait:file-pipeline && yarn wait:core",
     "dev": "tsdx watch --verbose",
     "build": "tsdx build",
     "test": "tsdx test"
@@ -30,6 +31,7 @@
   "dependencies": {
     "@blitzjs/display": "0.16.5-canary.5",
     "@blitzjs/file-pipeline": "0.16.5-canary.5",
+    "@blitzjs/config": "0.16.5-canary.5",
     "b64-lite": "1.4.0",
     "cookie": "0.4.1",
     "cross-spawn": "7.0.2",

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -27,6 +27,7 @@ import {
   HEADER_CSRF_ERROR,
   MiddlewareResponse,
 } from "@blitzjs/core"
+import {getConfig} from "@blitzjs/config"
 import pkgDir from "pkg-dir"
 import {join} from "path"
 import {addMinutes, isPast, differenceInMinutes} from "date-fns"
@@ -37,6 +38,12 @@ import {IncomingMessage, ServerResponse} from "http"
 function assert(condition: any, message: string): asserts condition {
   if (!condition) throw new Error(message)
 }
+
+// ----------------------------------------------------------------------------------------
+// IMPORTANT: blitz.config.js must be loaded for session managment config to be initialized
+// This line ensures that blitz.config.js is loaded
+// ----------------------------------------------------------------------------------------
+getConfig()
 
 const getDb = () => {
   const projectRoot = pkgDir.sync() || process.cwd()


### PR DESCRIPTION


### What are the changes and their implications?

Fix this error you get if you use `getSessionContext` in `getServerSideProps`

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
