### PR TITLE
Fix bug with creating new session after revoking current one

### DIFF
--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -372,6 +372,13 @@ export const setHeader = (res: ServerResponse, name: string, value: string) => {
   }
 }
 
+export const removeHeader = (res: ServerResponse, name: string) => {
+  res.removeHeader(name)
+  if ("_blitz" in res) {
+    delete (res as any)._blitz[name]
+  }
+}
+
 export const setSessionCookie = (
   req: IncomingMessage,
   res: ServerResponse,
@@ -647,6 +654,7 @@ export async function createNewSession(
     setPublicDataCookie(req, res, publicDataToken)
     // Clear the anonymous session cookie in case it was previously set
     setAnonymousSessionCookie(req, res, "", new Date(0))
+    removeHeader(res, HEADER_SESSION_REVOKED)
 
     return {
       handle,


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1198

### What are the changes and their implications?

This clears the HEADER_SESSION_REVOKED header from the response when a new session is created.  This allows someone revoke() and then create() within the same request without the new data being lost.

I tested this change in the examples/auth app by adding a session.revoke() call as part of the login mutation.  Before the fix I was experiencing the same issue I described in 1198. After this fix it works as expected.
