### PR TITLE
Fix `blitz generate pages` to use kebab-case for all url paths

### DIFF
--- a/packages/generator/src/generators/page-generator.ts
+++ b/packages/generator/src/generators/page-generator.ts
@@ -1,5 +1,6 @@
 import {Generator, GeneratorOptions} from "../generator"
 import {join} from "path"
+import {camelCaseToKebabCase} from "../utils/kebab-case"
 
 export interface PageGeneratorOptions extends GeneratorOptions {
   ModelName: string
@@ -51,9 +52,10 @@ export class PageGenerator extends Generator<PageGeneratorOptions> {
   }
 
   getTargetDirectory() {
+    const kebabCaseModelName = camelCaseToKebabCase(this.options.modelNames)
     const parent = this.options.parentModels
       ? `${this.options.parentModels}/__parentModelParam__/`
       : ""
-    return `app/${this.getModelNamesPath()}/pages/${parent}${this.options.modelNames}`
+    return `app/${this.getModelNamesPath()}/pages/${parent}${kebabCaseModelName}`
   }
 }

--- a/packages/generator/src/utils/kebab-case.ts
+++ b/packages/generator/src/utils/kebab-case.ts
@@ -1,0 +1,3 @@
+export function camelCaseToKebabCase(transformString: string) {
+  return transformString.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, "$1-$2").toLowerCase()
+}

--- a/packages/generator/test/utils/kebab-case.test.ts
+++ b/packages/generator/test/utils/kebab-case.test.ts
@@ -1,0 +1,31 @@
+import {camelCaseToKebabCase} from "../../src/utils/kebab-case"
+
+describe("kebabCase utility function", () => {
+  describe("transform a camelCase string to kebab case", () => {
+    it("works for 2 word camelCase", () => {
+      const result = camelCaseToKebabCase("testResult")
+
+      expect(result).toBe("test-result")
+    })
+
+    it("works for multiple camelCase words", () => {
+      const result = camelCaseToKebabCase("longTestStringResult")
+
+      expect(result).toBe("long-test-string-result")
+    })
+  })
+
+  describe("do not transform strings that are not camelCase", () => {
+    it("does not modify a kebabCase string", () => {
+      const result = camelCaseToKebabCase("test-result")
+
+      expect(result).toBe("test-result")
+    })
+
+    it("does not modify single word string", () => {
+      const result = camelCaseToKebabCase("testresult")
+
+      expect(result).toBe("testresult")
+    })
+  })
+})


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1022

### What are the changes and their implications?
If you run `blitz generate pages testResult` right now the generated URLs for this would container `testResult`. For better SEO all urls should be kebab-case. Running the above command now generates the URLs in kebab-case form (`test-result`).