### PR TITLE
Rename `<Error>` to `<ErrorComponent>`

### DIFF
--- a/examples/auth/app/components/ErrorBoundary.tsx
+++ b/examples/auth/app/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import {Error as ErrorComponent} from "blitz"
+import {ErrorComponent} from "blitz"
 import {queryCache} from "react-query"
 import LoginForm from "app/auth/components/LoginForm"
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,4 +46,4 @@ export {
 
 export {default as dynamic} from "next/dynamic"
 
-export {default as Error} from "next/error"
+export {default as ErrorComponent} from "next/error"


### PR DESCRIPTION
### What are the changes and their implications?

BREAKING CHANGE

Me naming the built-in ErrorComponent from Next.js as `Error` was really dumb. If you import it, then you can't do `throw new Error()`.

### Checklist

- ~[ ] Tests added for changes~
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
