### PR TITLE
Automatically run initial db migrations during new app setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-peer-deps-external": "2.2.2",
     "semver": "7.3.2",
+    "stdout-stderr": "0.1.13",
     "test-listen": "1.1.0",
     "ts-jest": "24.3.0",
     "tsdx": "0.13.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,7 +60,7 @@
     "@oclif/test": "1.2.5",
     "@prisma/cli": "2.4.1",
     "nock": "13.0.0-beta.3",
-    "stdout-stderr": "^0.1.13"
+    "stdout-stderr": "0.1.13"
   },
   "oclif": {
     "commands": "./lib/src/commands",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,7 +59,8 @@
     "@oclif/dev-cli": "1.22.2",
     "@oclif/test": "1.2.5",
     "@prisma/cli": "2.4.1",
-    "nock": "13.0.0-beta.3"
+    "nock": "13.0.0-beta.3",
+    "stdout-stderr": "^0.1.13"
   },
   "oclif": {
     "commands": "./lib/src/commands",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -12,7 +12,7 @@ export class Build extends Command {
     }
 
     try {
-      await build(config, runPrismaGeneration({silent: true}))
+      await build(config, runPrismaGeneration({silent: true, failSilently: true}))
     } catch (err) {
       console.error(err)
       process.exit(1) // clean up?

--- a/packages/cli/src/commands/console.ts
+++ b/packages/cli/src/commands/console.ts
@@ -32,7 +32,7 @@ export class Console extends Command {
       setupTsnode()
     }
 
-    await runPrismaGeneration({silent: true})
+    await runPrismaGeneration({silent: true, failSilently: true})
     spinner.succeed()
 
     runRepl(Console.replOptions)

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -44,10 +44,10 @@ const runPrismaExitOnError = async (...args: Parameters<typeof runPrisma>) => {
 
 // Prisma client generation will fail if no model is defined in the schema.
 // So the silent option is here to ignore that failure
-export const runPrismaGeneration = async ({silent = false} = {}) => {
+export const runPrismaGeneration = async ({silent = false, failSilently = false} = {}) => {
   const success = await runPrisma(["generate", schemaArg], silent)
 
-  if (!success) {
+  if (!success && !failSilently) {
     throw new Error("Prisma Client generation failed")
   }
 }
@@ -213,9 +213,7 @@ ${chalk.bold("reset")}   Reset the database and run a fresh migration via Prisma
 
     if (command === "reset") {
       const spinner = log.spinner("Loading your database").start()
-      try {
-        await runPrismaGeneration({silent: true})
-      } catch {}
+      await runPrismaGeneration({silent: true, failSilently: true})
       spinner.succeed()
 
       const {confirm} = await prompt<{confirm: string}>({

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -8,73 +8,84 @@ import * as fs from "fs"
 import * as path from "path"
 import {promisify} from "util"
 import {projectRoot} from "../utils/get-project-root"
+import pEvent from "p-event"
 
-const schemaPath = path.join(process.cwd(), "db", "schema.prisma")
-const schemaArg = `--schema=${schemaPath}`
 const getPrismaBin = () => resolveBinAsync("@prisma/cli", "prisma")
+let prismaBin: string
+let schemaArg: string
+
+const runPrisma = async (args: string[], silent = false) => {
+  if (!prismaBin) {
+    try {
+      prismaBin = await getPrismaBin()
+    } catch {
+      throw new Error(
+        "Oops, we can't find Prisma Client. Please make sure it's installed in your project",
+      )
+    }
+  }
+
+  const cp = spawn(prismaBin, args, {
+    stdio: silent ? "ignore" : "inherit",
+    env: process.env,
+  })
+  const code = await pEvent(cp, "exit", {rejectionEvents: []})
+
+  return code === 0
+}
+
+const runPrismaExitOnError = async (...args: Parameters<typeof runPrisma>) => {
+  const success = await runPrisma(...args)
+
+  if (!success) {
+    process.exit(1)
+  }
+}
 
 // Prisma client generation will fail if no model is defined in the schema.
 // So the silent option is here to ignore that failure
 export const runPrismaGeneration = async ({silent = false} = {}) => {
-  try {
-    const prismaBin = await getPrismaBin()
+  const success = await runPrisma(["generate", schemaArg], silent)
 
-    return new Promise((resolve) => {
-      spawn(prismaBin, ["generate", schemaArg], {stdio: silent ? "ignore" : "inherit"}).on(
-        "exit",
-        (code) => {
-          if (code === 0) {
-            resolve()
-          } else if (silent) {
-            resolve()
-          } else {
-            process.exit(1)
-          }
-        },
-      )
-    })
-  } catch (error) {
-    if (silent) return
-    throw new Error(
-      "Oops, we can't find Prisma Client. Please make sure it's installed in your project",
-    )
+  if (!success) {
+    throw new Error("Prisma Client generation failed")
   }
 }
 
-const runMigrateUp = (prismaBin: string, resolve: (value?: unknown) => void) => {
+const runMigrateUp = async ({silent = false} = {}) => {
   const args = ["migrate", "up", schemaArg, "--create-db", "--experimental"]
-  if (process.env.NODE_ENV === "production") {
+
+  if (process.env.NODE_ENV === "production" || silent) {
     args.push("--auto-approve")
   }
-  const cp = spawn(prismaBin, args, {stdio: "inherit"})
-  cp.on("exit", async (code) => {
-    if (code === 0) {
-      await runPrismaGeneration()
-      resolve()
-    } else {
-      process.exit(1)
-    }
-  })
+
+  const success = await runPrisma(args, silent)
+
+  if (!success) {
+    throw new Error("Migration failed")
+  }
+
+  return runPrismaGeneration({silent})
 }
 
-export const runMigrate = async () => {
-  const prismaBin = await getPrismaBin()
-  return new Promise((resolve) => {
-    if (process.env.NODE_ENV === "production") {
-      runMigrateUp(prismaBin, resolve)
-    } else {
-      const cp = spawn(prismaBin, ["migrate", "save", schemaArg, "--create-db", "--experimental"], {
-        stdio: "inherit",
-      })
-      cp.on("exit", (code) => {
-        if (code === 0) {
-          runMigrateUp(prismaBin, resolve)
-        } else {
-          process.exit(1)
-        }
-      })
-    }
-  })
+export const runMigrate = async (name?: string) => {
+  if (process.env.NODE_ENV === "production") {
+    return runMigrateUp()
+  }
+
+  const silent = Boolean(name)
+  const args = ["migrate", "save", schemaArg, "--create-db", "--experimental"]
+  if (name) {
+    args.push("--name", name)
+  }
+
+  const success = await runPrisma(args, silent)
+
+  if (!success) {
+    throw new Error("Migration failed")
+  }
+
+  return runMigrateUp({silent})
 }
 
 export async function resetPostgres(connectionString: string, db: any): Promise<void> {
@@ -167,79 +178,84 @@ ${chalk.bold("reset")}   Reset the database and run a fresh migration via Prisma
 
   static flags = {
     help: flags.help({char: "h"}),
+    // Used by `new` command to perform the initial migration
+    name: flags.string({hidden: true}),
   }
 
   async run() {
-    const {args} = this.parse(Db)
+    const {args, flags} = this.parse(Db)
     const command = args["command"]
 
-    const prismaBin = await getPrismaBin()
+    // Needs to happen at run-time since the `new` command needs to change the cwd before running
+    const schemaPath = path.join(process.cwd(), "db", "schema.prisma")
+    schemaArg = `--schema=${schemaPath}`
 
     if (command === "migrate" || command === "m") {
-      await runMigrate()
-    } else if (command === "introspect") {
-      const cp = spawn(prismaBin, ["introspect", schemaArg], {
-        stdio: "inherit",
-      })
-      cp.on("exit", (code) => {
-        if (code === 0) {
-          spawn(prismaBin, ["generate", schemaArg], {stdio: "inherit"}).on(
-            "exit",
-            (code: number) => {
-              if (code !== 0) {
-                process.exit(1)
-              }
-            },
-          )
+      try {
+        return await runMigrate(flags.name)
+      } catch (error) {
+        if (flags.name) {
+          throw error
         } else {
           process.exit(1)
         }
-      })
-    } else if (command === "studio") {
-      const cp = spawn(prismaBin, ["studio", schemaArg, "--experimental"], {
-        stdio: "inherit",
-      })
-      cp.on("exit", (code) => {
-        if (code === 0) {
-        } else {
-          process.exit(1)
-        }
-      })
-    } else if (command === "reset") {
+      }
+    }
+
+    if (command === "introspect") {
+      await runPrismaExitOnError(["introspect", schemaArg])
+      return runPrismaExitOnError(["generate", schemaArg])
+    }
+
+    if (command === "studio") {
+      return runPrismaExitOnError(["studio", schemaArg, "--experimental"])
+    }
+
+    if (command === "reset") {
       const spinner = log.spinner("Loading your database").start()
-      await runPrismaGeneration({silent: true})
+      try {
+        await runPrismaGeneration({silent: true})
+      } catch {}
       spinner.succeed()
-      await prompt<{confirm: string}>({
+
+      const {confirm} = await prompt<{confirm: string}>({
         type: "confirm",
         name: "confirm",
         message: "Are you sure you want to reset your database and erase ALL data?",
-      }).then((res) => {
-        if (res.confirm) {
-          const prismaClientPath = require.resolve("@prisma/client", {paths: [projectRoot]})
-          const {PrismaClient} = require(prismaClientPath)
-          const db = new PrismaClient()
-          const dataSource: any = db.engine.datasources[0]
-          const providerType: string = dataSource.name
-          const connectionString: string = dataSource.url
-          if (providerType === "postgresql") {
-            resetPostgres(connectionString, db)
-          } else if (providerType === "mysql") {
-            resetMysql(connectionString, db)
-          } else if (providerType === "sqlite") {
-            resetSqlite(connectionString)
-          } else {
-            this.log("Could not find a valid database configuration")
-          }
-        }
       })
-    } else if (command === "help") {
-      await Db.run(["--help"])
-    } else {
-      this.log("\nUh oh, Blitz does not support that command.")
-      this.log("You can try running a prisma command directly with:")
-      this.log("\n  `npm run prisma COMMAND` or `yarn prisma COMMAND`\n")
-      this.log("Or you can list available db commands with with:")
-      this.log("\n  `npm run blitz db --help` or `yarn blitz db --help`\n")
+
+      if (!confirm) {
+        return
+      }
+
+      const prismaClientPath = require.resolve("@prisma/client", {paths: [projectRoot]})
+      const {PrismaClient} = require(prismaClientPath)
+      const db = new PrismaClient()
+      const dataSource: any = db.engine.datasources[0]
+      const providerType: string = dataSource.name
+      const connectionString: string = dataSource.url
+
+      if (providerType === "postgresql") {
+        resetPostgres(connectionString, db)
+      } else if (providerType === "mysql") {
+        resetMysql(connectionString, db)
+      } else if (providerType === "sqlite") {
+        resetSqlite(connectionString)
+      } else {
+        this.log("Could not find a valid database configuration")
+      }
+
+      return
     }
+
+    if (command === "help") {
+      return Db.run(["--help"])
+    }
+
+    this.log("\nUh oh, Blitz does not support that command.")
+    this.log("You can try running a prisma command directly with:")
+    this.log("\n  `npm run prisma COMMAND` or `yarn prisma COMMAND`\n")
+    this.log("Or you can list available db commands with with:")
+    this.log("\n  `npm run blitz db --help` or `yarn blitz db --help`\n")
   }
 }

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -99,7 +99,7 @@ export class New extends Command {
         postInstallSteps.push(npm ? "npm install" : "yarn")
         postInstallSteps.push("blitz db migrate (when asked, you can name the migration anything)")
       } else {
-        const spinner = log.spinner(log.withBrand("Migrating database")).start()
+        const spinner = log.spinner(log.withBrand("Initializing SQLite database")).start()
 
         try {
           // Required in order for DATABASE_URL to be available
@@ -107,7 +107,7 @@ export class New extends Command {
           await Db.run(["migrate", "--name", "Initial Migration"])
           spinner.succeed()
         } catch {
-          spinner.stop()
+          spinner.fail()
           postInstallSteps.push(
             "blitz db migrate (when asked, you can name the migration anything)",
           )

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -121,6 +121,7 @@ export class New extends Command {
       postInstallSteps.forEach((step, index) => {
         this.log(chalk.yellow(`   ${index + 1}. ${step}`))
       })
+      this.log("") // new line
     } catch (err) {
       if (err instanceof PromptAbortedError) this.exit(0)
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -32,9 +32,9 @@ export class Start extends Command {
 
     try {
       if (flags.production) {
-        await prod(config, runPrismaGeneration({silent: true}))
+        await prod(config, runPrismaGeneration({silent: true, failSilently: true}))
       } else {
-        await dev(config, runPrismaGeneration({silent: true}))
+        await dev(config, runPrismaGeneration({silent: true, failSilently: true}))
       }
     } catch (err) {
       console.error(err)

--- a/packages/cli/test/commands/build.test.ts
+++ b/packages/cli/test/commands/build.test.ts
@@ -6,7 +6,7 @@ const spawn = jest.fn(() => {
   onSpy = jest.fn(function on(_: string, callback: (_: number) => {}) {
     callback(0)
   })
-  return {on: onSpy}
+  return {on: onSpy, off: jest.fn()}
 })
 
 jest.doMock("cross-spawn", () => ({spawn}))

--- a/packages/cli/test/commands/console.test.ts
+++ b/packages/cli/test/commands/console.test.ts
@@ -58,7 +58,7 @@ describe("Console command", () => {
 
   it("runs PrismaGeneration with silent allowed", async () => {
     await Console.prototype.run()
-    expect(db.runPrismaGeneration).toHaveBeenCalledWith({silent: true})
+    expect(db.runPrismaGeneration).toHaveBeenCalledWith({silent: true, failSilently: true})
   })
 
   it("runs repl", async () => {

--- a/packages/cli/test/commands/db.test.ts
+++ b/packages/cli/test/commands/db.test.ts
@@ -1,13 +1,11 @@
 import * as path from "path"
 import {resolveBinAsync} from "@blitzjs/server"
 
-let onSpy: jest.Mock
-const spawn = jest.fn(() => {
-  onSpy = jest.fn(function on(_: string, callback: (_: number) => {}) {
-    callback(0)
-  })
-  return {on: onSpy}
+let onSpy = jest.fn(function on(_: string, callback: (_: number) => {}) {
+  callback(0)
 })
+
+const spawn = jest.fn(() => ({on: onSpy, off: jest.fn()}))
 
 jest.doMock("cross-spawn", () => ({spawn}))
 
@@ -18,6 +16,7 @@ let prismaBin: string
 let migrateSaveParams: any[]
 let migrateUpDevParams: any[]
 let migrateUpProdParams: any[]
+let migrateSaveWithNameParams: any[]
 beforeAll(async () => {
   schemaArg = `--schema=${path.join(process.cwd(), "db", "schema.prisma")}`
   prismaBin = await resolveBinAsync("@prisma/cli", "prisma")
@@ -25,17 +24,22 @@ beforeAll(async () => {
   migrateSaveParams = [
     prismaBin,
     ["migrate", "save", schemaArg, "--create-db", "--experimental"],
-    {stdio: "inherit"},
+    {stdio: "inherit", env: process.env},
   ]
   migrateUpDevParams = [
     prismaBin,
     ["migrate", "up", schemaArg, "--create-db", "--experimental"],
-    {stdio: "inherit"},
+    {stdio: "inherit", env: process.env},
   ]
   migrateUpProdParams = [
     prismaBin,
     ["migrate", "up", schemaArg, "--create-db", "--experimental", "--auto-approve"],
-    {stdio: "inherit"},
+    {stdio: "inherit", env: process.env},
+  ]
+  migrateSaveWithNameParams = [
+    prismaBin,
+    ["migrate", "save", schemaArg, "--create-db", "--experimental", "--name", "name"],
+    {stdio: "ignore", env: process.env},
   ]
 })
 
@@ -50,21 +54,26 @@ describe("Db command", () => {
 
   function expectDbMigrateOutcome() {
     expect(spawn).toBeCalledWith(...migrateSaveParams)
-    expect(spawn.mock.calls.length).toBe(3)
+    expect(spawn).toHaveBeenCalledTimes(3)
 
-    // following expection is not working
-    //expect(onSpy).toHaveBeenCalledWith(0);
+    expect(onSpy).toHaveBeenCalledTimes(3)
 
     expect(spawn).toBeCalledWith(...migrateUpDevParams)
   }
 
   function expectProductionDbMigrateOutcome() {
-    expect(spawn.mock.calls.length).toBe(2)
+    expect(spawn).toHaveBeenCalledTimes(2)
 
-    // following expection is not working
-    //expect(onSpy).toHaveBeenCalledWith(0);
+    expect(onSpy).toHaveBeenCalledTimes(2)
 
     expect(spawn).toBeCalledWith(...migrateUpProdParams)
+  }
+
+  function expectDbMigrateWithNameOutcome() {
+    expect(spawn).toBeCalledWith(...migrateSaveWithNameParams)
+    expect(spawn).toHaveBeenCalledTimes(3)
+
+    expect(onSpy).toHaveBeenCalledTimes(3)
   }
 
   it("runs db help when no command given", async () => {
@@ -131,18 +140,34 @@ describe("Db command", () => {
   it("runs db introspect", async () => {
     await Db.run(["introspect"])
 
-    expect(spawn).toHaveBeenCalled()
+    expect(spawn).toHaveBeenCalledWith(prismaBin, ["introspect", schemaArg], {
+      stdio: "inherit",
+      env: process.env,
+    })
+    expect(spawn).toHaveBeenCalledWith(prismaBin, ["generate", schemaArg], {
+      stdio: "inherit",
+      env: process.env,
+    })
   })
 
   it("runs db studio", async () => {
     await Db.run(["studio"])
 
-    expect(spawn).toHaveBeenCalled()
+    expect(spawn).toHaveBeenCalledWith(prismaBin, ["studio", schemaArg, "--experimental"], {
+      stdio: "inherit",
+      env: process.env,
+    })
   })
 
   it("does not run db in case of invalid command", async () => {
     await Db.run(["invalid"])
 
     expect(spawn.mock.calls.length).toBe(0)
+  })
+
+  it("runs db migrate silently with the right args when name flag is used", async () => {
+    await Db.run(["migrate", "--name", "name"])
+
+    expectDbMigrateWithNameOutcome()
   })
 })

--- a/packages/cli/test/commands/start.test.ts
+++ b/packages/cli/test/commands/start.test.ts
@@ -8,7 +8,7 @@ const spawn = jest.fn(() => {
   onSpy = jest.fn(function on(_: string, callback: (_: number) => {}) {
     callback(0)
   })
-  return {on: onSpy}
+  return {on: onSpy, off: jest.fn()}
 })
 
 jest.doMock("cross-spawn", () => ({spawn}))

--- a/yarn.lock
+++ b/yarn.lock
@@ -16218,7 +16218,7 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stdout-stderr@^0.1.9:
+stdout-stderr@^0.1.13, stdout-stderr@^0.1.9:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/stdout-stderr/-/stdout-stderr-0.1.13.tgz#54e3450f3d4c54086a49c0c7f8786a44d1844b6f"
   integrity sha512-Xnt9/HHHYfjZ7NeQLvuQDyL1LnbsbddgMFKCuaQKwGCdJm8LnstZIXop+uOY36UR1UXXoHXfMbC1KlVdVd2JLA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -16218,7 +16218,7 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stdout-stderr@^0.1.13, stdout-stderr@^0.1.9:
+stdout-stderr@0.1.13, stdout-stderr@^0.1.9:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/stdout-stderr/-/stdout-stderr-0.1.13.tgz#54e3450f3d4c54086a49c0c7f8786a44d1844b6f"
   integrity sha512-Xnt9/HHHYfjZ7NeQLvuQDyL1LnbsbddgMFKCuaQKwGCdJm8LnstZIXop+uOY36UR1UXXoHXfMbC1KlVdVd2JLA==


### PR DESCRIPTION
Closes: #851 

### What are the changes and their implications?

This PR adds a few things:
- Refactors the db command to use `p-event` and abstract the calls to prisma. The logic with multiple nested callback funcs was a bit hard to follow. This way, using async/await I feel it's more readable.
- Add hidden option `name` to the db command which passes it to `prisma migrate save` call
- Adds the initial migration to the `new` command
- Adds the `yarn` or `npm install` step to the new command if the run is dry or `--skip-install` is passed
- Adds/fixes some tests in the db command
- Adds logic for testing `new` command stdout and instruction steps
- Adds a full install test for the `new` command

I'm not sure about the copy in many places, I can update if needed.

For implementation, since the recommendation is to run `blitz db migrate`, I figured it should *actually* call that command underneath. This way, if that command changes in the future, we don't have to duplicate the logic and maintain it both places. Only difference in this is that if something goes wrong, instead of hard exit, it'll just print the message including the step to call the `db migrate`.

For the spinner, I'm not sure about the behavior if something goes wrong. For now I just stopped/hid it. But we could also mark it as `fail()`

### Checklist

- [x] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
