### PR TITLE
Significantly improve CLI performance: reduce execute time from 1700ms  -> 900ms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dist
 **/.env.*.local
 **/.envrc
 .blitz-*
+.blitz-cli-cache

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,9 @@
     "rimraf": "3.0.2",
     "tar": "6.0.2",
     "ts-node": "8.9.0",
-    "tsconfig-paths": "3.9.0"
+    "tsconfig-paths": "3.9.0",
+    "@salesforce/lazy-require": "0.3.2",
+    "v8-compile-cache": "2.1.1"
   },
   "devDependencies": {
     "@blitzjs/generator": "0.22.1",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,6 +1,4 @@
 import {Command} from "@oclif/command"
-import {build} from "@blitzjs/server"
-import {runPrismaGeneration} from "./db"
 
 export class Build extends Command {
   static description = "Create a production build"
@@ -12,7 +10,10 @@ export class Build extends Command {
     }
 
     try {
-      await build(config, runPrismaGeneration({silent: true, failSilently: true}))
+      await require("@blitzjs/server").build(
+        config,
+        require("./db").runPrismaGeneration({silent: true, failSilently: true}),
+      )
     } catch (err) {
       console.error(err)
       process.exit(1) // clean up?

--- a/packages/cli/src/commands/console.ts
+++ b/packages/cli/src/commands/console.ts
@@ -1,16 +1,7 @@
-import {runRepl} from "@blitzjs/repl"
 import {Command} from "@oclif/command"
-import path from "path"
-import fs from "fs"
-import pkgDir from "pkg-dir"
-import {log} from "@blitzjs/display"
-import chalk from "chalk"
 
-import {setupTsnode} from "../utils/setup-ts-node"
-import {runPrismaGeneration} from "./db"
-
-const projectRoot = pkgDir.sync() || process.cwd()
-const isTypescript = fs.existsSync(path.join(projectRoot, "tsconfig.json"))
+const projectRoot = require("pkg-dir").sync() || process.cwd()
+const isTypescript = require("fs").existsSync(require("path").join(projectRoot, "tsconfig.json"))
 
 export class Console extends Command {
   static description = "Run the Blitz console REPL"
@@ -22,6 +13,8 @@ export class Console extends Command {
   }
 
   async run() {
+    const {log} = require("@blitzjs/display")
+    const chalk = require("chalk")
     log.branded("You have entered the Blitz console")
     console.log(chalk.yellow("Tips: - Exit by typing .exit or pressing Ctrl-D"))
     console.log(chalk.yellow("      - Use your db like this: await db.project.findMany()"))
@@ -29,12 +22,12 @@ export class Console extends Command {
 
     const spinner = log.spinner("Loading your code").start()
     if (isTypescript) {
-      setupTsnode()
+      require("../utils/setup-ts-node").setupTsnode()
     }
 
-    await runPrismaGeneration({silent: true, failSilently: true})
+    await require("./db").runPrismaGeneration({silent: true, failSilently: true})
     spinner.succeed()
 
-    runRepl(Console.replOptions)
+    require("@blitzjs/repl").runRepl(Console.replOptions)
   }
 }

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,9 +1,6 @@
 import {Command} from "../command"
 import {flags} from "@oclif/command"
-import * as fs from "fs"
-import * as path from "path"
-import enquirer from "enquirer"
-import _pluralize from "pluralize"
+import {log} from "@blitzjs/display"
 import {
   PageGenerator,
   MutationGenerator,
@@ -13,15 +10,13 @@ import {
   QueryGenerator,
 } from "@blitzjs/generator"
 import {PromptAbortedError} from "../errors/prompt-aborted"
-import {log} from "@blitzjs/display"
-import camelCase from "camelcase"
-import pkgDir from "pkg-dir"
+
 const debug = require("debug")("blitz:generate")
-
-const pascalCase = (str: string) => camelCase(str, {pascalCase: true})
-
-const projectRoot = pkgDir.sync() || process.cwd()
-const isTypescript = fs.existsSync(path.join(projectRoot, "tsconfig.json"))
+const pascalCase = (str: string) => require("camelcase")(str, {pascalCase: true})
+const getIsTypescript = () =>
+  require("fs").existsSync(
+    require("path").join(require("../utils/get-project-root").projectRoot, "tsconfig.json"),
+  )
 
 enum ResourceType {
   All = "all",
@@ -46,18 +41,18 @@ interface Args {
 }
 
 function pluralize(input: string): string {
-  return _pluralize.isPlural(input) ? input : _pluralize.plural(input)
+  return require("pluralize").isPlural(input) ? input : require("pluralize").plural(input)
 }
 
 function singular(input: string): string {
-  return _pluralize.isSingular(input) ? input : _pluralize.singular(input)
+  return require("pluralize").isSingular(input) ? input : require("pluralize").singular(input)
 }
 
 function modelName(input: string = "") {
-  return camelCase(singular(input))
+  return require("camelcase")(singular(input))
 }
 function modelNames(input: string = "") {
-  return camelCase(pluralize(input))
+  return require("camelcase")(pluralize(input))
 }
 function ModelName(input: string = "") {
   return pascalCase(singular(input))
@@ -157,31 +152,33 @@ export class Generate extends Command {
   ]
 
   async promptForTargetDirectory(paths: string[]): Promise<string> {
-    return enquirer
-      .prompt<{directory: string}>({
+    return require("enquirer")
+      .prompt({
         name: "directory",
         type: "select",
         message: "Please select a target directory:",
         choices: paths,
       })
-      .then((resp) => resp.directory)
+      .then((resp: any) => resp.directory)
   }
 
   async genericConfirmPrompt(message: string): Promise<boolean> {
-    return enquirer
-      .prompt<{continue: string}>({
+    return require("enquirer")
+      .prompt({
         name: "continue",
         type: "select",
         message: message,
         choices: ["Yes", "No"],
       })
-      .then((resp) => resp.continue === "Yes")
+      .then((resp: any) => resp.continue === "Yes")
   }
 
   async handleNoContext(message: string): Promise<void> {
     const shouldCreateNewRoot = await this.genericConfirmPrompt(message)
     if (!shouldCreateNewRoot) {
-      log.error("Could not determine proper location for files. Aborting.")
+      require("@blitzjs/display").log.error(
+        "Could not determine proper location for files. Aborting.",
+      )
       this.exit(0)
     }
   }
@@ -192,7 +189,7 @@ export class Generate extends Command {
     if (modelSegments.length > 1) {
       return {
         model: modelSegments[modelSegments.length - 1],
-        context: path.join(...modelSegments.slice(0, modelSegments.length - 1)),
+        context: require("path").join(...modelSegments.slice(0, modelSegments.length - 1)),
       }
     }
 
@@ -201,7 +198,7 @@ export class Generate extends Command {
 
       return {
         model: modelName,
-        context: path.join(...contextSegments),
+        context: require("path").join(...contextSegments),
       }
     }
 
@@ -222,7 +219,7 @@ export class Generate extends Command {
       const generators = generatorMap[args.type]
       for (const GeneratorClass of generators) {
         const generator = new GeneratorClass({
-          destinationRoot: path.resolve(),
+          destinationRoot: require("path").resolve(),
           extraArgs: argv.slice(2).filter((arg) => !arg.startsWith("-")),
           modelName: singularRootContext,
           modelNames: modelNames(singularRootContext),
@@ -234,7 +231,7 @@ export class Generate extends Command {
           ParentModels: ModelNames(flags.parent),
           dryRun: flags["dry-run"],
           context: context,
-          useTs: isTypescript,
+          useTs: getIsTypescript(),
         })
         await generator.run()
       }

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -8,7 +8,7 @@ import {promisify} from "util"
 const pipeline = promisify(Stream.pipeline)
 
 async function got(url: string) {
-  return require("got")(url).catch((e) => Boolean(console.error(e)) || e)
+  return require("got")(url).catch((e: any) => Boolean(console.error(e)) || e)
 }
 
 async function gotJSON(url: string) {

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -1,14 +1,11 @@
-import * as path from "path"
 import {flags} from "@oclif/command"
 import {Command} from "../command"
-import {AppGenerator, AppGeneratorOptions} from "@blitzjs/generator"
+import type {AppGeneratorOptions} from "@blitzjs/generator"
 import chalk from "chalk"
 import hasbin from "hasbin"
 import {log} from "@blitzjs/display"
 const debug = require("debug")("blitz:new")
-
 import {PromptAbortedError} from "../errors/prompt-aborted"
-import {Db} from "./db"
 
 export interface Flags {
   ts: boolean
@@ -60,8 +57,8 @@ export class New extends Command {
     debug("flags: ", flags)
 
     try {
-      const destinationRoot = path.resolve(args.name)
-      const appName = path.basename(destinationRoot)
+      const destinationRoot = require("path").resolve(args.name)
+      const appName = require("path").basename(destinationRoot)
 
       const formChoices: Array<{name: AppGeneratorOptions["form"]; message?: string}> = [
         {name: "React Final Form", message: "React Final Form (recommended)"},
@@ -78,7 +75,7 @@ export class New extends Command {
 
       const {"dry-run": dryRun, "skip-install": skipInstall, npm} = flags
 
-      const generator = new AppGenerator({
+      const generator = new (require("@blitzjs/generator").AppGenerator)({
         destinationRoot,
         appName,
         dryRun,
@@ -105,7 +102,7 @@ export class New extends Command {
         try {
           // Required in order for DATABASE_URL to be available
           require("dotenv-expand")(require("dotenv-flow").config({silent: true}))
-          await Db.run(["migrate", "--name", "Initial Migration"])
+          await require("./db").Db.run(["migrate", "--name", "Initial Migration"])
           spinner.succeed()
         } catch {
           spinner.fail()

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,6 +1,5 @@
 import {dev, prod} from "@blitzjs/server"
 import {Command, flags} from "@oclif/command"
-import {runPrismaGeneration} from "./db"
 
 export class Start extends Command {
   static description = "Start a development server"
@@ -31,9 +30,9 @@ export class Start extends Command {
 
     try {
       if (flags.production) {
-        await prod(config, runPrismaGeneration({silent: true, failSilently: true}))
+        await prod(config, require("./db").runPrismaGeneration({silent: true, failSilently: true}))
       } else {
-        await dev(config, runPrismaGeneration({silent: true, failSilently: true}))
+        await dev(config, require("./db").runPrismaGeneration({silent: true, failSilently: true}))
       }
     } catch (err) {
       console.error(err)

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,6 +1,5 @@
 import {spawn} from "cross-spawn"
 import {Command} from "@oclif/command"
-import hasYarn from "has-yarn"
 
 export class Test extends Command {
   static description = "Run project tests"
@@ -20,7 +19,7 @@ export class Test extends Command {
     if (watch) {
       watchMode = watch === "watch" || watch === "w"
     }
-    const packageManager = hasYarn() ? "yarn" : "npm"
+    const packageManager = require("has-yarn")() ? "yarn" : "npm"
 
     if (watchMode) spawn(packageManager, ["test:watch"], {stdio: "inherit"})
     else spawn(packageManager, ["test"], {stdio: "inherit"})

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,6 @@
 import {run as oclifRun} from "@oclif/command"
+const lazyLoad = require("@salesforce/lazy-require").default.create(".blitz-cli-cache")
+lazyLoad.start()
 
 // Load the .env environment variable so it's available for all commands
 require("dotenv-expand")(require("dotenv-flow").config({silent: true}))

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
-import {run as oclifRun} from "@oclif/command"
+require("v8-compile-cache")
 const lazyLoad = require("@salesforce/lazy-require").default.create(".blitz-cli-cache")
 lazyLoad.start()
+import {run as oclifRun} from "@oclif/command"
 
 // Load the .env environment variable so it's available for all commands
 require("dotenv-expand")(require("dotenv-flow").config({silent: true}))

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -10,6 +10,7 @@
     "sourceMap": false,
     "esModuleInterop": true,
     "types": [],
+    "noEmit": false,
     "lib": ["dom", "dom.iterable", "ES2018"]
   },
   "include": ["src/**/*", "types"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noEmit": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3649,6 +3649,14 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@salesforce/lazy-require@0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/lazy-require/-/lazy-require-0.3.2.tgz#0d3b5a697e639a4b2357c9b18d6dd883a620c57c"
+  integrity sha512-T1M9mcf9CYBihe4kYwnOuuGS32Eg4mjqZbto5gXJi1qQxmG/zdrQ6pv5zHD8nfbZb1d1hQzTW0y+cCvwcWV6qw==
+  dependencies:
+    debug "^3.2.6"
+    tslib "^1.10.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -18512,7 +18520,7 @@ tslib@1.11.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tslib@^1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
@@ -18980,7 +18988,7 @@ uuid@^7.0.2, uuid@^7.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
-v8-compile-cache@^2.0.3:
+v8-compile-cache@2.1.1, v8-compile-cache@^2.0.3:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
   integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==


### PR DESCRIPTION
### What are the changes and their implications?

This brings the command runtime down to around 900ms from 1700ms by doing the following:
- Use v8 compile cache
- Convert top level imports to just-in-time require()s
- Lazy require modules, so only the part of the module you are using is loaded.

This also fixes a big hangup in `blitz console` where you couldn't type anything for several seconds.


Something else we can do at some point is to snapshot heap memory, same as Electron does.

### Checklist

- ~[ ] Tests added for changes~
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
