### PR TITLE
Adds tests for core parsePublicDataToken

### DIFF
--- a/packages/core/src/supertokens.test.ts
+++ b/packages/core/src/supertokens.test.ts
@@ -25,7 +25,7 @@ describe("supertokens", () => {
       })
     })
 
-    it("parses the expireAt if a separator is present", () => {
+    it("returns no expireAt value if not set", () => {
       const data = `"foo"${TOKEN_SEPARATOR}`
       expect(parsePublicDataToken(btoa(data))).toEqual({
         publicData: "foo",

--- a/packages/core/src/supertokens.test.ts
+++ b/packages/core/src/supertokens.test.ts
@@ -26,23 +26,23 @@ describe("supertokens", () => {
     })
 
     it("parses the expireAt if a separator is present", () => {
-      const validJSON = `"foo"${TOKEN_SEPARATOR}`
-      expect(parsePublicDataToken(btoa(validJSON))).toEqual({
+      const data = `"foo"${TOKEN_SEPARATOR}`
+      expect(parsePublicDataToken(btoa(data))).toEqual({
         publicData: "foo",
       })
     })
 
     it("parses the expireAt date", () => {
-      const validJSON = `"foo"${TOKEN_SEPARATOR}${date}`
-      expect(parsePublicDataToken(btoa(validJSON))).toEqual({
+      const data = `"foo"${TOKEN_SEPARATOR}${date}`
+      expect(parsePublicDataToken(btoa(data))).toEqual({
         publicData: "foo",
         expireAt: date,
       })
     })
 
     it("only uses the first two separated tokens", () => {
-      const validJSON = `"foo"${TOKEN_SEPARATOR}${date}${TOKEN_SEPARATOR}123`
-      expect(parsePublicDataToken(btoa(validJSON))).toEqual({
+      const data = `"foo"${TOKEN_SEPARATOR}${date}${TOKEN_SEPARATOR}123`
+      expect(parsePublicDataToken(btoa(data))).toEqual({
         publicData: "foo",
         expireAt: date,
       })

--- a/packages/core/src/supertokens.test.ts
+++ b/packages/core/src/supertokens.test.ts
@@ -1,0 +1,51 @@
+import {parsePublicDataToken, TOKEN_SEPARATOR} from "./supertokens"
+import {setMilliseconds} from "date-fns"
+describe("supertokens", () => {
+  describe("parsePublicDataToken", () => {
+    // sets milliseconds to zero because of precision loss between strings and Dates
+    // const d = new Date()
+    // d != new Date(atob(btoa(d)))
+    const date = setMilliseconds(new Date(), 0)
+    it("throws if token is empty", () => {
+      const ret = () => parsePublicDataToken("")
+      expect(ret).toThrow("[parsePublicDataToken] Failed: token is empty")
+    })
+
+    it("throws if the token cannot be parsed", () => {
+      const invalidJSON = "{"
+      const ret = () => parsePublicDataToken(btoa(invalidJSON))
+
+      expect(ret).toThrowError("[parsePublicDataToken] Failed to parse publicDataStr: {")
+    })
+
+    it("parses the public data", () => {
+      const validJSON = '"foo"'
+      expect(parsePublicDataToken(btoa(validJSON))).toEqual({
+        publicData: "foo",
+      })
+    })
+
+    it("parses the expireAt if a separator is present", () => {
+      const validJSON = `"foo"${TOKEN_SEPARATOR}`
+      expect(parsePublicDataToken(btoa(validJSON))).toEqual({
+        publicData: "foo",
+      })
+    })
+
+    it("parses the expireAt date", () => {
+      const validJSON = `"foo"${TOKEN_SEPARATOR}${date}`
+      expect(parsePublicDataToken(btoa(validJSON))).toEqual({
+        publicData: "foo",
+        expireAt: date,
+      })
+    })
+
+    it("only uses the first two separated tokens", () => {
+      const validJSON = `"foo"${TOKEN_SEPARATOR}${date}${TOKEN_SEPARATOR}123`
+      expect(parsePublicDataToken(btoa(validJSON))).toEqual({
+        publicData: "foo",
+        expireAt: date,
+      })
+    })
+  })
+})


### PR DESCRIPTION

### What are the changes and their implications?
Adds some unit tests to help the issue https://github.com/blitz-js/blitz/issues/757.
Does a small bit of refactoring to favour the use of `const` over `let` and makes the return type a bit stricter.

I've changed the testing for ` expireAt.getTime() < Date.now()` to make it clearer what is being compared

### Checklist

- [x] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
