### PR TITLE
Fix `blitz console` not closing on first Ctrl+D

### DIFF
--- a/packages/repl/src/repl.ts
+++ b/packages/repl/src/repl.ts
@@ -90,9 +90,7 @@ const setupFileWatchers = async (repl: REPLServer) => {
 
 const runRepl = async (replOptions: REPL.ReplOptions) => {
   const repl = await initializeRepl(replOptions)
-  repl.on("exit", () => {
-    process.exit()
-  })
+  repl.on("exit", () => process.exit())
   await setupFileWatchers(repl)
 }
 

--- a/packages/repl/src/repl.ts
+++ b/packages/repl/src/repl.ts
@@ -90,6 +90,9 @@ const setupFileWatchers = async (repl: REPLServer) => {
 
 const runRepl = async (replOptions: REPL.ReplOptions) => {
   const repl = await initializeRepl(replOptions)
+  repl.on("exit", () => {
+    process.exit()
+  })
   await setupFileWatchers(repl)
 }
 


### PR DESCRIPTION
Closes: #1099

### What are the changes and their implications?
Fixes the issue of `blitz console` not closing after any await calls by pressing CTRL+D.

As mentioned in the issue by @flybayer the fix was to listen for `exit` event on `repel` and call `process.exit()`

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
