### PR TITLE
Return 404 if no default export is found on query or migrations

### DIFF
--- a/packages/server/src/stages/rpc/index.ts
+++ b/packages/server/src/stages/rpc/index.ts
@@ -65,12 +65,16 @@ const isomorhicHandlerTemplate = (
 ) => `
 import {getIsomorphicRpcHandler} from '@blitzjs/core'
 const resolverModule = require('${resolverPath}')
-export default getIsomorphicRpcHandler(
-  resolverModule,
-  '${resolverPath}',
-  '${resolverName}',
-  '${resolverType}',
-) ${useTypes ? "as typeof resolverModule.default" : ""}
+export default resolverModule.default 
+  ? getIsomorphicRpcHandler(
+      resolverModule,
+      '${resolverPath}',
+      '${resolverName}',
+      '${resolverType}',
+    ) ${useTypes ? "as typeof resolverModule.default" : ""}
+  : function notFoundHandler(_req, res) {
+      res.status(404).end()
+    }
 `
 
 // Clarification: try/catch around db is to prevent query errors when not using blitz's inbuilt database (See #572)
@@ -93,11 +97,15 @@ try {
   db = require('db').default
   connect = require('db').connect ?? (() => db.$connect ? db.$connect() : db.connect())
 }catch(err){}
-export default rpcApiHandler(
-  resolverModule,
-  getAllMiddlewareForModule(resolverModule),
-  () => db && connect(),
-)
+export default resolverModule.default 
+  ? rpcApiHandler(
+      resolverModule,
+      getAllMiddlewareForModule(resolverModule),
+      () => db && connect(),
+    )
+  : function notFoundHandler(_req, res) {
+      res.status(404).end()
+    }
 export const config = {
   api: {
     externalResolver: true,


### PR DESCRIPTION
Closes: #957 

### What are the changes and their implications?

This PR changes the default behavior of the `isomorhicHandlerTemplate` and  `apiHandlerTemplate` to return 404 when there's no default export from a query or a mutation.

### Checklist

- [ ] Tests added for changes
- [X] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
