### PR TITLE
Add `isLoading` property to `useSession()` hook result

### DIFF
--- a/examples/auth/app/pages/index.tsx
+++ b/examples/auth/app/pages/index.tsx
@@ -14,6 +14,9 @@ const CurrentUserInfo = () => {
 const UserStuff = () => {
   const session = useSession()
   const query = useRouterQuery()
+
+  if (session.isLoading) return <div>Loading...</div>
+
   return (
     <div>
       {!session.userId && (

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -1,5 +1,6 @@
-import {useState, useEffect} from "react"
+import {useState} from "react"
 import BadBehavior from "bad-behavior"
+import {useIsomorphicLayoutEffect} from "./utils/hooks"
 
 export const TOKEN_SEPARATOR = ";"
 export const HANDLE_SEPARATOR = ":"
@@ -140,15 +141,17 @@ publicDataStore.initialize()
 
 export const useSession = () => {
   const [publicData, setPublicData] = useState(emptyPublicData)
+  const [isLoading, setIsLoading] = useState(true)
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     // Initialize on mount
     setPublicData(publicDataStore.getData())
+    setIsLoading(false)
     const subscription = publicDataStore.observable.subscribe(setPublicData)
     return subscription.unsubscribe
   }, [])
 
-  return publicData
+  return {...publicData, isLoading}
 }
 
 // Taken from https://github.com/HenrikJoreteg/cookie-getter

--- a/packages/core/src/utils/hooks.ts
+++ b/packages/core/src/utils/hooks.ts
@@ -1,0 +1,7 @@
+import {useEffect, useLayoutEffect} from "react"
+const isServer = typeof window === "undefined"
+
+// React currently throws a warning when using useLayoutEffect on the server.
+// To get around it, we can conditionally useEffect on the server (no-op) and
+// useLayoutEffect in the browser.
+export const useIsomorphicLayoutEffect = isServer ? useEffect : useLayoutEffect


### PR DESCRIPTION
### What are the changes and their implications?

I am adding the `isReady` piece of state in the `useSession` hook in order to check if the session has been initialised in the component. When using the `useSession` hook and checking for `session.userId`,  I am noticing a flash of unauthenticated view for a couple of milliseconds until the session data becomes available (until useEffect runs and gets the session data from `publicDataStore`). 

 It would be nice to be able to check if the session data is ready and display a loading spinner until the session data is actually available in the hook and decide what to render conditionally afterwards. I have added the usage in the auth example as well.

Dosc PR: https://github.com/blitz-js/blitzjs.com/pull/142