### PR TITLE
Minor updates to pages/queries/mutations templates (add useMutation and use db.findFirst)

### DIFF
--- a/packages/generator/templates/mutation/create__ModelName__.ts
+++ b/packages/generator/templates/mutation/create__ModelName__.ts
@@ -7,9 +7,7 @@ if (process.env.parentModel) {
     __parentModelId__: number
   }
 } else {
-  type Create__ModelName__Input = {
-    data: __ModelName__CreateArgs["data"]
-  }
+  type Create__ModelName__Input = Pick<__ModelName__CreateArgs, "data">
 }
 
 if (process.env.parentModel) {

--- a/packages/generator/templates/mutation/delete__ModelName__.ts
+++ b/packages/generator/templates/mutation/delete__ModelName__.ts
@@ -1,9 +1,7 @@
 import {Ctx} from "blitz"
 import db, {__ModelName__DeleteArgs} from "db"
 
-type Delete__ModelName__Input = {
-  where: __ModelName__DeleteArgs["where"]
-}
+type Delete__ModelName__Input = Pick<__ModelName__DeleteArgs, "where">
 
 export default async function delete__ModelName__(
   {where}: Delete__ModelName__Input,

--- a/packages/generator/templates/mutation/update__ModelName__.ts
+++ b/packages/generator/templates/mutation/update__ModelName__.ts
@@ -8,10 +8,7 @@ if (process.env.parentModel) {
     __parentModelId__: number
   }
 } else {
-  type Update__ModelName__Input = {
-    where: __ModelName__UpdateArgs["where"]
-    data: __ModelName__UpdateArgs["data"]
-  }
+  type Update__ModelName__Input = Pick<__ModelName__UpdateArgs, "where" | "data">
 }
 
 export default async function update__ModelName__(

--- a/packages/generator/templates/page/__modelIdParam__.tsx
+++ b/packages/generator/templates/page/__modelIdParam__.tsx
@@ -1,6 +1,6 @@
 import React, {Suspense} from "react"
 import Layout from "app/layouts/Layout"
-import {Head, Link, useRouter, useQuery, useParam, BlitzPage} from "blitz"
+import {Link, useRouter, useQuery, useParam, BlitzPage} from "blitz"
 import get__ModelName__ from "app/__modelNamesPath__/queries/get__ModelName__"
 import delete__ModelName__ from "app/__modelNamesPath__/mutations/delete__ModelName__"
 
@@ -63,31 +63,25 @@ const Show__ModelName__Page: BlitzPage = () => {
 
   return (
     <div>
-      <Head>
-        <title>__ModelName__</title>
-      </Head>
-
-      <main>
-        <p>
-          <if condition="parentModel">
-            <Link
-              href="/__parentModels__/__parentModelId__/__modelNames__"
-              as={`/__parentModels__/${__parentModelId__}/__modelNames__`}
-            >
+      <p>
+        <if condition="parentModel">
+          <Link
+            href="/__parentModels__/__parentModelId__/__modelNames__"
+            as={`/__parentModels__/${__parentModelId__}/__modelNames__`}
+          >
+            <a>__ModelNames__</a>
+          </Link>
+          <else>
+            <Link href="/__modelNames__">
               <a>__ModelNames__</a>
             </Link>
-            <else>
-              <Link href="/__modelNames__">
-                <a>__ModelNames__</a>
-              </Link>
-            </else>
-          </if>
-        </p>
+          </else>
+        </if>
+      </p>
 
-        <Suspense fallback={<div>Loading...</div>}>
-          <__ModelName__ />
-        </Suspense>
-      </main>
+      <Suspense fallback={<div>Loading...</div>}>
+        <__ModelName__ />
+      </Suspense>
     </div>
   )
 }

--- a/packages/generator/templates/page/__modelIdParam__/edit.tsx
+++ b/packages/generator/templates/page/__modelIdParam__/edit.tsx
@@ -1,6 +1,6 @@
 import React, {Suspense} from "react"
 import Layout from "app/layouts/Layout"
-import {Head, Link, useRouter, useQuery, useParam, BlitzPage} from "blitz"
+import {Link, useRouter, useQuery, useMutation, useParam, BlitzPage} from "blitz"
 import get__ModelName__ from "app/__modelNamesPath__/queries/get__ModelName__"
 import update__ModelName__ from "app/__modelNamesPath__/mutations/update__ModelName__"
 import __ModelName__Form from "app/__modelNamesPath__/components/__ModelName__Form"
@@ -12,6 +12,7 @@ export const Edit__ModelName__ = () => {
     const __parentModelId__ = useParam("__parentModelId__", "number")
   }
   const [__modelName__, {mutate}] = useQuery(get__ModelName__, {where: {id: __modelId__}})
+  const [update__ModelName__Mutation] = useMutation(update__ModelName__)
 
   return (
     <div>
@@ -22,7 +23,7 @@ export const Edit__ModelName__ = () => {
         initialValues={__modelName__}
         onSubmit={async () => {
           try {
-            const updated = await update__ModelName__({
+            const updated = await update__ModelName__Mutation({
               where: {id: __modelName__.id},
               data: {name: "MyNewName"},
             })
@@ -53,31 +54,25 @@ const Edit__ModelName__Page: BlitzPage = () => {
 
   return (
     <div>
-      <Head>
-        <title>Edit __ModelName__</title>
-      </Head>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Edit__ModelName__ />
+      </Suspense>
 
-      <main>
-        <Suspense fallback={<div>Loading...</div>}>
-          <Edit__ModelName__ />
-        </Suspense>
-
-        <p>
-          <if condition="parentModel">
-            <Link
-              as="/__parentModels__/__parentModelId__/__modelNames__"
-              href={`/__parentModels__/${__parentModelId__}/__modelNames__`}
-            >
+      <p>
+        <if condition="parentModel">
+          <Link
+            as="/__parentModels__/__parentModelId__/__modelNames__"
+            href={`/__parentModels__/${__parentModelId__}/__modelNames__`}
+          >
+            <a>__ModelNames__</a>
+          </Link>
+          <else>
+            <Link href="/__modelNames__">
               <a>__ModelNames__</a>
             </Link>
-            <else>
-              <Link href="/__modelNames__">
-                <a>__ModelNames__</a>
-              </Link>
-            </else>
-          </if>
-        </p>
-      </main>
+          </else>
+        </if>
+      </p>
     </div>
   )
 }

--- a/packages/generator/templates/page/index.tsx
+++ b/packages/generator/templates/page/index.tsx
@@ -1,9 +1,9 @@
 import React, {Suspense} from "react"
 import Layout from "app/layouts/Layout"
 if (process.env.parentModel) {
-  import {Head, Link, usePaginatedQuery, useRouter, useParam, BlitzPage} from "blitz"
+  import {Link, usePaginatedQuery, useRouter, useParam, BlitzPage} from "blitz"
 } else {
-  import {Head, Link, usePaginatedQuery, useRouter, BlitzPage} from "blitz"
+  import {Link, usePaginatedQuery, useRouter, BlitzPage} from "blitz"
 }
 import get__ModelNames__ from "app/__modelNamesPath__/queries/get__ModelNames__"
 
@@ -90,33 +90,25 @@ const __ModelNames__Page: BlitzPage = () => {
 
   return (
     <div>
-      <Head>
-        <title>__ModelNames__</title>
-      </Head>
-
-      <main>
-        <h1>__ModelNames__</h1>
-
-        <p>
-          <if condition="parentModel">
-            <Link
-              href="/__parentModels__/__parentModelId__/__modelNames__/new"
-              as={`/__parentModels__/${__parentModelId__}/__modelNames__/new`}
-            >
+      <p>
+        <if condition="parentModel">
+          <Link
+            href="/__parentModels__/__parentModelId__/__modelNames__/new"
+            as={`/__parentModels__/${__parentModelId__}/__modelNames__/new`}
+          >
+            <a>Create __ModelName__</a>
+          </Link>
+          <else>
+            <Link href="/__modelNames__/new">
               <a>Create __ModelName__</a>
             </Link>
-            <else>
-              <Link href="/__modelNames__/new">
-                <a>Create __ModelName__</a>
-              </Link>
-            </else>
-          </if>
-        </p>
+          </else>
+        </if>
+      </p>
 
-        <Suspense fallback={<div>Loading...</div>}>
-          <__ModelNames__List />
-        </Suspense>
-      </main>
+      <Suspense fallback={<div>Loading...</div>}>
+        <__ModelNames__List />
+      </Suspense>
     </div>
   )
 }

--- a/packages/generator/templates/page/new.tsx
+++ b/packages/generator/templates/page/new.tsx
@@ -1,9 +1,9 @@
 import React from "react"
 import Layout from "app/layouts/Layout"
 if (process.env.parentModel) {
-  import {Head, Link, useRouter, useParam, BlitzPage} from "blitz"
+  import {Link, useRouter, useMutation, useParam, BlitzPage} from "blitz"
 } else {
-  import {Head, Link, useRouter, BlitzPage} from "blitz"
+  import {Link, useRouter, useMutation, BlitzPage} from "blitz"
 }
 import create__ModelName__ from "app/__modelNamesPath__/mutations/create__ModelName__"
 import __ModelName__Form from "app/__modelNamesPath__/components/__ModelName__Form"
@@ -13,60 +13,57 @@ const New__ModelName__Page: BlitzPage = () => {
   if (process.env.parentModel) {
     const __parentModelId__ = useParam("__parentModelId__", "number")
   }
+  const [create__ModelName__Mutation] = useMutation(create__ModelName__)
 
   return (
     <div>
-      <Head>
-        <title>New __ModelName__</title>
-      </Head>
+      <h1>Create New __ModelName__</h1>
 
-      <main>
-        <h1>Create New __ModelName__</h1>
+      <__ModelName__Form
+        initialValues={{}}
+        onSubmit={async () => {
+          try {
+            const __modelName__ = await create__ModelName__Mutation(
+              process.env.parentModel
+                ? {data: {name: "MyName"}, __parentModelId__}
+                : {data: {name: "MyName"}},
+            )
+            alert("Success!" + JSON.stringify(__modelName__))
+            router.push(
+              process.env.parentModel
+                ? "/__parentModels__/__parentModelParam__/__modelNames__/__modelIdParam__"
+                : "/__modelNames__/__modelIdParam__",
+              process.env.parentModel
+                ? `/__parentModels__/${__parentModelId__}/__modelNames__/${__modelName__.id}`
+                : `/__modelNames__/${__modelName__.id}`,
+            )
+          } catch (error) {
+            alert("Error creating __modelName__ " + JSON.stringify(error, null, 2))
+          }
+        }}
+      />
 
-        <__ModelName__Form
-          initialValues={{}}
-          onSubmit={async () => {
-            try {
-              const __modelName__ = await create__ModelName__(
-                process.env.parentModel
-                  ? {data: {name: "MyName"}, __parentModelId__}
-                  : {data: {name: "MyName"}},
-              )
-              alert("Success!" + JSON.stringify(__modelName__))
-              router.push(
-                process.env.parentModel
-                  ? "/__parentModels__/__parentModelParam__/__modelNames__/__modelIdParam__"
-                  : "/__modelNames__/__modelIdParam__",
-                process.env.parentModel
-                  ? `/__parentModels__/${__parentModelId__}/__modelNames__/${__modelName__.id}`
-                  : `/__modelNames__/${__modelName__.id}`,
-              )
-            } catch (error) {
-              alert("Error creating __modelName__ " + JSON.stringify(error, null, 2))
-            }
-          }}
-        />
-
-        <p>
-          <if condition="parentModel">
-            <Link
-              as="/__parentModels__/__parentModelId__/__modelNames__"
-              href={`/__parentModels__/${__parentModelId__}/__modelNames__`}
-            >
+      <p>
+        <if condition="parentModel">
+          <Link
+            as="/__parentModels__/__parentModelId__/__modelNames__"
+            href={`/__parentModels__/${__parentModelId__}/__modelNames__`}
+          >
+            <a>__ModelNames__</a>
+          </Link>
+          <else>
+            <Link href="/__modelNames__">
               <a>__ModelNames__</a>
             </Link>
-            <else>
-              <Link href="/__modelNames__">
-                <a>__ModelNames__</a>
-              </Link>
-            </else>
-          </if>
-        </p>
-      </main>
+          </else>
+        </if>
+      </p>
     </div>
   )
 }
 
-New__ModelName__Page.getLayout = (page) => <Layout title={"Create New __ModelName__"}>{page}</Layout>
+New__ModelName__Page.getLayout = (page) => (
+  <Layout title={"Create New __ModelName__"}>{page}</Layout>
+)
 
 export default New__ModelName__Page

--- a/packages/generator/templates/queries/get__ModelName__.ts
+++ b/packages/generator/templates/queries/get__ModelName__.ts
@@ -1,14 +1,12 @@
 import {Ctx, NotFoundError} from "blitz"
-import db, {FindOne__ModelName__Args} from "db"
+import db, {FindFirst__ModelName__Args} from "db"
 
-type Get__ModelName__Input = {
-  where: FindOne__ModelName__Args["where"]
-}
+type Get__ModelName__Input = Pick<FindFirst__ModelName__Args, "where">
 
 export default async function get__ModelName__({where}: Get__ModelName__Input, {session}: Ctx) {
   session.authorize()
 
-  const __modelName__ = await db.__modelName__.findOne({where})
+  const __modelName__ = await db.__modelName__.findFirst({where})
 
   if (!__modelName__) throw new NotFoundError()
 

--- a/packages/generator/templates/queries/get__ModelNames__.ts
+++ b/packages/generator/templates/queries/get__ModelNames__.ts
@@ -1,12 +1,7 @@
 import {Ctx} from "blitz"
 import db, {FindMany__ModelName__Args} from "db"
 
-type Get__ModelNames__Input = {
-  where?: FindMany__ModelName__Args["where"]
-  orderBy?: FindMany__ModelName__Args["orderBy"]
-  skip?: FindMany__ModelName__Args["skip"]
-  take?: FindMany__ModelName__Args["take"]
-}
+type Get__ModelNames__Input = Pick<FindMany__ModelName__Args, "where" | "orderBy" | "skip" | "take">
 
 export default async function get__ModelNames__(
   {where, orderBy, skip = 0, take}: Get__ModelNames__Input,


### PR DESCRIPTION


### What are the changes and their implications?

- Update pages templates to useMutation
- Remove `<head>` from page templates because it is in Layout.
- Update single getItem query to use findFirst
- Refactor generated type definitions for queries/mutations

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
