### PR TITLE
Fix useQuery's mutate and router.push in same frame will cause error

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -63,3 +63,22 @@ export interface EnhancedResolver<TInput, TResult>
 export interface EnhancedResolverRpcClient<TInput, TResult>
   extends ResolverRpc<TInput, TResult>,
     ResolverEnhancement {}
+
+type RequestIdleCallbackHandle = any
+type RequestIdleCallbackOptions = {
+  timeout: number
+}
+type RequestIdleCallbackDeadline = {
+  readonly didTimeout: boolean
+  timeRemaining: () => number
+}
+
+declare global {
+  interface Window {
+    requestIdleCallback: (
+      callback: (deadline: RequestIdleCallbackDeadline) => void,
+      opts?: RequestIdleCallbackOptions,
+    ) => RequestIdleCallbackHandle
+    cancelIdleCallback: (handle: RequestIdleCallbackHandle) => void
+  }
+}

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -1,23 +1,35 @@
 import {queryCache, QueryKey} from "react-query"
 import {serialize} from "superjson"
 import {Resolver, EnhancedResolverRpcClient} from "../types"
-import {isServer} from "."
+import {isServer, isClient} from "."
 
 type MutateOptions = {
   refetch?: boolean
 }
 
 export interface QueryCacheFunctions<T> {
-  mutate: (newData: T | ((oldData: T | undefined) => T), opts?: MutateOptions) => void
+  mutate: (
+    newData: T | ((oldData: T | undefined) => T),
+    opts?: MutateOptions,
+  ) => Promise<void | ReturnType<typeof queryCache.invalidateQueries>>
 }
 
 export const getQueryCacheFunctions = <T>(queryKey: QueryKey): QueryCacheFunctions<T> => ({
   mutate: (newData, opts = {refetch: true}) => {
-    queryCache.setQueryData(queryKey, newData)
-    if (opts.refetch) {
-      return queryCache.invalidateQueries(queryKey, {refetchActive: true})
-    }
-    return null
+    return new Promise((res) => {
+      queryCache.setQueryData(queryKey, newData)
+      let result: void | ReturnType<typeof queryCache.invalidateQueries>
+      if (opts.refetch) {
+        result = res(queryCache.invalidateQueries(queryKey, {refetchActive: true}))
+      }
+      if (isClient) {
+        window.requestIdleCallback(() => {
+          res(result)
+        })
+      } else {
+        res(result)
+      }
+    })
   },
 })
 

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -23,6 +23,7 @@ export const getQueryCacheFunctions = <T>(queryKey: QueryKey): QueryCacheFunctio
         result = res(queryCache.invalidateQueries(queryKey, {refetchActive: true}))
       }
       if (isClient) {
+        // Fix for https://github.com/blitz-js/blitz/issues/1174
         window.requestIdleCallback(() => {
           res(result)
         })

--- a/packages/core/test/react-query-utils.test.ts
+++ b/packages/core/test/react-query-utils.test.ts
@@ -5,6 +5,9 @@ jest.mock("react-query")
 
 describe("getQueryCacheFunctions", () => {
   it("returns a mutate function with working options", async () => {
+    window.requestIdleCallback = jest.fn((fn) => {
+      fn({} as any)
+    })
     const spyRefetchQueries = jest.spyOn(queryCache, "invalidateQueries")
     const {mutate} = getQueryCacheFunctions("testQueryKey")
     expect(mutate).toBeTruthy()

--- a/packages/core/test/react-query-utils.test.ts
+++ b/packages/core/test/react-query-utils.test.ts
@@ -4,15 +4,15 @@ import {queryCache} from "react-query"
 jest.mock("react-query")
 
 describe("getQueryCacheFunctions", () => {
-  it("returns a mutate function with working options", () => {
+  it("returns a mutate function with working options", async () => {
     const spyRefetchQueries = jest.spyOn(queryCache, "invalidateQueries")
     const {mutate} = getQueryCacheFunctions("testQueryKey")
     expect(mutate).toBeTruthy()
-    mutate({newData: true})
+    await mutate({newData: true})
     expect(spyRefetchQueries).toBeCalledTimes(1)
-    mutate({newData: true}, {refetch: false})
+    await mutate({newData: true}, {refetch: false})
     expect(spyRefetchQueries).toBeCalledTimes(1)
-    mutate({newData: true}, {refetch: true})
+    await mutate({newData: true}, {refetch: true})
     expect(spyRefetchQueries).toBeCalledTimes(2)
   })
 })

--- a/packages/generator/templates/page/__modelIdParam__/edit.tsx
+++ b/packages/generator/templates/page/__modelIdParam__/edit.tsx
@@ -26,7 +26,7 @@ export const Edit__ModelName__ = () => {
               where: {id: __modelName__.id},
               data: {name: "MyNewName"},
             })
-            mutate(updated)
+            await mutate(updated)
             alert("Success!" + JSON.stringify(updated))
             router.push(
               process.env.parentModel


### PR DESCRIPTION
Closes: #1174

### What are the changes and their implications?

Fix useQuery's mutate and router.push in same frame will cause error

### Checklist

- [x] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
