### PR TITLE
Disable automatic query request cancellation

### DIFF
--- a/packages/core/src/rpc.ts
+++ b/packages/core/src/rpc.ts
@@ -107,7 +107,9 @@ export const executeRpcCall = <TInput, TResult>(
       }
     }) as CancellablePromise<TResult>
 
-  promise.cancel = () => controller.abort()
+  // Disable react-query request cancellation for now
+  // Having too many weird bugs with it enabled
+  // promise.cancel = () => controller.abort()
 
   return promise
 }


### PR DESCRIPTION
### What are the changes and their implications?

Disable automatic query request cancellation

We added this in `0.23.0`, but we've been experiencing a number of weird bugs as a result. Possibly because it's not fully concurrent mode safe. So disabling for now.


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
