### PR TITLE
Fix to allow usage without `db/index.(ts|js)` file

### DIFF
--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -1,3 +1,5 @@
+const fs = require("fs")
+
 export function withBlitz(nextConfig: any) {
   return (phase: string, nextOpts: any = {}) => {
     // Need to grab the normalized config based on the phase
@@ -15,7 +17,7 @@ export function withBlitz(nextConfig: any) {
           const originalEntry = config.entry
           config.entry = async () => ({
             ...(await originalEntry()),
-            "../__db": "./db/index",
+            ...(doesDbModuleExist ? {"../__db": "./db/index"} : {}),
           })
         } else {
           config.module = config.module || {}
@@ -43,6 +45,8 @@ export function withBlitz(nextConfig: any) {
         return config
       },
     })
+
+    const doesDbModuleExist = fs.existsSync("./db")
 
     // We add next-transpile-modules during internal blitz development so that changes in blitz
     // framework code will trigger a hot reload of any example apps that are running

--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -1,4 +1,6 @@
-const fs = require("fs")
+import pkgDir from "pkg-dir"
+import path from "path"
+import fs from "fs"
 
 export function withBlitz(nextConfig: any) {
   return (phase: string, nextOpts: any = {}) => {
@@ -17,7 +19,7 @@ export function withBlitz(nextConfig: any) {
           const originalEntry = config.entry
           config.entry = async () => ({
             ...(await originalEntry()),
-            ...(doesDbModuleExist ? {"../__db": "./db/index"} : {}),
+            ...(doesDbModuleExist() ? {"../__db": "./db/index"} : {}),
           })
         } else {
           config.module = config.module || {}
@@ -46,7 +48,14 @@ export function withBlitz(nextConfig: any) {
       },
     })
 
-    const doesDbModuleExist = fs.existsSync("./db")
+    function doesDbModuleExist() {
+      const projectRoot = pkgDir.sync() || process.cwd()
+      return (
+        fs.existsSync(path.join(projectRoot, "db/index.js")) ||
+        fs.existsSync(path.join(projectRoot, "db/index.ts")) ||
+        fs.existsSync(path.join(projectRoot, "db/index.tsx"))
+      )
+    }
 
     // We add next-transpile-modules during internal blitz development so that changes in blitz
     // framework code will trigger a hot reload of any example apps that are running


### PR DESCRIPTION
Closes: #890 

### What are the changes and their implications?

Adds the `db` module to webpack only if it exists, allowing for usage without it. 
It checks if the `db` folder exists within the `.blitz` cache.

Works when running with dev, will test soon with prod. 

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
