### PR TITLE
Fix `ctx.session.authorize()` throwing AuthorizationError instead of AuthenticationError if user logged out. (#1030) 

### DIFF
--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -197,6 +197,8 @@ export class SessionContextClass implements SessionContext {
   }
 
   authorize(input?: any) {
+    if (!this.userId) throw new AuthenticationError()
+
     if (!this.isAuthorized(input)) {
       throw new AuthorizationError()
     }


### PR DESCRIPTION


### What are the changes and their implications?

Fix `ctx.session.authorize()` throwing AuthorizationError instead of AuthenticationError if user logged out.

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
