### PR TITLE
Encode error to avoid ERR_INVALID_CHAR

### DIFF
--- a/packages/core/src/passport-adapter.ts
+++ b/packages/core/src/passport-adapter.ts
@@ -109,7 +109,7 @@ export function passportAuth(config: BlitzPassportConfig) {
                 "/"
 
               if (error) {
-                redirectUrl += "?authError=" + error.toString()
+                redirectUrl += "?authError=" + encodeURIComponent(error.toString())
                 res.setHeader("Location", redirectUrl)
                 res.statusCode = 302
                 res.end()


### PR DESCRIPTION
Closes: #809 

### What are the changes and their implications?

There's a set of allowed characters for the Location: https://github.com/nodejs/node/blob/v9.6.0/lib/_http_common.js#L245

Wrapped the error with `encodreURIComponent`, to ensure the characters will be valid.

Tested by manually throwing an error in the auth example (since this only happens with Twitter/GitHub flow), and was able to reproduce the error, but encoding the string fixed it.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
