### PR TITLE
Show `blitz install` command in `blitz help` output

### DIFF
--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -47,7 +47,7 @@ interface RecipeMeta {
 }
 
 export class Install extends Command {
-  static description = "Install a third-party package into your Blitz app"
+  static description = "Install a Recipe into your Blitz app"
   static aliases = ["i"]
   static strict = false
 

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -50,7 +50,6 @@ export class Install extends Command {
   static description = "Install a third-party package into your Blitz app"
   static aliases = ["i"]
   static strict = false
-  static hidden = true
 
   static args = [
     {


### PR DESCRIPTION
### What are the changes and their implications.
As mentioned on Slack last night, this is the only command out of the box that is `hidden`. I assume it may have been hidden while in early development, but as `install` is now listed in the docs we may as well make it visible.
