### PR TITLE
Reduce re-renders by memoizing useParams and useRouterQuery

### DIFF
--- a/packages/core/src/use-params.ts
+++ b/packages/core/src/use-params.ts
@@ -49,18 +49,13 @@ export function useParams(returnType?: "string" | "number" | "array") {
   const router = useRouter()
   const query = useRouterQuery()
   const [lastRouterQuery, setLastRouterQuery] = useState(router.query)
-  const [lastQuery, setLastQuery] = useState(query)
 
   if (!isEqual(router.query, lastRouterQuery)) {
     setLastRouterQuery(router.query)
   }
 
-  if (!isEqual(query, lastQuery)) {
-    setLastQuery(query)
-  }
-
   const params = useMemo(() => {
-    const rawParams = extractRouterParams(lastRouterQuery, lastQuery)
+    const rawParams = extractRouterParams(lastRouterQuery, query)
 
     if (returnType === "string") {
       const params: Record<string, string> = {}
@@ -93,7 +88,7 @@ export function useParams(returnType?: "string" | "number" | "array") {
     }
 
     return rawParams
-  }, [lastRouterQuery, lastQuery, returnType])
+  }, [lastRouterQuery, query, returnType])
 
   return params
 }

--- a/packages/core/src/use-params.ts
+++ b/packages/core/src/use-params.ts
@@ -1,5 +1,5 @@
-import {useMemo, useState} from "react"
-import {fromPairs, isEqual} from "lodash"
+import {useMemo} from "react"
+import {fromPairs} from "lodash"
 import {useRouter} from "next/router"
 import {useRouterQuery} from "./use-router-query"
 
@@ -48,14 +48,9 @@ export function useParams(returnType: "array"): Record<string, Array<string | un
 export function useParams(returnType?: "string" | "number" | "array") {
   const router = useRouter()
   const query = useRouterQuery()
-  const [lastRouterQuery, setLastRouterQuery] = useState(router.query)
-
-  if (!isEqual(router.query, lastRouterQuery)) {
-    setLastRouterQuery(router.query)
-  }
 
   const params = useMemo(() => {
-    const rawParams = extractRouterParams(lastRouterQuery, query)
+    const rawParams = extractRouterParams(router.query, query)
 
     if (returnType === "string") {
       const params: Record<string, string> = {}
@@ -88,7 +83,7 @@ export function useParams(returnType?: "string" | "number" | "array") {
     }
 
     return rawParams
-  }, [lastRouterQuery, query, returnType])
+  }, [router.query, query, returnType])
 
   return params
 }

--- a/packages/core/src/use-router-query.ts
+++ b/packages/core/src/use-router-query.ts
@@ -1,4 +1,4 @@
-import {useState} from "react"
+import {useRef} from "react"
 import {isEqual} from "lodash"
 import {useRouter} from "next/router"
 import {parse} from "url"
@@ -8,11 +8,11 @@ export function useRouterQuery() {
 
   const {query} = parse(router.asPath, true)
 
-  const [lastQuery, setLastQuery] = useState(query)
+  const lastQueryRef = useRef(query)
 
-  if (!isEqual(query, lastQuery)) {
-    setLastQuery(query)
+  if (!isEqual(query, lastQueryRef.current)) {
+    lastQueryRef.current = query
   }
 
-  return lastQuery
+  return lastQueryRef.current
 }

--- a/packages/core/src/use-router-query.ts
+++ b/packages/core/src/use-router-query.ts
@@ -1,18 +1,15 @@
-import {useRef} from "react"
-import {isEqual} from "lodash"
+import {useMemo} from "react"
 import {useRouter} from "next/router"
 import {parse} from "url"
 
 export function useRouterQuery() {
   const router = useRouter()
 
-  const {query} = parse(router.asPath, true)
+  const query = useMemo(() => {
+    const {query} = parse(router.asPath, true)
 
-  const lastQueryRef = useRef(query)
+    return query
+  }, [router.asPath])
 
-  if (!isEqual(query, lastQueryRef.current)) {
-    lastQueryRef.current = query
-  }
-
-  return lastQueryRef.current
+  return query
 }

--- a/packages/core/src/use-router-query.ts
+++ b/packages/core/src/use-router-query.ts
@@ -1,8 +1,18 @@
+import {useState} from "react"
+import {isEqual} from "lodash"
 import {useRouter} from "next/router"
 import {parse} from "url"
 
 export function useRouterQuery() {
   const router = useRouter()
+
   const {query} = parse(router.asPath, true)
-  return query
+
+  const [lastQuery, setLastQuery] = useState(query)
+
+  if (!isEqual(query, lastQuery)) {
+    setLastQuery(query)
+  }
+
+  return lastQuery
 }


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1155 & https://github.com/blitz-js/blitz/issues/1154

### What are the changes and their implications?

I've added memoization and deep comparison to the `useParams` hook. Had to use state instead of refs because refs can't be passed to the `useMemo` hook as a dependency.

No changes were done to the `useParam` hook since it relies on the `useParams` hook and is automatically memoized.

Added deep comparison only to the `useRouterQuery` since if we will add an `useMemo` to watch `router.asPath`, the query will trigger updates on URL change, even if the effective query from URL didn't change.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
