### PR TITLE
Change the new app schema provider to be just `sqlite` instead of an array

### DIFF
--- a/packages/generator/templates/app/.env.local
+++ b/packages/generator/templates/app/.env.local
@@ -1,7 +1,8 @@
 # This env file should NOT be checked into source control
 # This is the place for values that changed for every developer
 
-# SQLite is ready to go out of the box, but you can switch to Postgres easily
-# by swapping the DATABASE_URL.
+# SQLite is ready to go out of the box, but you can switch to Postgres
+# by first changing the provider from "sqlite" to "postgres" in the Prisma
+# schema file and by second swapping the DATABASE_URL below.
 DATABASE_URL="file:./db.sqlite"
 # DATABASE_URL=postgresql://__username__@localhost:5432/__name__

--- a/packages/generator/templates/app/.env.test.local
+++ b/packages/generator/templates/app/.env.test.local
@@ -1,6 +1,7 @@
 # THIS FILE SHOULD NOT BE CHECKED INTO YOUR VERSION CONTROL SYSTEM
 
-# SQLite is ready to go out of the box, but you can switch to Postgres easily
-# by swapping the DATABASE_URL.
+# SQLite is ready to go out of the box, but you can switch to Postgres
+# by first changing the provider from "sqlite" to "postgres" in the Prisma
+# schema file and by second swapping the DATABASE_URL below.
 DATABASE_URL="file:./db_test.sqlite"
 # DATABASE_URL=postgresql://__username__@localhost:5432/__name___test

--- a/packages/generator/templates/app/db/schema.prisma
+++ b/packages/generator/templates/app/db/schema.prisma
@@ -2,7 +2,7 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 datasource db {
-  provider = ["sqlite", "postgres"]
+  provider = "sqlite"
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
Closes: #1044

### What are the changes and their implications?

After this PR, the Prisma schema sets the db provider as `sqlite` instead of the array `["sqlite", "postgres"]`. The `.env.local` and `.env.test.local` files were updated to specify that if the developer wanted to change from using SQLite to PostgreSQL then they'd need to change the db provider value in the the `db/schema.prisma` file.

Additional a [PR](https://github.com/blitz-js/blitzjs.com/pull/163) opened to update the [Database Overview](https://github.com/blitz-js/blitzjs.com/blob/main/docs/database-overview.mdx) docs page.

### Checklist

- [ ] ~~Tests added for changes~~ (no new code)
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

