### PR TITLE
Use npm for husky pre-push hook instead of yarn

### DIFF
--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -22,7 +22,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "tsc && lint-staged && pretty-quick --staged",
-      "pre-push": "yarn lint && yarn test"
+      "pre-push": "npm lint && npm test"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Closes: #1170 

### What are the changes and their implications?

Fixes an issue introduced by #1104 by switching from yarn (which not everybody will have installed) to npm which everybody will have.

### Checklist

- [ ] ~~Tests added for changes~~ N/A
- [ ] ~~PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~~ N/A
