### PR TITLE
Fix queries and mutations for plain JS projects

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,7 +1,12 @@
-import {Command, flags} from "@oclif/command"
 import {dev, prod} from "@blitzjs/server"
-
+import {Command, flags} from "@oclif/command"
+import fs from "fs"
+import path from "path"
+import pkgDir from "pkg-dir"
 import {runPrismaGeneration} from "./db"
+
+const projectRoot = pkgDir.sync() || process.cwd()
+const isTypescript = fs.existsSync(path.join(projectRoot, "tsconfig.json"))
 
 export class Start extends Command {
   static description = "Start a development server"
@@ -22,12 +27,14 @@ export class Start extends Command {
   }
 
   async run() {
+    
     const {flags} = this.parse(Start)
 
     const config = {
       rootFolder: process.cwd(),
       port: flags.port,
       hostname: flags.hostname,
+      isTypescript,
     }
 
     try {

--- a/packages/file-pipeline/src/transform-files/index.ts
+++ b/packages/file-pipeline/src/transform-files/index.ts
@@ -17,6 +17,7 @@ type SynchronizeFilesOptions = {
   source?: FSStreamer
   writer?: FSStreamer
   noclean?: boolean
+  isTypescript?: boolean
 }
 
 const defaultBus = through.obj()
@@ -41,6 +42,7 @@ export async function transformFiles(
     source,
     writer,
     noclean = false,
+    isTypescript = true,
   } = options
 
   // HACK: cleaning the dev folder on every restart means we do more work than necessary
@@ -57,6 +59,7 @@ export async function transformFiles(
       include,
       ignore,
       watch,
+      isTypescript,
     }
 
     bus.on("data", ({type}) => {

--- a/packages/file-pipeline/src/types.ts
+++ b/packages/file-pipeline/src/types.ts
@@ -21,6 +21,7 @@ export type StageConfig = {
   include: string[]
   ignore: string[]
   watch: boolean
+  isTypescript: boolean
 }
 
 /**

--- a/packages/server/src/build.ts
+++ b/packages/server/src/build.ts
@@ -17,6 +17,7 @@ export async function build(
     ignore,
     include,
     watch,
+    isTypescript,
     ...stageConfig
   } = await normalize(config)
 
@@ -27,6 +28,7 @@ export async function build(
     ignore,
     include,
     watch,
+    isTypescript,
   }
   await Promise.all([transformFiles(src, stages, dest, options), readyForNextBuild])
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -15,6 +15,7 @@ export type ServerConfig = {
   writeManifestFile?: boolean
   watch?: boolean
   transformFiles?: Synchronizer
+  isTypescript?: boolean
 }
 
 type NormalizedConfig = Omit<ServerConfig, "interceptNextErrors"> & {
@@ -26,6 +27,7 @@ type NormalizedConfig = Omit<ServerConfig, "interceptNextErrors"> & {
   transformFiles: Synchronizer
   writeManifestFile: boolean
   watch: boolean
+  isTypescript: boolean
 }
 
 const defaults = {
@@ -67,5 +69,6 @@ export async function normalize(config: ServerConfig): Promise<NormalizedConfig>
     transformFiles: config.transformFiles ?? transformFiles,
     watch: config.watch ?? false,
     writeManifestFile: config.writeManifestFile ?? defaults.writeManifestFile,
+    isTypescript: config.isTypescript ?? true,
   }
 }

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -15,6 +15,7 @@ export async function dev(
     devFolder,
     ignore,
     include,
+    isTypescript,
     ...stagesConfig
   } = await normalize({
     ...config,
@@ -28,6 +29,7 @@ export async function dev(
     ignore,
     include,
     watch,
+    isTypescript,
   }
 
   const [{manifest}] = await Promise.all([

--- a/packages/server/src/stages/rpc/index.ts
+++ b/packages/server/src/stages/rpc/index.ts
@@ -1,8 +1,8 @@
-import File from "vinyl"
-import slash from "slash"
-import {absolutePathTransform} from "../utils"
-import {relative} from "path"
 import {Stage, transform} from "@blitzjs/file-pipeline"
+import {relative} from "path"
+import slash from "slash"
+import File from "vinyl"
+import {absolutePathTransform, isTypescript} from "../utils"
 
 /**
  * Returns a Stage that manages generating the internal RPC commands and handlers
@@ -69,7 +69,7 @@ export default getIsomorphicRpcHandler(
   '${resolverPath}',
   '${resolverName}',
   '${resolverType}',
-) as typeof resolverModule.default
+) ${isTypescript() ? "as typeof resolverModule.default" : ""}
 `
 
 // Clarification: try/catch around db is to prevent query errors when not using blitz's inbuilt database (See #572)

--- a/packages/server/src/stages/stage-test-utils.ts
+++ b/packages/server/src/stages/stage-test-utils.ts
@@ -11,6 +11,7 @@ export function mockStageArgs(a: {entries?: string[]; cwd?: string}): StageArgs 
     include: [],
     src: "",
     watch: false,
+    isTypescript: true,
   }
   return {
     getInputCache() {

--- a/packages/server/src/stages/utils.ts
+++ b/packages/server/src/stages/utils.ts
@@ -1,6 +1,4 @@
-import fs from "fs"
-import path, {relative, resolve} from "path"
-import pkgDir from "pkg-dir"
+import {relative, resolve} from "path"
 
 // Transform an absolute path with a relative path transformer
 export const absolutePathTransform = (sourceFolder = "") => (
@@ -10,6 +8,3 @@ export const absolutePathTransform = (sourceFolder = "") => (
   const transformedPath = relativeTransformer(startingPath)
   return resolve(sourceFolder, transformedPath)
 }
-
-export const isTypescript = () =>
-  fs.existsSync(path.join(pkgDir.sync() || process.cwd(), "tsconfig.json"))

--- a/packages/server/src/stages/utils.ts
+++ b/packages/server/src/stages/utils.ts
@@ -1,4 +1,6 @@
-import {relative, resolve} from "path"
+import fs from "fs"
+import path, {relative, resolve} from "path"
+import pkgDir from "pkg-dir"
 
 // Transform an absolute path with a relative path transformer
 export const absolutePathTransform = (sourceFolder = "") => (
@@ -8,3 +10,6 @@ export const absolutePathTransform = (sourceFolder = "") => (
   const transformedPath = relativeTransformer(startingPath)
   return resolve(sourceFolder, transformedPath)
 }
+
+export const isTypescript = () =>
+  fs.existsSync(path.join(pkgDir.sync() || process.cwd(), "tsconfig.json"))


### PR DESCRIPTION
Closes: #864

### What are the changes and their implications?

Removed TS types from RPC templates to be able to run blitz app with `--js`
