### PR TITLE
Improve default `useQuery` retry behavior in production

### DIFF
--- a/packages/core/src/use-infinite-query.ts
+++ b/packages/core/src/use-infinite-query.ts
@@ -3,7 +3,7 @@ import {
   InfiniteQueryResult,
   InfiniteQueryOptions,
 } from "react-query"
-import {useIsDevPrerender, emptyQueryFn} from "./use-query"
+import {useIsDevPrerender, emptyQueryFn, retryFunction} from "./use-query"
 import {PromiseReturnType, InferUnaryParam, QueryFn} from "./types"
 import {getQueryCacheFunctions, QueryCacheFunctions} from "./utils/query-cache"
 import {EnhancedRpcFunction} from "./rpc"
@@ -41,7 +41,7 @@ export function useInfiniteQuery<T extends QueryFn>(
     queryFn: (_: string, params, more?) => queryRpcFn({...params, ...more}, {fromQueryHook: true}),
     config: {
       suspense: true,
-      retry: process.env.NODE_ENV === "production" ? 3 : false,
+      retry: retryFunction,
       ...options,
     },
   })

--- a/packages/core/src/use-paginated-query.ts
+++ b/packages/core/src/use-paginated-query.ts
@@ -3,7 +3,7 @@ import {
   PaginatedQueryResult,
   QueryOptions,
 } from "react-query"
-import {useIsDevPrerender, emptyQueryFn} from "./use-query"
+import {useIsDevPrerender, emptyQueryFn, retryFunction} from "./use-query"
 import {PromiseReturnType, InferUnaryParam, QueryFn} from "./types"
 import {QueryCacheFunctions, getQueryCacheFunctions} from "./utils/query-cache"
 import {EnhancedRpcFunction} from "./rpc"
@@ -41,7 +41,7 @@ export function usePaginatedQuery<T extends QueryFn>(
     queryFn: (_: string, params) => queryRpcFn(params, {fromQueryHook: true}),
     config: {
       suspense: true,
-      retry: process.env.NODE_ENV === "production" ? 3 : false,
+      retry: retryFunction,
       ...options,
     },
   })

--- a/packages/core/src/use-query.ts
+++ b/packages/core/src/use-query.ts
@@ -39,7 +39,7 @@ export const retryFunction = (failureCount: number, error: any) => {
   if (error.name === "ZodError") return false
   // Prisma errors
   if (typeof error.code === "string" && error.code.startsWith("P")) return false
-  if (failureCount > 3) return false
+  if (failureCount > 2) return false
 
   return true
 }


### PR DESCRIPTION
Closes: #863

### What are the changes and their implications?

Previously the default `useQuery` retry behavior is retry 3 times regardless of the error. But that is not good because many errors will fail regardless of how many times you retry.

So this PR changes that to not retry for any of the following:

- `AuthenticationError`
- `AuthorizationError`
- `CSRFTokenMismatchError`
- `NotFoundError`
- `ZodError`
- And all Prisma errors

### Checklist

- ~[ ] Tests added for changes~
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes: https://github.com/blitz-js/blitzjs.com/pull/128

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
