### PR TITLE
Add `useRedirectLoggedInUserTo()` hook

### DIFF
--- a/packages/generator/templates/app/app/auth/pages/login.tsx
+++ b/packages/generator/templates/app/app/auth/pages/login.tsx
@@ -2,8 +2,10 @@ import React from "react"
 import { useRouter, BlitzPage } from "blitz"
 import Layout from "app/layouts/Layout"
 import { LoginForm } from "app/auth/components/LoginForm"
+import { useRedirectLoggedInUser } from "../../hooks/redirectLoggedInUser"
 
 const LoginPage: BlitzPage = () => {
+  useRedirectLoggedInUser("/")
   const router = useRouter()
 
   return (

--- a/packages/generator/templates/app/app/auth/pages/login.tsx
+++ b/packages/generator/templates/app/app/auth/pages/login.tsx
@@ -2,10 +2,10 @@ import React from "react"
 import { useRouter, BlitzPage } from "blitz"
 import Layout from "app/layouts/Layout"
 import { LoginForm } from "app/auth/components/LoginForm"
-import { useRedirectLoggedInUser } from "../../hooks/redirectLoggedInUser"
+import { useRedirectLoggedInUserTo } from "app/hooks/redirectLoggedInUser"
 
 const LoginPage: BlitzPage = () => {
-  useRedirectLoggedInUser("/")
+  useRedirectLoggedInUserTo("/")
   const router = useRouter()
 
   return (

--- a/packages/generator/templates/app/app/auth/pages/signup.tsx
+++ b/packages/generator/templates/app/app/auth/pages/signup.tsx
@@ -2,8 +2,10 @@ import React from "react"
 import { useRouter, BlitzPage } from "blitz"
 import Layout from "app/layouts/Layout"
 import { SignupForm } from "app/auth/components/SignupForm"
+import { useRedirectLoggedInUser } from "../../hooks/redirectLoggedInUser"
 
 const SignupPage: BlitzPage = () => {
+  useRedirectLoggedInUser("/")
   const router = useRouter()
 
   return (

--- a/packages/generator/templates/app/app/auth/pages/signup.tsx
+++ b/packages/generator/templates/app/app/auth/pages/signup.tsx
@@ -2,10 +2,10 @@ import React from "react"
 import { useRouter, BlitzPage } from "blitz"
 import Layout from "app/layouts/Layout"
 import { SignupForm } from "app/auth/components/SignupForm"
-import { useRedirectLoggedInUser } from "../../hooks/redirectLoggedInUser"
+import { useRedirectLoggedInUserTo } from "app/hooks/redirectLoggedInUser"
 
 const SignupPage: BlitzPage = () => {
-  useRedirectLoggedInUser("/")
+  useRedirectLoggedInUserTo("/")
   const router = useRouter()
 
   return (

--- a/packages/generator/templates/app/app/hooks/redirectLoggedInUser.ts
+++ b/packages/generator/templates/app/app/hooks/redirectLoggedInUser.ts
@@ -1,13 +1,13 @@
 import { useRouter, useSession } from "@blitzjs/core"
 import { useEffect } from "react"
 
-export const useRedirectLoggedInUser = (url: string) => {
+export const useRedirectLoggedInUserTo = (url: string) => {
   const session = useSession()
   const router = useRouter()
 
   useEffect(() => {
     if (session.userId) {
-      router.push(url, url)
+      router.push(url)
     }
   }, [session, router])
 }

--- a/packages/generator/templates/app/app/hooks/redirectLoggedInUser.ts
+++ b/packages/generator/templates/app/app/hooks/redirectLoggedInUser.ts
@@ -1,0 +1,13 @@
+import { useRouter, useSession } from "@blitzjs/core"
+import { useEffect } from "react"
+
+export const useRedirectLoggedInUser = (url: string) => {
+  const session = useSession()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (session.userId) {
+      router.push(url, url)
+    }
+  }, [session, router])
+}


### PR DESCRIPTION
Some users were asking how to redirect from login page if user is already logged in. Small change to redirect to the root page if a users is logged in from `signup` / `login` page.