### PR TITLE
add ability to disable CSRF protection

### DIFF
--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -239,7 +239,8 @@ export async function getSession(
   const anonymousSessionToken = req.cookies[COOKIE_ANONYMOUS_SESSION_TOKEN]
   const sessionToken = req.cookies[COOKIE_SESSION_TOKEN] // for essential method
   const idRefreshToken = req.cookies[COOKIE_REFRESH_TOKEN] // for advanced method
-  const enableCsrfProtection = req.method !== "GET" && req.method !== "OPTIONS"
+  const enableCsrfProtection =
+    req.method !== "GET" && req.method !== "OPTIONS" && !process.env.DISABLE_CSRF_PROTECTION
   const antiCSRFToken = req.headers[HEADER_CSRF] as string
 
   if (sessionToken) {


### PR DESCRIPTION
### What are the changes and their implications?

We are having at least one report of a production blitz app where it's throwing a lot of CSRF errors. It seems we have a bug with that somewhere.

As a temporary workaround, this adds ability to disable CSRF by setting the env var `DISABLE_CSRF_PROTECTION=true`

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
