### PR TITLE
Add dotenv-flow to jest config for new apps

### DIFF
--- a/packages/generator/templates/app/jest.config.js
+++ b/packages/generator/templates/app/jest.config.js
@@ -2,6 +2,7 @@ const { pathsToModuleNameMapper } = require("ts-jest/utils")
 const { compilerOptions } = require("./tsconfig")
 
 module.exports = {
+  setupFiles: ["dotenv-flow/config"],
   // Test setup file
   setupFilesAfterEnv: ["<rootDir>/test/setup.ts"],
   // Add type checking to Typescript test files

--- a/packages/generator/templates/app/jest.config.js
+++ b/packages/generator/templates/app/jest.config.js
@@ -2,7 +2,6 @@ const { pathsToModuleNameMapper } = require("ts-jest/utils")
 const { compilerOptions } = require("./tsconfig")
 
 module.exports = {
-  setupFiles: ["dotenv-flow/config"],
   // Test setup file
   setupFilesAfterEnv: ["<rootDir>/test/setup.ts"],
   // Add type checking to Typescript test files

--- a/packages/generator/templates/app/test/setup.ts
+++ b/packages/generator/templates/app/test/setup.ts
@@ -3,3 +3,4 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect"
+require("dotenv-flow").config({ silent: true })

--- a/packages/generator/templates/app/test/setup.ts
+++ b/packages/generator/templates/app/test/setup.ts
@@ -3,4 +3,3 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect"
-require("dotenv-flow").config({ silent: true })


### PR DESCRIPTION

### What are the changes and their implications?

Add dotenv-flow to jest config for new apps. This makes jest env match the env handling of everything else in Blitz.

