### PR TITLE
Remove favicon from generators

### DIFF
--- a/packages/generator/templates/page/__modelIdParam__.tsx
+++ b/packages/generator/templates/page/__modelIdParam__.tsx
@@ -65,7 +65,6 @@ const Show__ModelName__Page: BlitzPage = () => {
     <div>
       <Head>
         <title>__ModelName__</title>
-        <link rel="icon" href="/favicon.ico" />
       </Head>
 
       <main>

--- a/packages/generator/templates/page/__modelIdParam__/edit.tsx
+++ b/packages/generator/templates/page/__modelIdParam__/edit.tsx
@@ -55,7 +55,6 @@ const Edit__ModelName__Page: BlitzPage = () => {
     <div>
       <Head>
         <title>Edit __ModelName__</title>
-        <link rel="icon" href="/favicon.ico" />
       </Head>
 
       <main>

--- a/packages/generator/templates/page/index.tsx
+++ b/packages/generator/templates/page/index.tsx
@@ -58,7 +58,6 @@ const __ModelNames__Page: BlitzPage = () => {
     <div>
       <Head>
         <title>__ModelNames__</title>
-        <link rel="icon" href="/favicon.ico" />
       </Head>
 
       <main>

--- a/packages/generator/templates/page/new.tsx
+++ b/packages/generator/templates/page/new.tsx
@@ -18,7 +18,6 @@ const New__ModelName__Page: BlitzPage = () => {
     <div>
       <Head>
         <title>New __ModelName__</title>
-        <link rel="icon" href="/favicon.ico" />
       </Head>
 
       <main>


### PR DESCRIPTION
# What are the changes and their implications?

Quick follow-up to #880 - we added a Layout to have the base favicon but didn't remove the favicon from the generators. Now we have a single place for the favicon there's no need to have it in the generators too.

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
