### PR TITLE
Fix bug when using same query for usePaginatedQuery and useInfiniteQuery

### DIFF
--- a/packages/core/src/use-infinite-query.ts
+++ b/packages/core/src/use-infinite-query.ts
@@ -37,12 +37,15 @@ export function useInfiniteQuery<T extends QueryFn>(
 
   const {data, ...queryRest} = useInfiniteReactQuery({
     queryKey: [
+      serialize(typeof params === "function" ? (params as Function)() : params),
       queryRpcFn._meta.apiUrl,
       // We add the session object here so queries will refetch if session changes
       useSession(),
-      serialize(typeof params === "function" ? (params as Function)() : params),
+      // we need an extra cache key for infinite loading so that the cache for
+      // for this query is stored separately since the hook result is an array of results. Without this cache for usePaginatedQuery and this will conflict and break.
+      "infinite",
     ],
-    queryFn: (_: string, __: any, params, resultOfGetFetchMore?) =>
+    queryFn: (params, _, __, ___, resultOfGetFetchMore?) =>
       queryRpcFn(params, {fromQueryHook: true, resultOfGetFetchMore}),
     config: {
       suspense: true,

--- a/packages/core/src/use-paginated-query.ts
+++ b/packages/core/src/use-paginated-query.ts
@@ -37,12 +37,12 @@ export function usePaginatedQuery<T extends QueryFn>(
 
   const {resolvedData, ...queryRest} = usePaginatedReactQuery({
     queryKey: [
+      serialize(typeof params === "function" ? (params as Function)() : params),
       queryRpcFn._meta.apiUrl,
       // We add the session object here so queries will refetch if session changes
       useSession(),
-      serialize(typeof params === "function" ? (params as Function)() : params),
     ],
-    queryFn: (_: string, __: any, params) => queryRpcFn(params, {fromQueryHook: true}),
+    queryFn: (params) => queryRpcFn(params, {fromQueryHook: true}),
     config: {
       suspense: true,
       retry: retryFunction,

--- a/packages/core/src/use-query.ts
+++ b/packages/core/src/use-query.ts
@@ -62,12 +62,12 @@ export function useQuery<T extends QueryFn>(
 
   const {data, ...queryRest} = useReactQuery({
     queryKey: [
+      serialize(typeof params === "function" ? (params as Function)() : params),
       queryRpcFn._meta.apiUrl,
       // We add the session object here so queries will refetch if session changes
       useSession(),
-      serialize(typeof params === "function" ? (params as Function)() : params),
     ],
-    queryFn: (_: string, __: any, params) => queryRpcFn(params, {fromQueryHook: true}),
+    queryFn: (params) => queryRpcFn(params, {fromQueryHook: true}),
     config: {
       suspense: true,
       retry: retryFunction,


### PR DESCRIPTION
### What are the changes and their implications?

We discovered a bug via #881 where using the same query for both usePaginatedQuery and useInfiniteQuery would break because the cache of one would be used for the other. That can't work because infiniteQuery returns an array of results but paginatedQuery only return a single result.

Is seems like this should be handled by react-query, but apparently not :)

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
