### PR TITLE
Fix: Refetch all queries if session changes

### DIFF
--- a/packages/core/src/use-infinite-query.ts
+++ b/packages/core/src/use-infinite-query.ts
@@ -3,6 +3,7 @@ import {
   InfiniteQueryResult,
   InfiniteQueryOptions,
 } from "react-query"
+import {useSession} from "./supertokens"
 import {useIsDevPrerender, emptyQueryFn, retryFunction} from "./use-query"
 import {PromiseReturnType, InferUnaryParam, QueryFn} from "./types"
 import {getQueryCacheFunctions, QueryCacheFunctions} from "./utils/query-cache"
@@ -37,9 +38,12 @@ export function useInfiniteQuery<T extends QueryFn>(
   const {data, ...queryRest} = useInfiniteReactQuery({
     queryKey: [
       queryRpcFn._meta.apiUrl,
+      // We add the session object here so queries will refetch if session changes
+      useSession(),
       serialize(typeof params === "function" ? (params as Function)() : params),
     ],
-    queryFn: (_: string, params, more?) => queryRpcFn({...params, ...more}, {fromQueryHook: true}),
+    queryFn: (_: string, __: any, params, more?) =>
+      queryRpcFn({...params, ...more}, {fromQueryHook: true}),
     config: {
       suspense: true,
       retry: retryFunction,

--- a/packages/core/src/use-paginated-query.ts
+++ b/packages/core/src/use-paginated-query.ts
@@ -3,6 +3,7 @@ import {
   PaginatedQueryResult,
   QueryOptions,
 } from "react-query"
+import {useSession} from "./supertokens"
 import {useIsDevPrerender, emptyQueryFn, retryFunction} from "./use-query"
 import {PromiseReturnType, InferUnaryParam, QueryFn} from "./types"
 import {QueryCacheFunctions, getQueryCacheFunctions} from "./utils/query-cache"
@@ -37,9 +38,11 @@ export function usePaginatedQuery<T extends QueryFn>(
   const {resolvedData, ...queryRest} = usePaginatedReactQuery({
     queryKey: [
       queryRpcFn._meta.apiUrl,
+      // We add the session object here so queries will refetch if session changes
+      useSession(),
       serialize(typeof params === "function" ? (params as Function)() : params),
     ],
-    queryFn: (_: string, params) => queryRpcFn(params, {fromQueryHook: true}),
+    queryFn: (_: string, __: any, params) => queryRpcFn(params, {fromQueryHook: true}),
     config: {
       suspense: true,
       retry: retryFunction,

--- a/packages/core/src/use-query.ts
+++ b/packages/core/src/use-query.ts
@@ -1,4 +1,5 @@
 import {useQuery as useReactQuery, QueryResult, QueryOptions} from "react-query"
+import {useSession} from "./supertokens"
 import {PromiseReturnType, InferUnaryParam, QueryFn} from "./types"
 import {QueryCacheFunctions, getQueryCacheFunctions} from "./utils/query-cache"
 import {EnhancedRpcFunction} from "./rpc"
@@ -62,9 +63,11 @@ export function useQuery<T extends QueryFn>(
   const {data, ...queryRest} = useReactQuery({
     queryKey: [
       queryRpcFn._meta.apiUrl,
+      // We add the session object here so queries will refetch if session changes
+      useSession(),
       serialize(typeof params === "function" ? (params as Function)() : params),
     ],
-    queryFn: (_: string, params) => queryRpcFn(params, {fromQueryHook: true}),
+    queryFn: (_: string, __: any, params) => queryRpcFn(params, {fromQueryHook: true}),
     config: {
       suspense: true,
       retry: retryFunction,


### PR DESCRIPTION
### What are the changes and their implications?

Queries often depend on session data, so if the session changes they need to be revalidated. With this PR, this will now happen automatically behind the scenes for you. If the new query data is the same, the user will not know it was refetched.

An example is if a user logs out, any queries that depend on a logged in state should reset. 
Before this PR, protected query data would remain on the screen after a logout.

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
