### PR TITLE
Fix `blitz generate query` does not preserve plurality

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -232,6 +232,7 @@ export class Generate extends Command {
           parentModels: modelNames(flags.parent),
           ParentModel: ModelName(flags.parent),
           ParentModels: ModelNames(flags.parent),
+          rawInput: model,
           dryRun: flags["dry-run"],
           context: context,
           useTs: isTypescript,

--- a/packages/generator/src/generators/query-generator.ts
+++ b/packages/generator/src/generators/query-generator.ts
@@ -2,7 +2,7 @@ import {Generator, GeneratorOptions} from "../generator"
 import {join} from "path"
 
 export interface QueryGeneratorOptions extends GeneratorOptions {
-  modelName: string
+  rawInput: string
 }
 
 export class QueryGenerator extends Generator<QueryGeneratorOptions> {
@@ -12,7 +12,7 @@ export class QueryGenerator extends Generator<QueryGeneratorOptions> {
   // eslint-disable-next-line require-await
   async getTemplateValues() {
     return {
-      modelName: this.options.modelName,
+      rawInput: this.options.rawInput,
     }
   }
 

--- a/packages/generator/templates/query/__modelName__.ts
+++ b/packages/generator/templates/query/__modelName__.ts
@@ -1,6 +1,0 @@
-import {SessionContext} from "blitz"
-import db from "db"
-
-export default async function __modelName__(__, ctx: {session?: SessionContext} = {}) {
-  return ctx
-}

--- a/packages/generator/templates/query/__rawInput__.ts
+++ b/packages/generator/templates/query/__rawInput__.ts
@@ -1,0 +1,6 @@
+import {SessionContext} from "blitz"
+import db from "db"
+
+export default async function __rawInput__(__, ctx: {session?: SessionContext} = {}) {
+  return ctx
+}


### PR DESCRIPTION
…use this rawInput as its templateValue.

Closes: https://github.com/blitz-js/blitz/issues/1032

### What are the changes and their implications?
The queryGenerator was using modelName which did not preserve plurality. `blitz generate query getProjects` created a query with the name `getProject.ts`. 

Using the rawInput creates the correct file- and functionName.
