### PR TITLE
🐛 fix query + page generator for default setup

### DIFF
--- a/packages/generator/templates/page/index.tsx
+++ b/packages/generator/templates/page/index.tsx
@@ -27,7 +27,7 @@ export const __ModelNames__List = () => {
     return (
       <div>
         <ul>
-          {__modelNames__.map((__modelName__) => (
+          {__modelNames__?.map((__modelName__) => (
             <li key={__modelName__.id}>
               <Link
                 href="/__parentModels__/__parentModelParam__/__modelNames__/__modelIdParam__"
@@ -60,7 +60,7 @@ export const __ModelNames__List = () => {
     return (
       <div>
         <ul>
-          {__modelNames__.map((__modelName__) => (
+          {__modelNames__?.map((__modelName__) => (
             <li key={__modelName__.id}>
               <Link
                 href="/__modelNames__/__modelIdParam__"

--- a/packages/generator/templates/queries/get__ModelNames__.ts
+++ b/packages/generator/templates/queries/get__ModelNames__.ts
@@ -1,4 +1,4 @@
-import {SessionContext} from "blitz"
+import {NotFoundError, SessionContext} from "blitz"
 import db, {FindMany__ModelName__Args} from "db"
 
 type Get__ModelNames__Input = {
@@ -16,12 +16,15 @@ export default async function get__ModelNames__(
 ) {
   ctx.session!.authorize()
 
-  const __modelNames__ = await db.__modelName__.findMany({
+  const __modelNames__ = await db.__modelName__?.findMany({
     where,
     orderBy,
     take,
     skip,
   })
+
+  if (!__modelNames__) throw new NotFoundError()
+
 
   const count = await db.__modelName__.count()
   const hasMore = typeof take === "number" ? skip + take < count : false


### PR DESCRIPTION
## What are the changes and their implications?
When running a fresh install of Blitz, the default homepage says to run:

`blitz generate all project name:string`
`blitz db migrate`
`blitz start`

and then to navigate to `/projects`

however, because the database is empty and the `getProjects.ts` file generated by Blitz is relying on `db.project.findMany` it causes an error because `db.project` is `undefined`

A similar thing happens with the `/pages/projects/index.tsx` file that is generated by Blitz, which has `projects.map` and errors out because `projects` is `undefined`.

Hopefully this should fix that!

but this results in 
### Checklist

- [ x] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
