### PR TITLE
Fix `prisma.connect` warning with prisma 2.4.0

### DIFF
--- a/packages/server/src/stages/rpc/index.ts
+++ b/packages/server/src/stages/rpc/index.ts
@@ -90,7 +90,7 @@ let db
 let connect
 try {
   db = require('db').default
-  connect = require('db').connect ?? (() => db.connect())
+  connect = require('db').connect ?? (() => db.$connect ? db.$connect() : db.connect())
 }catch(err){}
 export default rpcApiHandler(
   resolverModule,


### PR DESCRIPTION
Closes: #838 

### What are the changes and their implications?
Uses the new Prisma $connect() method if available rather than connect() which was deprecated in [Prisma 2.4.0](https://github.com/prisma/prisma/releases/tag/2.4.0)

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

I was able to reproduce this by updating examples/auth to use Prisma 2.4.0. It seemed like bumping the Prisma version for the examples was out of scope for this PR, but let me know if it makes sense to bump those as part of this.