### PR TITLE
Upgrade environment variable support to match Next.js (use dotenv-flow)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,7 @@ tsconfig.tsbuildinfo
 dist
 .now
 # local env files
-**/.envrc
-**/.env
 **/.env.local
-**/.env.development.local
-**/.env.test.local
-**/.env.production.local
+**/.env.*.local
+**/.envrc
 .blitz-*

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/debug": "4.1.5",
     "@types/detect-port": "1.3.0",
     "@types/diff": "4.0.2",
+    "@types/dotenv-flow": "3.0.1",
     "@types/flush-write-stream": "1.0.0",
     "@types/from2": "2.3.0",
     "@types/fs-extra": "8.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "chalk": "4.0.0",
     "cross-spawn": "7.0.3",
     "dotenv-flow": "3.2.0",
+    "dotenv-expand": "5.1.0",
     "enquirer": "2.3.4",
     "got": "11.1.3",
     "has-yarn": "2.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
     "camelcase": "6.0.0",
     "chalk": "4.0.0",
     "cross-spawn": "7.0.3",
-    "dotenv": "8.2.0",
+    "dotenv-flow": "3.2.0",
     "enquirer": "2.3.4",
     "got": "11.1.3",
     "has-yarn": "2.1.0",

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -104,7 +104,7 @@ export class New extends Command {
 
         try {
           // Required in order for DATABASE_URL to be available
-          require("dotenv-flow").config({silent: true})
+          require("dotenv-expand")(require("dotenv-flow").config({silent: true}))
           await Db.run(["migrate", "--name", "Initial Migration"])
           spinner.succeed()
         } catch {

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -104,7 +104,7 @@ export class New extends Command {
 
         try {
           // Required in order for DATABASE_URL to be available
-          require("dotenv").config()
+          require("dotenv-flow").config({silent: true})
           await Db.run(["migrate", "--name", "Initial Migration"])
           spinner.succeed()
         } catch {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 import {run as oclifRun} from "@oclif/command"
 
 // Load the .env environment variable so it's available for all commands
-require("dotenv-flow").config({silent: true})
+require("dotenv-expand")(require("dotenv-flow").config({silent: true}))
 
 export function run() {
   oclifRun()

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 import {run as oclifRun} from "@oclif/command"
 
 // Load the .env environment variable so it's available for all commands
-require("dotenv").config()
+require("dotenv-flow").config({silent: true})
 
 export function run() {
   oclifRun()

--- a/packages/generator/.gitignore
+++ b/packages/generator/.gitignore
@@ -12,4 +12,4 @@ tmp
 # good directory to use for testing app generation
 _app
 
-!templates/**/.env
+!templates/**/.env*

--- a/packages/generator/templates/app/.env
+++ b/packages/generator/templates/app/.env
@@ -1,0 +1,2 @@
+# This env file should be checked into source control
+# This is the place for default values that should be used in all environments

--- a/packages/generator/templates/app/.env
+++ b/packages/generator/templates/app/.env
@@ -1,6 +1,0 @@
-# THIS FILE SHOULD NOT BE CHECKED INTO YOUR VERSION CONTROL SYSTEM
-
-# SQLite is ready to go out of the box, but you can switch to Postgres easily
-# by swapping the DATABASE_URL.
-DATABASE_URL="file:./db.sqlite"
-# DATABASE_URL=postgresql://__username__@localhost:5432/__name__

--- a/packages/generator/templates/app/.env.local
+++ b/packages/generator/templates/app/.env.local
@@ -1,0 +1,7 @@
+# This env file should NOT be checked into source control
+# This is the place for values that changed for every developer
+
+# SQLite is ready to go out of the box, but you can switch to Postgres easily
+# by swapping the DATABASE_URL.
+DATABASE_URL="file:./db.sqlite"
+# DATABASE_URL=postgresql://__username__@localhost:5432/__name__

--- a/packages/generator/templates/app/.env.test.local
+++ b/packages/generator/templates/app/.env.test.local
@@ -1,0 +1,6 @@
+# THIS FILE SHOULD NOT BE CHECKED INTO YOUR VERSION CONTROL SYSTEM
+
+# SQLite is ready to go out of the box, but you can switch to Postgres easily
+# by swapping the DATABASE_URL.
+DATABASE_URL="file:./db_test.sqlite"
+# DATABASE_URL=postgresql://__username__@localhost:5432/__name___test

--- a/packages/generator/templates/app/README.md
+++ b/packages/generator/templates/app/README.md
@@ -2,7 +2,7 @@
 
 This is a [Blitz.js](https://github.com/blitz-js/blitz) app.
 
-# __name__
+# **name**
 
 ## Getting Started
 
@@ -13,6 +13,20 @@ blitz start
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+## Environment Variables
+
+Ensure the `.env.local` file has required environment variables:
+
+```
+DATABASE_URL=postgresql://<YOUR_DB_USERNAME>@localhost:5432/__name__
+```
+
+Ensure the `.env.test.local` file has required environment variables:
+
+```
+DATABASE_URL=postgresql://<YOUR_DB_USERNAME>@localhost:5432/__name___test
+```
 
 ## Tests
 

--- a/packages/generator/templates/app/gitignore
+++ b/packages/generator/templates/app/gitignore
@@ -19,12 +19,9 @@ blitz-log.log
 .DS_Store
 
 # local env files
-.env
-.envrc
 .env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env.*.local
+.envrc
 
 # Logs
 logs

--- a/yarn.lock
+++ b/yarn.lock
@@ -3796,6 +3796,11 @@
   resolved "https://registry.yarnpkg.com/@types/diff/-/diff-4.0.2.tgz#2e9bb89f9acc3ab0108f0f3dc4dbdcf2fff8a99c"
   integrity sha512-mIenTfsIe586/yzsyfql69KRnA75S8SVXQbTLpDejRrjH0QSJcpu3AUOi/Vjnt9IOsXKxPhJfGpQUNMueIU1fQ==
 
+"@types/dotenv-flow@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/dotenv-flow/-/dotenv-flow-3.0.1.tgz#28e7884aed155cb7561691fe6684ce47c1eb1ce1"
+  integrity sha512-+HD2z/1kVDPk9s85HdK8jmYvW+B2SqpUzfpz8nZdpy+NXY/+ixcxeD2dAUn2tVaj/8t04lMwPO+Zfh0tbQkCjQ==
+
 "@types/duplexify@*":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@types/duplexify/-/duplexify-3.6.0.tgz#dfc82b64bd3a2168f5bd26444af165bf0237dcd8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7908,6 +7908,11 @@ dot-prop@^4.1.0, dot-prop@^4.2.0:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv-expand@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
+  integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
+
 dotenv-flow@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/dotenv-flow/-/dotenv-flow-3.2.0.tgz#a5d79dd60ddb6843d457a4874aaf122cf659a8b7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7908,7 +7908,14 @@ dot-prop@^4.1.0, dot-prop@^4.2.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@8.2.0:
+dotenv-flow@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv-flow/-/dotenv-flow-3.2.0.tgz#a5d79dd60ddb6843d457a4874aaf122cf659a8b7"
+  integrity sha512-GEB6RrR4AbqDJvNSFrYHqZ33IKKbzkvLYiD5eo4+9aFXr4Y4G+QaFrB/fNp0y6McWBmvaPn3ZNjIufnj8irCtg==
+  dependencies:
+    dotenv "^8.0.0"
+
+dotenv@^8.0.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==


### PR DESCRIPTION
Closes: #953 

### What are the changes and their implications?

Changes environment variable support to match Next.js via the [dotenv-flow](https://github.com/kerimdzhanov/dotenv-flow) library.

Additionally, this changes new apps to track `.env` via git but not `.env.local`. This is the recommended approach with Next.js and dotenv-flow.

### Checklist

- ~[ ] Tests added for changes~
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes: https://github.com/blitz-js/blitzjs.com/pull/147

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
