### PR TITLE
Fix CI by removing browser setting for cypress

### DIFF
--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts,.tsx .",
     "analyze": "cross-env ANALYZE=true blitz build",
     "cy:open": "cypress open",
-    "cy:run": "cypress run --browser chrome",
+    "cy:run": "cypress run",
     "test:start": "blitz db migrate && blitz start --production -p 3099",
     "test": "cross-env NODE_ENV=test start-server-and-test test:start http://localhost:3099 cy:run"
   },


### PR DESCRIPTION


### What are the changes and their implications?

Fix CI by removing browser setting for cypress. Apparently github windows runners just stopped having chrome installed.