### PR TITLE
Add `.blitz` to modulePathIgnorePatterns in Jest config for new apps

### DIFF
--- a/packages/generator/templates/app/jest.config.js
+++ b/packages/generator/templates/app/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
   },
   // This makes absolute imports work
   moduleDirectories: ["node_modules", "<rootDir>/node_modules", "."],
+  modulePathIgnorePatterns: [".blitz"],
   moduleNameMapper: {
     // This ensures any path aliases in tsconfig also work in jest
     ...pathsToModuleNameMapper(compilerOptions.paths || {}),


### PR DESCRIPTION

### What are the changes and their implications?

Add `.blitz` to modulePathIgnorePatterns in Jest config. Not having this resulted in jest processing files inside `.blitz` which it shouldn't.

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
