### PR TITLE
Fix Heroku issue where `blitz start --production` always rebuilds even after running `blitz build`

### DIFF
--- a/packages/server/src/build-hash.ts
+++ b/packages/server/src/build-hash.ts
@@ -5,7 +5,17 @@ import {resolve} from "path"
 export async function getInputArtefactsHash() {
   const options = {
     algo: "md5",
-    folders: {exclude: ["node_modules", ".blitz-build", ".blitz", "cypress", ".next"]},
+    folders: {
+      exclude: [
+        "node_modules",
+        ".blitz-build",
+        ".blitz",
+        "cypress",
+        ".next",
+        ".heroku",
+        ".profile.d",
+      ],
+    },
   }
   const tree = await hashElement(".", options)
   return tree.hash


### PR DESCRIPTION
Closes: #861 

### What are the changes and their implications?
Fixes heroku rebuilding app when running start command by ignoring `.heroku` and `.profile.d` folders in artefacts hash.

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
