### PR TITLE
Add --force flag for `blitz db reset` command

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -163,7 +163,9 @@ ${require("chalk").bold(
   "studio",
 )}   Open the Prisma Studio UI at http://localhost:5555 so you can easily see and change data in your database.
 
-${require("chalk").bold("reset")}   Reset the database and run a fresh migration via Prisma 2.
+${require("chalk").bold(
+  "reset",
+)}   Reset the database and run a fresh migration via Prisma 2. You can also pass --force to skip all the user prompts.
 `
 
   static args = [
@@ -179,6 +181,8 @@ ${require("chalk").bold("reset")}   Reset the database and run a fresh migration
     help: flags.help({char: "h"}),
     // Used by `new` command to perform the initial migration
     name: flags.string({hidden: true}),
+    // Used by `reset` command to skip the confirmation prompt
+    force: flags.boolean({char: "f", hidden: true, default: false}),
   }
 
   static strict = false
@@ -217,14 +221,18 @@ ${require("chalk").bold("reset")}   Reset the database and run a fresh migration
       await runPrismaGeneration({silent: true, failSilently: true})
       spinner.succeed()
 
-      const {confirm} = await require("enquirer").prompt({
-        type: "confirm",
-        name: "confirm",
-        message: "Are you sure you want to reset your database and erase ALL data?",
-      })
+      const forceSkipConfirmation = flags.force
 
-      if (!confirm) {
-        return
+      if (!forceSkipConfirmation) {
+        const {confirm} = await require("enquirer").prompt({
+          type: "confirm",
+          name: "confirm",
+          message: "Are you sure you want to reset your database and erase ALL data?",
+        })
+
+        if (!confirm) {
+          return
+        }
       }
 
       const {projectRoot} = require("../utils/get-project-root")

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -182,7 +182,7 @@ ${require("chalk").bold(
     // Used by `new` command to perform the initial migration
     name: flags.string({hidden: true}),
     // Used by `reset` command to skip the confirmation prompt
-    force: flags.boolean({char: "f", hidden: true, default: false}),
+    force: flags.boolean({char: "f", hidden: true}),
   }
 
   static strict = false

--- a/packages/cli/test/commands/db.test.ts
+++ b/packages/cli/test/commands/db.test.ts
@@ -157,7 +157,7 @@ describe("Db command", () => {
   })
 
   it("runs db migrate. (with unknown flags)", async () => {
-    await Db.run(["migrate", "--hoge", 'aaa'])
+    await Db.run(["migrate", "--hoge", "aaa"])
 
     expectDbMigrateWithUnknownFlag()
   })


### PR DESCRIPTION
Closes: #1096 

### What are the changes and their implications?
Added `--force` flag which can skip all the user prompts while running `blitz db reset` command.
**Usage:** `blitz db reset --force` or `blitz db reset -f`

### Checklist

- [ ] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
