### PR TITLE
Fix `blitz db reset` for Prisma >= 2.2.0

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -118,7 +118,7 @@ export async function resetMysql(connectionString: string, db: any): Promise<voi
 }
 
 export async function resetSqlite(connectionString: string): Promise<void> {
-  const dbPath: string = connectionString.replace(/^(?:\.\.[\\/])+/, "")
+  const dbPath: string = connectionString.replace(/^file:/, "").replace(/^(?:\.\.[\\/])+/, "")
   const unlink = promisify(fs.unlink)
   try {
     // delete database from folder
@@ -218,14 +218,14 @@ ${chalk.bold("reset")}   Reset the database and run a fresh migration via Prisma
           const prismaClientPath = require.resolve("@prisma/client", {paths: [projectRoot]})
           const {PrismaClient} = require(prismaClientPath)
           const db = new PrismaClient()
-          const dataSource: any = db.internalDatasources[0]
-          const connectorType: string = dataSource.connectorType
-          const connectionString: string = dataSource.url.value
-          if (connectorType === "postgresql") {
+          const dataSource: any = db.engine.datasources[0]
+          const providerType: string = dataSource.name
+          const connectionString: string = dataSource.url
+          if (providerType === "postgresql") {
             resetPostgres(connectionString, db)
-          } else if (connectorType === "mysql") {
+          } else if (providerType === "mysql") {
             resetMysql(connectionString, db)
-          } else if (connectorType === "sqlite") {
+          } else if (providerType === "sqlite") {
             resetSqlite(connectionString)
           } else {
             this.log("Could not find a valid database configuration")


### PR DESCRIPTION
### What are the changes and their implications?

`blitz db reset` has been broken since Prisma 2.2.0 came out.

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
