### PR TITLE
Change `ctx.session.userId` type to be `any`

### DIFF
--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -26,13 +26,13 @@ function assert(condition: any, message: string): asserts condition {
 }
 
 export interface PublicData extends Record<any, any> {
-  userId: string | number | null
+  userId: any
   roles: string[]
 }
 
 export interface SessionModel extends Record<any, any> {
   handle: string
-  userId?: string | number
+  userId?: any
   expiresAt?: Date
   hashedSessionToken?: string
   antiCSRFToken?: string
@@ -45,7 +45,7 @@ export type SessionConfig = {
   method?: "essential" | "advanced"
   sameSite?: "none" | "lax" | "strict"
   getSession: (handle: string) => Promise<SessionModel | null>
-  getSessions: (userId: string | number) => Promise<SessionModel[]>
+  getSessions: (userId: any) => Promise<SessionModel[]>
   createSession: (session: SessionModel) => Promise<SessionModel>
   updateSession: (handle: string, session: Partial<SessionModel>) => Promise<SessionModel>
   deleteSession: (handle: string) => Promise<SessionModel>
@@ -56,7 +56,7 @@ export interface SessionContext {
   /**
    * null if anonymous
    */
-  userId: string | number | null
+  userId: any
   roles: string[]
   handle: string | null
   publicData: PublicData


### PR DESCRIPTION
### What are the changes and their implications?

The type of `ctx.session.userId` was `number | string` which was just plain annoying. This changes the type to `any` until we can implement something better.

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
