### PR TITLE
fix(app-generator): init git repo prior to install

### DIFF
--- a/packages/generator/src/generators/app-generator.ts
+++ b/packages/generator/src/generators/app-generator.ts
@@ -88,6 +88,17 @@ export class AppGenerator extends Generator<AppGeneratorOptions> {
   }
 
   async postWrite() {
+    let initResult
+    if (!this.options.skipGit) {
+      initResult = spawn.sync("git", ["init"], {
+        stdio: "ignore",
+      })
+
+      if (initResult.status !== 0) {
+        log.warning("Failed to run git init.")
+        log.warning("Find out more about how to install git here: https://git-scm.com/downloads.")
+      }
+    }
     const pkgJsonLocation = join(this.destinationPath(), "package.json")
     const pkg = readJSONSync(pkgJsonLocation)
 
@@ -212,15 +223,8 @@ export class AppGenerator extends Generator<AppGeneratorOptions> {
     }
 
     if (!this.options.skipGit) {
-      const initResult = spawn.sync("git", ["init"], {
-        stdio: "ignore",
-      })
-
-      if (initResult.status === 0) {
+      if (initResult?.status === 0) {
         this.commitChanges()
-      } else {
-        log.warning("Failed to run git init.")
-        log.warning("Find out more about how to install git here: https://git-scm.com/downloads.")
       }
     }
   }


### PR DESCRIPTION
Initializes the git repo before it installs the dependencies,
ensuring that the husky hooks get properly set.

Fixes #973

