### PR TITLE
Fix bug when users use `next-compose-plugins` and with framework code being transpiled in dev

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -48,8 +48,6 @@
     "merge-stream": "2.0.0",
     "nanoid": "3.1.10",
     "next": "9.5.1",
-    "next-compose-plugins": "2.2.0",
-    "next-transpile-modules": "3.2.0",
     "null-loader": "4.0.0",
     "ora": "4.0.4",
     "parallel-transform": "1.2.0",
@@ -67,7 +65,8 @@
     "vinyl-fs": "3.0.3"
   },
   "devDependencies": {
-    "@blitzjs/core": "0.16.5-canary.7"
+    "@blitzjs/core": "0.16.5-canary.7",
+    "next-transpile-modules": "3.2.0"
   },
   "gitHead": "d3b9fce0bdd251c2b1890793b0aa1cd77c1c0922"
 }

--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -1,58 +1,59 @@
-const withPlugins = require("next-compose-plugins")
-const withTM = require("next-transpile-modules")(["@blitzjs/core"])
+// We add next-transpile-modules during internal blitz development so that changes in blitz
+// framework code will trigger a hot reload of any example apps that are running
+const isInternalBlitzDevelopment = __dirname.includes("packages/server/src")
+const withTM = require("next-transpile-modules")(["@blitzjs/core", "@blitzjs/server"])
 
 export function withBlitz(nextConfig: any) {
   return (phase: string, nextOpts: any = {}) => {
-    // Need to grab the normalized config based on the phase we are in incase we are given a functional config to extend
+    // Need to grab the normalized config based on the phase
+    // we are in incase we are given a functional config to extend
     const normalizedConfig =
       typeof nextConfig === "function" ? nextConfig(phase, nextOpts) : nextConfig
 
-    const plugins = []
-    if (process.env.NODE_ENV === "development") {
-      // This is needed during monorepo development so that examples auto reload when packages change
-      plugins.push(withTM)
+    const newConfig = Object.assign({}, normalizedConfig, {
+      experimental: {
+        reactMode: "concurrent",
+        ...(normalizedConfig.experimental || {}),
+      },
+      webpack(config: any, options: Record<any, any>) {
+        if (options.isServer) {
+          const originalEntry = config.entry
+          config.entry = async () => ({
+            ...(await originalEntry()),
+            "../__db.js": "./db/index",
+          })
+        } else {
+          config.module = config.module || {}
+          config.module.rules = config.module.rules || []
+          config.module.rules.push({test: /_resolvers/, use: {loader: "null-loader"}})
+          config.module.rules.push({test: /@blitzjs[\\/]display/, use: {loader: "null-loader"}})
+          config.module.rules.push({test: /@blitzjs[\\/]config/, use: {loader: "null-loader"}})
+          config.module.rules.push({test: /@prisma[\\/]client/, use: {loader: "null-loader"}})
+          config.module.rules.push({test: /passport/, use: {loader: "null-loader"}})
+          config.module.rules.push({test: /cookie-session/, use: {loader: "null-loader"}})
+          config.module.rules.push({
+            test: /blitz[\\/]packages[\\/]config/,
+            use: {loader: "null-loader"},
+          })
+          config.module.rules.push({
+            test: /blitz[\\/]packages[\\/]display/,
+            use: {loader: "null-loader"},
+          })
+        }
+
+        if (typeof normalizedConfig.webpack === "function") {
+          return normalizedConfig.webpack(config, options)
+        }
+
+        return config
+      },
+    })
+
+    // if inside monorepo
+    if (isInternalBlitzDevelopment) {
+      return withTM(newConfig)
+    } else {
+      return newConfig
     }
-
-    return withPlugins(
-      plugins,
-      Object.assign({}, normalizedConfig, {
-        experimental: {
-          reactMode: "concurrent",
-          ...(normalizedConfig.experimental || {}),
-        },
-        webpack(config: any, options: Record<any, any>) {
-          if (options.isServer) {
-            const originalEntry = config.entry
-            config.entry = async () => ({
-              ...(await originalEntry()),
-              "../__db.js": "./db/index",
-            })
-          } else {
-            config.module = config.module || {}
-            config.module.rules = config.module.rules || []
-            config.module.rules.push({test: /_resolvers/, use: {loader: "null-loader"}})
-            config.module.rules.push({test: /@blitzjs[\\/]display/, use: {loader: "null-loader"}})
-            config.module.rules.push({test: /@blitzjs[\\/]config/, use: {loader: "null-loader"}})
-            config.module.rules.push({test: /@prisma[\\/]client/, use: {loader: "null-loader"}})
-            config.module.rules.push({test: /passport/, use: {loader: "null-loader"}})
-            config.module.rules.push({test: /cookie-session/, use: {loader: "null-loader"}})
-            config.module.rules.push({
-              test: /blitz[\\/]packages[\\/]config/,
-              use: {loader: "null-loader"},
-            })
-            config.module.rules.push({
-              test: /blitz[\\/]packages[\\/]display/,
-              use: {loader: "null-loader"},
-            })
-          }
-
-          if (typeof normalizedConfig.webpack === "function") {
-            return normalizedConfig.webpack(config, options)
-          }
-
-          return config
-        },
-      }),
-    )(phase, nextOpts)
   }
 }

--- a/packages/server/test/with-blitz.test.ts
+++ b/packages/server/test/with-blitz.test.ts
@@ -6,7 +6,10 @@ describe("withBlitz", () => {
       foo: "bar",
     })
     const newNext = nextConfigFn("", {defaultConfig: {}})
-    const newNextWithoutWebpack = Object.assign({}, newNext, {webpack: null})
+    const newNextWithoutWebpack = Object.assign({}, newNext, {
+      webpack: null,
+      webpackDevMiddleware: null,
+    })
 
     expect(newNextWithoutWebpack).toStrictEqual({
       foo: "bar",
@@ -14,13 +17,17 @@ describe("withBlitz", () => {
         reactMode: "concurrent",
       },
       webpack: null,
+      webpackDevMiddleware: null,
     })
   })
 
   it("can handle functional next configs", () => {
     const nextConfigFn = withBlitz((phase: any) => ({phase, foo: "bar"}))
     const newNext = nextConfigFn("foo", {defaultConfig: {}})
-    const newNextWithoutWebpack = Object.assign({}, newNext, {webpack: null})
+    const newNextWithoutWebpack = Object.assign({}, newNext, {
+      webpack: null,
+      webpackDevMiddleware: null,
+    })
 
     expect(newNextWithoutWebpack).toStrictEqual({
       phase: "foo",
@@ -29,6 +36,7 @@ describe("withBlitz", () => {
         reactMode: "concurrent",
       },
       webpack: null,
+      webpackDevMiddleware: null,
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -12134,11 +12134,6 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
-next-compose-plugins@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/next-compose-plugins/-/next-compose-plugins-2.2.0.tgz#95cd8eb40ab0652070d76572fb648354191628b0"
-  integrity sha512-ChUlpT9tWfJ7YxqGw/WQ2T1gf8EeX93n1XqeQw0lkvGa7seszahvF4eOZUJoq7Hetsbzg4UHVnPoCXfXTyQR3g==
-
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"


### PR DESCRIPTION
Closes: #749 

### What are the changes and their implications?

Fixes the following two issues!

- [x] Fix bug when users try to use next-compose-plugins in their app. Because we were adding it to webpack config internally, so then it would be added twice and break.
- [x] Fix bug where blitz framework code would be transpiled during development of blitz apps. This likely was slowing down boot and compile times for everyone in dev.

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
