### PR TITLE
Capitalize help command description

### DIFF
--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -3,7 +3,7 @@ import {Command, flags} from "@oclif/command"
 import Help from "@oclif/plugin-help"
 
 export class HelpCommand extends Command {
-  static description = "display help for <%= config.bin %>"
+  static description = "Display help for <%= config.bin %>"
 
   static aliases = ["h"]
 


### PR DESCRIPTION
# What are the changes and their implications?

All the other command descriptions are capitalized, so this brings `help` into line.

```
Blitz.js CLI

VERSION
  @blitzjs/cli/0.17.1-canary.4 darwin-x64 node-v14.8.0

USAGE
  $ blitz [COMMAND]

COMMANDS
  build     Create a production build
  console   Run the Blitz console REPL
  db        Run database commands
  generate  Generate new files for your Blitz project
  help      display help for blitz
  new       Create a new Blitz project
  start     Start a development server
  test      Run project tests
```