### PR TITLE
Remove prisma client generation from blitz in favor of new package.json schema config (Requires Prisma 2.7.0+ & new field in pkg.json))

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -10,10 +10,7 @@ export class Build extends Command {
     }
 
     try {
-      await require("@blitzjs/server").build(
-        config,
-        require("./db").runPrismaGeneration({silent: true, failSilently: true}),
-      )
+      await require("@blitzjs/server").build(config)
     } catch (err) {
       console.error(err)
       process.exit(1) // clean up?

--- a/packages/cli/src/commands/console.ts
+++ b/packages/cli/src/commands/console.ts
@@ -20,13 +20,9 @@ export class Console extends Command {
     console.log(chalk.yellow("      - Use your db like this: await db.project.findMany()"))
     console.log(chalk.yellow("      - Use your queries/mutations like this: await getProjects({})"))
 
-    const spinner = log.spinner("Loading your code").start()
     if (isTypescript) {
       require("../utils/setup-ts-node").setupTsnode()
     }
-
-    await require("./db").runPrismaGeneration({silent: true, failSilently: true})
-    spinner.succeed()
 
     require("@blitzjs/repl").runRepl(Console.replOptions)
   }

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -217,10 +217,6 @@ ${require("chalk").bold(
     }
 
     if (command === "reset") {
-      const spinner = log.spinner("Loading your database").start()
-      await runPrismaGeneration({silent: true, failSilently: true})
-      spinner.succeed()
-
       const forceSkipConfirmation = flags.force
 
       if (!forceSkipConfirmation) {
@@ -235,6 +231,7 @@ ${require("chalk").bold(
         }
       }
 
+      log.progress("Resetting your database...")
       const {projectRoot} = require("../utils/get-project-root")
       const prismaClientPath = require.resolve("@prisma/client", {paths: [projectRoot]})
       const {PrismaClient} = require(prismaClientPath)
@@ -247,16 +244,18 @@ ${require("chalk").bold(
       const connectionString = dataSource.url.value
 
       if (providerType === "postgresql") {
-        resetPostgres(connectionString, db)
+        await resetPostgres(connectionString, db)
+        return
       } else if (providerType === "mysql") {
-        resetMysql(connectionString, db)
+        await resetMysql(connectionString, db)
+        return
       } else if (providerType === "sqlite") {
-        resetSqlite(connectionString)
+        await resetSqlite(connectionString)
+        return
       } else {
-        this.log("Could not find a valid database configuration")
+        log.error("Could not find a valid database configuration")
+        return
       }
-
-      return
     }
 
     if (command === "help") {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -34,9 +34,9 @@ export class Start extends Command {
 
     try {
       if (flags.production) {
-        await prod(config, require("./db").runPrismaGeneration({silent: true, failSilently: true}))
+        await prod(config)
       } else {
-        await dev(config, require("./db").runPrismaGeneration({silent: true, failSilently: true}))
+        await dev(config)
       }
     } catch (err) {
       console.error(err)

--- a/packages/cli/test/commands/console.test.ts
+++ b/packages/cli/test/commands/console.test.ts
@@ -37,28 +37,9 @@ jest.mock(
   }),
 )
 
-jest.mock(
-  "../../src/commands/db",
-  jest.fn(() => {
-    return {
-      runPrismaGeneration: jest.fn(),
-    }
-  }),
-)
-
 describe("Console command", () => {
   beforeEach(() => {
     jest.resetAllMocks()
-  })
-
-  it("runs PrismaGeneration", async () => {
-    await Console.prototype.run()
-    expect(db.runPrismaGeneration).toHaveBeenCalled()
-  })
-
-  it("runs PrismaGeneration with silent allowed", async () => {
-    await Console.prototype.run()
-    expect(db.runPrismaGeneration).toHaveBeenCalledWith({silent: true, failSilently: true})
   })
 
   it("runs repl", async () => {

--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -12,6 +12,9 @@
   "browserslist": [
     "defaults"
   ],
+  "prisma": {
+    "schema": "db/schema.prisma"
+  },
   "prettier": {
     "semi": false,
     "printWidth": 100


### PR DESCRIPTION
### What are the changes and their implications?

[Prisma 2.7.0](https://github.com/prisma/prisma/releases/tag/2.7.0) added ability to define the Prisma schema location in `package.json`. I have been testing this, and it works phenomenal. Now the prisma client is automatically generated any time you run npm/yarn install. The only time it needs manually generated is if you change the schema, which we have `blitz db migrate` for.

So now we don't need to generate the client on every blitz cli command. Removing this step shaves a few seconds off every command that was doing it! 🏎💨 

Additionally, this makes all the usual prisma commands like `prisma generate`, `prisma introspect`, etc work without having to manually specify the schema location.


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
