### PR TITLE
Fix a resolver type build error (on canary)

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -22,7 +22,7 @@ export interface CancellablePromise<T> extends Promise<T> {
 export type QueryFn = (...args: any) => Promise<any>
 
 // The actual resolver source definition
-export type Resolver<TInput, TResult> = (input?: TInput, ctx?: unknown) => Promise<TResult>
+export type Resolver<TInput, TResult> = (input: TInput, ctx?: any) => Promise<TResult>
 
 // Resolver type when imported with require()
 export type ResolverModule<TInput, TResult> = {


### PR DESCRIPTION


### What are the changes and their implications?

Fix a resolver type build error (on canary)


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
