### PR TITLE
Fix superjson serialization for useQuery hook

### DIFF
--- a/packages/core/src/rpc.ts
+++ b/packages/core/src/rpc.ts
@@ -29,7 +29,8 @@ export async function executeRpcCall(url: string, params: any, opts: Options = {
     headers[HEADER_CSRF] = antiCSRFToken
   }
 
-  const serialized = serialize(params)
+  // query hook already serializes the params because otherwise react-query will mess it up
+  const serialized = opts.fromQueryHook ? params : serialize(params)
 
   const result = await window.fetch(url, {
     method: "POST",

--- a/packages/core/src/use-infinite-query.ts
+++ b/packages/core/src/use-infinite-query.ts
@@ -7,6 +7,7 @@ import {useIsDevPrerender, emptyQueryFn} from "./use-query"
 import {PromiseReturnType, InferUnaryParam, QueryFn} from "./types"
 import {getQueryCacheFunctions, QueryCacheFunctions} from "./utils/query-cache"
 import {EnhancedRpcFunction} from "./rpc"
+import {serialize} from "superjson"
 
 type RestQueryResult<T extends QueryFn> = Omit<
   InfiniteQueryResult<PromiseReturnType<T>, any>,
@@ -36,7 +37,7 @@ export function useInfiniteQuery<T extends QueryFn>(
   const {data, ...queryRest} = useInfiniteReactQuery({
     queryKey: [
       queryRpcFn._meta.apiUrl,
-      typeof params === "function" ? (params as Function)() : params,
+      serialize(typeof params === "function" ? (params as Function)() : params),
     ],
     queryFn: (_: string, params, more?) => queryRpcFn({...params, ...more}, {fromQueryHook: true}),
     config: {

--- a/packages/core/src/use-paginated-query.ts
+++ b/packages/core/src/use-paginated-query.ts
@@ -7,6 +7,7 @@ import {useIsDevPrerender, emptyQueryFn} from "./use-query"
 import {PromiseReturnType, InferUnaryParam, QueryFn} from "./types"
 import {QueryCacheFunctions, getQueryCacheFunctions} from "./utils/query-cache"
 import {EnhancedRpcFunction} from "./rpc"
+import {serialize} from "superjson"
 
 type RestQueryResult<T extends QueryFn> = Omit<
   PaginatedQueryResult<PromiseReturnType<T>>,
@@ -36,7 +37,7 @@ export function usePaginatedQuery<T extends QueryFn>(
   const {resolvedData, ...queryRest} = usePaginatedReactQuery({
     queryKey: [
       queryRpcFn._meta.apiUrl,
-      typeof params === "function" ? (params as Function)() : params,
+      serialize(typeof params === "function" ? (params as Function)() : params),
     ],
     queryFn: (_: string, params) => queryRpcFn(params, {fromQueryHook: true}),
     config: {

--- a/packages/core/src/use-query.ts
+++ b/packages/core/src/use-query.ts
@@ -2,6 +2,7 @@ import {useQuery as useReactQuery, QueryResult, QueryOptions} from "react-query"
 import {PromiseReturnType, InferUnaryParam, QueryFn} from "./types"
 import {QueryCacheFunctions, getQueryCacheFunctions} from "./utils/query-cache"
 import {EnhancedRpcFunction} from "./rpc"
+import {serialize} from "superjson"
 
 type RestQueryResult<T extends QueryFn> = Omit<QueryResult<PromiseReturnType<T>>, "data"> &
   QueryCacheFunctions<PromiseReturnType<T>>
@@ -52,7 +53,7 @@ export function useQuery<T extends QueryFn>(
   const {data, ...queryRest} = useReactQuery({
     queryKey: [
       queryRpcFn._meta.apiUrl,
-      typeof params === "function" ? (params as Function)() : params,
+      serialize(typeof params === "function" ? (params as Function)() : params),
     ],
     queryFn: (_: string, params) => queryRpcFn(params, {fromQueryHook: true}),
     config: {

--- a/packages/core/test/use-query.test.tsx
+++ b/packages/core/test/use-query.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import {act, render, waitForElementToBeRemoved, screen} from "./test-utils"
 import {useQuery} from "../src/use-query"
+import {deserialize} from "superjson"
 
 describe("useQuery", () => {
   const setupHook = (
@@ -9,13 +10,17 @@ describe("useQuery", () => {
   ): [{data?: any}, Function] => {
     // This enhance fn does what getIsomorphicRpcHandler does during build time
     const enhance = (fn: any) => {
-      fn._meta = {
+      const newFn = (...args: any) => {
+        const [data, ...rest] = args
+        return fn(deserialize(data), ...rest)
+      }
+      newFn._meta = {
         name: "testResolver",
         type: "query",
         path: "app/test",
         apiUrl: "test/url",
       }
-      return fn
+      return newFn
     }
     let res = {}
     function TestHarness() {


### PR DESCRIPTION
Closes: #859

### What are the changes and their implications?

Fix superjson serialization for useQuery hook

### Checklist

- ~[ ] Tests added for changes~
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
