### PR TITLE
Change new app template to set database through .env

### DIFF
--- a/packages/generator/templates/app/.env
+++ b/packages/generator/templates/app/.env
@@ -1,5 +1,6 @@
-# THIS FILE SHOULD NOT BE CHECKED INTO YOUR VERSION CONTROL SYSTEM	
+# THIS FILE SHOULD NOT BE CHECKED INTO YOUR VERSION CONTROL SYSTEM
 
-# You can use this file to specify secrets like your database connection information
-# if you move to a more sophisticated database than sqlite. For example, for postgres:
-DATABASE_URL=postgresql://__username__@localhost:5432/__name__
+# SQLite is ready to go out of the box, but you can switch to Postgres easily
+# by swapping the DATABASE_URL.
+DATABASE_URL="file:./db.sqlite"
+# DATABASE_URL=postgresql://__username__@localhost:5432/__name__

--- a/packages/generator/templates/app/db/schema.prisma
+++ b/packages/generator/templates/app/db/schema.prisma
@@ -1,17 +1,10 @@
 // This is your Prisma schema file,
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
-datasource sqlite {
-  provider = "sqlite"
-  url      = "file:./db.sqlite"
+datasource db {
+  provider = ["sqlite", "postgres"]
+  url      = env("DATABASE_URL")
 }
-
-// SQLite is easy to start with, but if you use Postgres in production
-// you should also use it in development with the following:
-//datasource postgresql {
-//  provider = "postgresql"
-//  url      = env("DATABASE_URL")
-//}
 
 generator client {
   provider = "prisma-client-js"


### PR DESCRIPTION
### What are the changes and their implications?
As floated on Slack, this takes advantage of a [newer feature available in Prisma](https://github.com/prisma/prisma/issues/1487#issuecomment-635999202) which makes configuring databases easier. Instead of needing to tinker with your `schema.prisma` file you can control your database through environment variables.

Primsa will inspect the `DATABASE_URL` and determine the first provider from the array that supports it.

This lets you use SQLite in development without having to change the schema file before deploying. It also makes it easy to switch to Postgres when ready with a one-line change.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
