### PR TITLE
Add pagination to `blitz generate` by default

### DIFF
--- a/packages/generator/templates/page/index.tsx
+++ b/packages/generator/templates/page/index.tsx
@@ -10,7 +10,7 @@ import get__ModelNames__ from "app/__modelNamesPath__/queries/get__ModelNames__"
 export const __ModelNames__List = () => {
   if (process.env.parentModel) {
     const __parentModelId__ = useParam("__parentModelId__", "number")
-    const [__modelNames__] = useQuery(get__ModelNames__, {
+    const [{__modelNames__}] = useQuery(get__ModelNames__, {
       where: {__parentModel__: {id: __parentModelId__}},
       orderBy: {id: "desc"},
     })
@@ -30,7 +30,7 @@ export const __ModelNames__List = () => {
       </ul>
     )
   } else {
-    const [__modelNames__] = useQuery(get__ModelNames__, {orderBy: {id: "desc"}})
+    const [{__modelNames__}] = useQuery(get__ModelNames__, {orderBy: {id: "desc"}})
 
     return (
       <ul>

--- a/packages/generator/templates/page/index.tsx
+++ b/packages/generator/templates/page/index.tsx
@@ -1,50 +1,84 @@
 import React, {Suspense} from "react"
 import Layout from "app/layouts/Layout"
 if (process.env.parentModel) {
-  import {Head, Link, useQuery, useParam, BlitzPage} from "blitz"
+  import {Head, Link, usePaginatedQuery, useRouter, useParam, BlitzPage} from "blitz"
 } else {
-  import {Head, Link, useQuery, BlitzPage} from "blitz"
+  import {Head, Link, usePaginatedQuery, useRouter, BlitzPage} from "blitz"
 }
 import get__ModelNames__ from "app/__modelNamesPath__/queries/get__ModelNames__"
 
+const ITEMS_PER_PAGE = 100
+
 export const __ModelNames__List = () => {
+  const router = useRouter()
+  const page = Number(router.query.page) || 0
   if (process.env.parentModel) {
     const __parentModelId__ = useParam("__parentModelId__", "number")
-    const [{__modelNames__}] = useQuery(get__ModelNames__, {
+    const [{__modelNames__, hasMore}] = usePaginatedQuery(get__ModelNames__, {
       where: {__parentModel__: {id: __parentModelId__}},
-      orderBy: {id: "desc"},
+      orderBy: {id: "asc"},
+      skip: ITEMS_PER_PAGE * page,
+      take: ITEMS_PER_PAGE,
     })
 
-    return (
-      <ul>
-        {__modelNames__.map((__modelName__) => (
-          <li key={__modelName__.id}>
-            <Link
-              href="/__parentModels__/__parentModelParam__/__modelNames__/__modelIdParam__"
-              as={`/__parentModels__/${__parentModelId__}/__modelNames__/${__modelName__.id}`}
-            >
-              <a>{__modelName__.name}</a>
-            </Link>
-          </li>
-        ))}
-      </ul>
-    )
-  } else {
-    const [{__modelNames__}] = useQuery(get__ModelNames__, {orderBy: {id: "desc"}})
+    const goToPreviousPage = () => router.push({query: {page: page - 1}})
+    const goToNextPage = () => router.push({query: {page: page + 1}})
 
     return (
-      <ul>
-        {__modelNames__.map((__modelName__) => (
-          <li key={__modelName__.id}>
-            <Link
-              href="/__modelNames__/__modelIdParam__"
-              as={`/__modelNames__/${__modelName__.id}`}
-            >
-              <a>{__modelName__.name}</a>
-            </Link>
-          </li>
-        ))}
-      </ul>
+      <div>
+        <ul>
+          {__modelNames__.map((__modelName__) => (
+            <li key={__modelName__.id}>
+              <Link
+                href="/__parentModels__/__parentModelParam__/__modelNames__/__modelIdParam__"
+                as={`/__parentModels__/${__parentModelId__}/__modelNames__/${__modelName__.id}`}
+              >
+                <a>{__modelName__.name}</a>
+              </Link>
+            </li>
+          ))}
+        </ul>
+
+        <button disabled={page === 0} onClick={goToPreviousPage}>
+          Previous
+        </button>
+        <button disabled={!hasMore} onClick={goToNextPage}>
+          Next
+        </button>
+      </div>
+    )
+  } else {
+    const [{__modelNames__, hasMore}] = usePaginatedQuery(get__ModelNames__, {
+      orderBy: {id: "asc"},
+      skip: ITEMS_PER_PAGE * page,
+      take: ITEMS_PER_PAGE,
+    })
+
+    const goToPreviousPage = () => router.push({query: {page: page - 1}})
+    const goToNextPage = () => router.push({query: {page: page + 1}})
+
+    return (
+      <div>
+        <ul>
+          {__modelNames__.map((__modelName__) => (
+            <li key={__modelName__.id}>
+              <Link
+                href="/__modelNames__/__modelIdParam__"
+                as={`/__modelNames__/${__modelName__.id}`}
+              >
+                <a>{__modelName__.name}</a>
+              </Link>
+            </li>
+          ))}
+        </ul>
+
+        <button disabled={page === 0} onClick={goToPreviousPage}>
+          Previous
+        </button>
+        <button disabled={!hasMore} onClick={goToNextPage}>
+          Next
+        </button>
+      </div>
     )
   }
 }

--- a/packages/generator/templates/queries/get__ModelNames__.ts
+++ b/packages/generator/templates/queries/get__ModelNames__.ts
@@ -4,15 +4,14 @@ import db, {FindMany__ModelName__Args} from "db"
 type Get__ModelNames__Input = {
   where?: FindMany__ModelName__Args["where"]
   orderBy?: FindMany__ModelName__Args["orderBy"]
-  cursor?: FindMany__ModelName__Args["cursor"]
-  take?: FindMany__ModelName__Args["take"]
   skip?: FindMany__ModelName__Args["skip"]
+  take?: FindMany__ModelName__Args["take"]
   // Only available if a model relationship exists
   // include?: FindMany__ModelName__Args['include']
 }
 
 export default async function get__ModelNames__(
-  {where, orderBy, cursor, take, skip}: Get__ModelNames__Input,
+  {where, orderBy, skip = 0, take}: Get__ModelNames__Input,
   ctx: {session?: SessionContext} = {},
 ) {
   ctx.session!.authorize()
@@ -20,10 +19,17 @@ export default async function get__ModelNames__(
   const __modelNames__ = await db.__modelName__.findMany({
     where,
     orderBy,
-    cursor,
     take,
     skip,
   })
 
-  return __modelNames__
+  const count = await db.__modelName__.count()
+  const hasMore = typeof take === "number" ? skip + take < count : false
+  const nextPage = hasMore ? {take, skip: skip + take!} : null
+
+  return {
+    __modelNames__,
+    nextPage,
+    hasMore,
+  }
 }


### PR DESCRIPTION


### What are the changes and their implications?

Basically everyone will need pagination for model index pages, to this adds it by default to the getModel query and the index page.

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
