### PR TITLE
Fix: export `AppProps` as a generic type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import {NextPage, NextComponentType} from "next"
+import {NextPage, NextComponentType, NextPageContext} from "next"
 import {AppProps as NextAppProps} from "next/app"
 
 export * from "./use-query"
@@ -49,10 +49,10 @@ export {default as dynamic} from "next/dynamic"
 
 export {default as ErrorComponent} from "next/error"
 
-export type BlitzComponentType = NextComponentType
+export type BlitzComponentType<C = NextPageContext, IP = {}, P = {}> = NextComponentType<C, IP, P>
 
-export interface AppProps extends NextAppProps {
-  Component: BlitzComponentType & {
+export interface AppProps<P = {}> extends NextAppProps<P> {
+  Component: BlitzComponentType<NextPageContext, any, P> & {
     getLayout?: (component: JSX.Element) => JSX.Element
   }
 }


### PR DESCRIPTION
### What are the changes and their implications?
Exports AppProps type as a generic type.

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
