### PR TITLE
Fix `useQuery` when resolver returns `undefined`

### DIFF
--- a/packages/core/src/rpc.ts
+++ b/packages/core/src/rpc.ts
@@ -62,7 +62,10 @@ export async function executeRpcCall(url: string, params: any, opts: Options = {
     }
     throw error
   } else {
-    const data = deserialize({json: payload.result, meta: payload.meta?.result})
+    const data =
+      payload.result === undefined
+        ? undefined
+        : deserialize({json: payload.result, meta: payload.meta?.result})
 
     if (!opts.fromQueryHook) {
       const queryKey = getQueryKey(url, params)


### PR DESCRIPTION
### What are the changes and their implications?

Fixes a bug just introduced in #784 