### PR TITLE
Add `SessionContext` and `session.authorize()` to query/mutation generators

### DIFF
--- a/packages/generator/templates/mutation/create__ModelName__.ts
+++ b/packages/generator/templates/mutation/create__ModelName__.ts
@@ -1,3 +1,4 @@
+import {SessionContext} from "blitz"
 import db, {__ModelName__CreateArgs} from "db"
 
 if (process.env.parentModel) {
@@ -14,8 +15,10 @@ if (process.env.parentModel) {
 if (process.env.parentModel) {
   export default async function create__ModelName__(
     {data, __parentModelId__}: Create__ModelName__Input,
-    ctx: Record<any, any> = {},
+    ctx: {session?: SessionContext} = {},
   ) {
+    ctx.session!.authorize()
+
     const __modelName__ = await db.__modelName__.create({
       data: {...data, __parentModel__: {connect: {id: __parentModelId__}}},
     })
@@ -25,8 +28,10 @@ if (process.env.parentModel) {
 } else {
   export default async function create__ModelName__(
     {data}: Create__ModelName__Input,
-    ctx: Record<any, any> = {},
+    ctx: {session?: SessionContext} = {},
   ) {
+    ctx.session!.authorize()
+
     const __modelName__ = await db.__modelName__.create({data})
 
     return __modelName__

--- a/packages/generator/templates/mutation/delete__ModelName__.ts
+++ b/packages/generator/templates/mutation/delete__ModelName__.ts
@@ -1,3 +1,4 @@
+import {SessionContext} from "blitz"
 import db, {__ModelName__DeleteArgs} from "db"
 
 type Delete__ModelName__Input = {
@@ -6,8 +7,10 @@ type Delete__ModelName__Input = {
 
 export default async function delete__ModelName__(
   {where}: Delete__ModelName__Input,
-  ctx: Record<any, any> = {},
+  ctx: {session?: SessionContext} = {},
 ) {
+  ctx.session!.authorize()
+
   const __modelName__ = await db.__modelName__.delete({where})
 
   return __modelName__

--- a/packages/generator/templates/mutation/update__ModelName__.ts
+++ b/packages/generator/templates/mutation/update__ModelName__.ts
@@ -1,3 +1,4 @@
+import {SessionContext} from "blitz"
 import db, {__ModelName__UpdateArgs} from "db"
 
 if (process.env.parentModel) {
@@ -15,8 +16,10 @@ if (process.env.parentModel) {
 
 export default async function update__ModelName__(
   {where, data}: Update__ModelName__Input,
-  ctx: Record<any, any> = {},
+  ctx: {session?: SessionContext} = {},
 ) {
+  ctx.session!.authorize()
+
   if (process.env.parentModel) {
     // Don't allow updating
     delete (data as any).__parentModel__

--- a/packages/generator/templates/query/get__ModelName__.ts
+++ b/packages/generator/templates/query/get__ModelName__.ts
@@ -1,4 +1,4 @@
-import {NotFoundError} from "blitz"
+import {NotFoundError, SessionContext} from "blitz"
 import db, {FindOne__ModelName__Args} from "db"
 
 type Get__ModelName__Input = {
@@ -9,8 +9,10 @@ type Get__ModelName__Input = {
 
 export default async function get__ModelName__(
   {where /* include */}: Get__ModelName__Input,
-  ctx: Record<any, any> = {},
+  ctx: {session?: SessionContext} = {},
 ) {
+  ctx.session!.authorize()
+
   const __modelName__ = await db.__modelName__.findOne({where})
 
   if (!__modelName__) throw new NotFoundError()

--- a/packages/generator/templates/query/get__ModelNames__.ts
+++ b/packages/generator/templates/query/get__ModelNames__.ts
@@ -1,3 +1,4 @@
+import {SessionContext} from "blitz"
 import db, {FindMany__ModelName__Args} from "db"
 
 type Get__ModelNames__Input = {
@@ -12,8 +13,10 @@ type Get__ModelNames__Input = {
 
 export default async function get__ModelNames__(
   {where, orderBy, cursor, take, skip}: Get__ModelNames__Input,
-  ctx: Record<any, any> = {},
+  ctx: {session?: SessionContext} = {},
 ) {
+  ctx.session!.authorize()
+
   const __modelNames__ = await db.__modelName__.findMany({
     where,
     orderBy,


### PR DESCRIPTION


### What are the changes and their implications?

Now that auth is included by default, this adds the `SessionContext` type and `session.authorize()` call to query and mutation templates.

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
