### PR TITLE
Fix `blitz autocomplete` adding alpha warning message to the shell config

### DIFF
--- a/packages/blitz/src/bin/cli.ts
+++ b/packages/blitz/src/bin/cli.ts
@@ -5,12 +5,16 @@ import chalk from "chalk"
 import {parseSemver} from "../utils/parse-semver"
 
 async function main() {
-  console.log(
-    chalk.yellow(
-      `You are using alpha software - if you have any problems, please open an issue here:
-    https://github.com/blitz-js/blitz/issues/new/choose\n`,
-    ),
-  )
+  const options = require("minimist")(process.argv.slice(2))
+
+  if (options._[0] !== "autocomplete:script" || Object.keys(options).length > 1) {
+    console.log(
+      chalk.yellow(
+        `You are using alpha software - if you have any problems, please open an issue here:
+      https://github.com/blitz-js/blitz/issues/new/choose\n`,
+      ),
+    )
+  }
 
   if (parseSemver(process.version).major < 12) {
     console.log(
@@ -37,7 +41,6 @@ async function main() {
 
   const cli = require(cliPkgPath)
 
-  const options = require("minimist")(process.argv.slice(2))
   const hasVersionFlag = options._.length === 0 && (options.v || options.version)
   const hasVerboseFlag = options._.length === 0 && (options.V || options.verbose)
 


### PR DESCRIPTION
Closes: #1094 

### What are the changes and their implications?
Check before printing Alpha software warning, if command is autocomplete:script without any flags, dont print the warning. That way the warning doesnt land in the config file of the terminal.

### Checklist

- [ ] Tests added for changes
No tests for this that I am aware of.
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes
PR fixes a bug, so no update to the documentation necessary.
