### PR TITLE
Remove check for Vercel

### DIFF
--- a/packages/server/src/stages/config/index.ts
+++ b/packages/server/src/stages/config/index.ts
@@ -6,7 +6,6 @@ import {transform} from "@blitzjs/file-pipeline"
 import {Stage} from "@blitzjs/file-pipeline"
 
 const isNextConfigPath = (p: string) => /next\.config\.(js|ts)/.test(p)
-const isNowBuild = () => process.env.NOW_BUILDER || process.env.VERCEL_BUILDER
 /**
  * Returns a Stage that manages converting from blitz.config.js to next.config.js
  */
@@ -15,7 +14,7 @@ export const createStageConfig: Stage = ({config, input}) => {
   const hasNextConfig = pathExistsSync(resolve(config.src, "next.config.js"))
   const hasBlitzConfig = pathExistsSync(resolve(config.src, "blitz.config.js"))
 
-  if (hasNextConfig && !isNowBuild()) {
+  if (hasNextConfig) {
     // TODO: Pause the stream and ask the user if they wish to have their configuration file renamed
     const err = new Error(
       "Blitz does not support next.config.js. Please rename your next.config.js to blitz.config.js",
@@ -35,19 +34,17 @@ export const createStageConfig: Stage = ({config, input}) => {
     )
   }
 
-  if (!hasNextConfig) {
-    input.write(
-      new File({
-        cwd: config.src,
-        path: resolve(config.src, "next.config.js"),
-        contents: Buffer.from(`
+  input.write(
+    new File({
+      cwd: config.src,
+      path: resolve(config.src, "next.config.js"),
+      contents: Buffer.from(`
 const {withBlitz} = require('@blitzjs/server');
 const config = require('./blitz.config.js');
 module.exports = withBlitz(config);
-        `),
-      }),
-    )
-  }
+      `),
+    }),
+  )
 
   // No need to filter yet
   const stream = transform.file((file) => {

--- a/packages/server/src/stages/config/index.ts
+++ b/packages/server/src/stages/config/index.ts
@@ -6,6 +6,8 @@ import {transform} from "@blitzjs/file-pipeline"
 import {Stage} from "@blitzjs/file-pipeline"
 
 const isNextConfigPath = (p: string) => /next\.config\.(js|ts)/.test(p)
+const isNowBuild = () => process.env.NOW_BUILDER || process.env.VERCEL_BUILDER
+
 /**
  * Returns a Stage that manages converting from blitz.config.js to next.config.js
  */


### PR DESCRIPTION
This shouldn't be required since Blitz.js is now supported natively by Vercel, right?

### What are the changes and their implications?

Don't allow `next.config.js` to be present, even during builds on Vercel.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
