### PR TITLE
Remove icon from scaffolded templates

### DIFF
--- a/packages/generator/templates/app/app/auth/pages/login.tsx
+++ b/packages/generator/templates/app/app/auth/pages/login.tsx
@@ -9,7 +9,6 @@ const SignupPage: BlitzPage = () => {
     <>
       <Head>
         <title>Log In</title>
-        <link rel="icon" href="/favicon.ico" />
       </Head>
 
       <div>

--- a/packages/generator/templates/app/app/auth/pages/signup.tsx
+++ b/packages/generator/templates/app/app/auth/pages/signup.tsx
@@ -12,7 +12,6 @@ const SignupPage: BlitzPage = () => {
     <>
       <Head>
         <title>Sign Up</title>
-        <link rel="icon" href="/favicon.ico" />
       </Head>
 
       <div>

--- a/packages/generator/templates/page/__modelIdParam__.tsx
+++ b/packages/generator/templates/page/__modelIdParam__.tsx
@@ -63,7 +63,6 @@ const Show__ModelName__Page: BlitzPage = () => {
     <div>
       <Head>
         <title>__ModelName__</title>
-        <link rel="icon" href="/favicon.ico" />
       </Head>
 
       <main>

--- a/packages/generator/templates/page/__modelIdParam__/edit.tsx
+++ b/packages/generator/templates/page/__modelIdParam__/edit.tsx
@@ -54,7 +54,6 @@ const Edit__ModelName__Page: BlitzPage = () => {
     <div>
       <Head>
         <title>Edit __ModelName__</title>
-        <link rel="icon" href="/favicon.ico" />
       </Head>
 
       <main>

--- a/packages/generator/templates/page/index.tsx
+++ b/packages/generator/templates/page/index.tsx
@@ -57,7 +57,6 @@ const __ModelNames__Page: BlitzPage = () => {
     <div>
       <Head>
         <title>__ModelNames__</title>
-        <link rel="icon" href="/favicon.ico" />
       </Head>
 
       <main>

--- a/packages/generator/templates/page/new.tsx
+++ b/packages/generator/templates/page/new.tsx
@@ -17,7 +17,6 @@ const New__ModelName__Page: BlitzPage = () => {
     <div>
       <Head>
         <title>New __ModelName__</title>
-        <link rel="icon" href="/favicon.ico" />
       </Head>
 
       <main>


### PR DESCRIPTION
# What are the changes and their implications?

All the generated template files include the favicon in the head - which seems overkill. Out of the box it's in `app/pages/index.tsx`. If you were seriously wanting to configure your favicon it would probably make sense to do once in the `_document.tsx` so you don't need to repeat yourself.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
