### PR TITLE
[legacy-framework] Fix Tailwind Recipe purging in production

### DIFF
--- a/recipes/tailwind/templates/config/tailwind.config.js
+++ b/recipes/tailwind/templates/config/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  purge: ["./app/*/pages/**/*.{js,jsx,ts,tsx}"],
+  purge: ["{app,pages}/**/*.{js,jsx,ts,tsx}"],
   theme: {},
   variants: {},
   plugins: [],


### PR DESCRIPTION
Closes: blitz-js/legacy-framework#791 

### What are the changes and their implications?

The current purging glob doesn’t work in production, since the pages get moved outside of the app directory. This fixes that.

### Checklist

- [ ] Tests added for changes (N/a)
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes (N/a)

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
