### PR TITLE
Fix some cache key issues with `useQuery`

### DIFF
--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -1,6 +1,7 @@
 import {useState} from "react"
 import BadBehavior from "bad-behavior"
 import {useIsomorphicLayoutEffect} from "./utils/hooks"
+import {queryCache} from "react-query"
 
 export const TOKEN_SEPARATOR = ";"
 export const HANDLE_SEPARATOR = ":"
@@ -154,6 +155,7 @@ export const publicDataStore = {
   },
   clear() {
     deleteCookie(COOKIE_PUBLIC_DATA_TOKEN)
+    queryCache.clear()
     this.updateState()
   },
 }

--- a/packages/core/src/use-paginated-query.ts
+++ b/packages/core/src/use-paginated-query.ts
@@ -3,12 +3,10 @@ import {
   PaginatedQueryResult,
   QueryOptions,
 } from "react-query"
-import {useSession} from "./supertokens"
 import {useIsDevPrerender, emptyQueryFn, retryFunction} from "./use-query"
 import {PromiseReturnType, InferUnaryParam, QueryFn} from "./types"
-import {QueryCacheFunctions, getQueryCacheFunctions} from "./utils/query-cache"
+import {QueryCacheFunctions, getQueryCacheFunctions, getQueryKey} from "./utils/query-cache"
 import {EnhancedRpcFunction} from "./rpc"
-import {serialize} from "superjson"
 
 type RestQueryResult<T extends QueryFn> = Omit<
   PaginatedQueryResult<PromiseReturnType<T>>,
@@ -35,14 +33,11 @@ export function usePaginatedQuery<T extends QueryFn>(
     ? emptyQueryFn
     : ((queryFn as unknown) as EnhancedRpcFunction)
 
+  const queryKey = getQueryKey(queryFn, params)
+
   const {resolvedData, ...queryRest} = usePaginatedReactQuery({
-    queryKey: [
-      serialize(typeof params === "function" ? (params as Function)() : params),
-      queryRpcFn._meta.apiUrl,
-      // We add the session object here so queries will refetch if session changes
-      useSession(),
-    ],
-    queryFn: (params) => queryRpcFn(params, {fromQueryHook: true}),
+    queryKey,
+    queryFn: (_apiUrl, params) => queryRpcFn(params, {fromQueryHook: true}),
     config: {
       suspense: true,
       retry: retryFunction,
@@ -52,7 +47,7 @@ export function usePaginatedQuery<T extends QueryFn>(
 
   const rest = {
     ...queryRest,
-    ...getQueryCacheFunctions<PromiseReturnType<T>>(queryRpcFn._meta.apiUrl),
+    ...getQueryCacheFunctions<PromiseReturnType<T>>(queryKey),
   }
 
   return [resolvedData as PromiseReturnType<T>, rest as RestQueryResult<T>]

--- a/packages/core/src/utils/query-cache.ts
+++ b/packages/core/src/utils/query-cache.ts
@@ -1,4 +1,7 @@
-import {queryCache} from "react-query"
+import {queryCache, QueryKey} from "react-query"
+import {serialize} from "superjson"
+import {InferUnaryParam, QueryFn} from "../types"
+import {EnhancedRpcFunction} from "rpc"
 
 type MutateOptions = {
   refetch?: boolean
@@ -8,7 +11,7 @@ export interface QueryCacheFunctions<T> {
   mutate: (newData: T | ((oldData: T | undefined) => T), opts?: MutateOptions) => void
 }
 
-export const getQueryCacheFunctions = <T>(queryKey: string): QueryCacheFunctions<T> => ({
+export const getQueryCacheFunctions = <T>(queryKey: QueryKey<any>): QueryCacheFunctions<T> => ({
   mutate: (newData, opts = {refetch: true}) => {
     queryCache.setQueryData(queryKey, newData)
     if (opts.refetch) {
@@ -17,3 +20,46 @@ export const getQueryCacheFunctions = <T>(queryKey: string): QueryCacheFunctions
     return null
   },
 })
+
+export function getQueryKey<T extends QueryFn>(
+  queryFn: T,
+  params: InferUnaryParam<T> | (() => InferUnaryParam<T>),
+) {
+  if (typeof queryFn === "undefined") {
+    throw new Error("getQueryKey is missing the first argument - it must be a query function")
+  }
+  if (typeof params === "undefined") {
+    throw new Error(
+      "getQueryKey is missing the second argument. This will be the input to your query function on the server. Pass `null` if the query function doesn't take any arguments",
+    )
+  }
+
+  const queryKey: [string, Record<string, any>] = [
+    ((queryFn as unknown) as EnhancedRpcFunction)._meta.apiUrl,
+    serialize(typeof params === "function" ? (params as Function)() : params),
+  ]
+  return queryKey
+}
+
+export function getInfiniteQueryKey<T extends QueryFn>(
+  queryFn: T,
+  params: InferUnaryParam<T> | (() => InferUnaryParam<T>),
+) {
+  if (typeof queryFn === "undefined") {
+    throw new Error("getQueryKey is missing the first argument - it must be a query function")
+  }
+  if (typeof params === "undefined") {
+    throw new Error(
+      "getQueryKey is missing the second argument. This will be the input to your query function on the server. Pass `null` if the query function doesn't take any arguments",
+    )
+  }
+
+  const queryKey: ["infinite", string, Record<string, any>] = [
+    // we need an extra cache key for infinite loading so that the cache for
+    // for this query is stored separately since the hook result is an array of results. Without this cache for usePaginatedQuery and this will conflict and break.
+    "infinite",
+    ((queryFn as unknown) as EnhancedRpcFunction)._meta.apiUrl,
+    serialize(typeof params === "function" ? (params as Function)() : params),
+  ]
+  return queryKey
+}


### PR DESCRIPTION
### What are the changes and their implications?

In my last update to useQuery, I messed a few things up. This fixes those.

1. Remove `session` from the cache keys, and instead use `queryCache.clear()` when a session expires
2. Fix order of cache keys (query URL should be first, then params second)
3. Use exact cache key for `mutate()`. I broke it in the last release. But even before that it only used the query URL as the cache key which could cause problems in certain cases.

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
