### PR TITLE
Update tailwind recipe to install tailwindcss@latest instead of tailwindcss@1

### DIFF
--- a/recipes/tailwind/index.ts
+++ b/recipes/tailwind/index.ts
@@ -16,7 +16,7 @@ export default RecipeBuilder()
     explanation: `Tailwind CSS requires a couple of dependencies to get up and running.
 We'll install the Tailwind library itself, as well as PostCSS for removing unused styles from our production bundles.`,
     packages: [
-      {name: "tailwindcss", version: "1"},
+      {name: "tailwindcss", version: "latest"},
       {name: "postcss-preset-env", version: "latest", isDevDep: true},
     ],
   })


### PR DESCRIPTION
Closes: ??

### What are the changes and their implications?
Install the latest version of tailwindcss instead of version 1.
### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes
