### PR TITLE
Add Node version check and warning to CLI startup routine

### DIFF
--- a/packages/blitz/src/bin/cli.ts
+++ b/packages/blitz/src/bin/cli.ts
@@ -2,6 +2,7 @@ import * as path from "path"
 import resolveFrom from "resolve-from"
 import pkgDir from "pkg-dir"
 import chalk from "chalk"
+import { parseSemver } from '../utils/parse-semver'
 
 console.log(
   chalk.yellow(
@@ -9,6 +10,14 @@ console.log(
   https://github.com/blitz-js/blitz/issues/new/choose\n`,
   ),
 )
+
+if (parseSemver(process.version).major < 12) {
+  console.log(
+    chalk.yellow(
+      `You are using an unsupported version of Node.js. Consider switching to v12 or newer.\n`,
+    ),
+  )
+}
 
 const globalBlitzPath = resolveFrom(__dirname, "blitz")
 const localBlitzPath = resolveFrom.silent(process.cwd(), "blitz")

--- a/packages/blitz/src/utils/parse-semver.test.ts
+++ b/packages/blitz/src/utils/parse-semver.test.ts
@@ -1,0 +1,29 @@
+import {parseSemver} from "./parse-semver"
+
+describe("parseSemver", () => {
+  describe("when given a non-semver-string", () => {
+    it("throws", () => {
+      expect(() => parseSemver("non-semver")).toThrow()
+    })
+  })
+
+  describe("when given a valid semver string", () => {
+    it("returns major, minor and patch", () => {
+      expect(parseSemver("12.8.4")).toEqual({
+        major: 12,
+        minor: 8,
+        patch: 4,
+      })
+    })
+  })
+
+  describe("when given a valid semver string preceded by a `v`", () => {
+    it("returns major, minor and patch", () => {
+      expect(parseSemver("v12.8.4")).toEqual({
+        major: 12,
+        minor: 8,
+        patch: 4,
+      })
+    })
+  })
+})

--- a/packages/blitz/src/utils/parse-semver.ts
+++ b/packages/blitz/src/utils/parse-semver.ts
@@ -1,0 +1,9 @@
+export function parseSemver(semver: string) {
+  if (semver.startsWith("v")) {
+    semver = semver.substring(1)
+  }
+
+  const [major, minor, patch] = semver.split(".").map(Number)
+
+  return {major, minor, patch}
+}


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/800#issuecomment-663810776

### What are the changes and their implications?

Check Node version at startup and warn if it's older than v12.

### Checklist

- [x] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
