### PR TITLE
Fix session race condition that would result in CSRF errors or users being logged out

### DIFF
--- a/examples/auth/app/pages/_app.tsx
+++ b/examples/auth/app/pages/_app.tsx
@@ -3,6 +3,10 @@ import {ErrorBoundary} from "react-error-boundary"
 import {queryCache} from "react-query"
 import LoginForm from "app/auth/components/LoginForm"
 
+if (typeof window !== "undefined") {
+  window["DEBUG_BLITZ"] = 1
+}
+
 export default function App({Component, pageProps}: AppProps) {
   const router = useRouter()
   return (

--- a/examples/auth/app/pages/index.tsx
+++ b/examples/auth/app/pages/index.tsx
@@ -1,10 +1,10 @@
 import {Suspense} from "react"
-import {Head, Link, useSession, useRouterQuery, useMutation, useQuery} from "blitz"
+import {Head, Link, useSession, useRouterQuery, useMutation} from "blitz"
 import getUser from "app/users/queries/getUser"
 import trackView from "app/users/mutations/trackView"
 import Layout from "app/layouts/Layout"
 import {useCurrentUser} from "app/hooks/useCurrentUser"
-import getUsers from "app/users/queries/getUsers"
+// import getUsers from "app/users/queries/getUsers"
 
 const CurrentUserInfo = () => {
   const currentUser = useCurrentUser()
@@ -12,11 +12,11 @@ const CurrentUserInfo = () => {
   return <pre>{JSON.stringify(currentUser, null, 2)}</pre>
 }
 
-const Users = () => {
-  const [users] = useQuery(getUsers, {})
-
-  return <pre style={{maxWidth: "30rem"}}>{JSON.stringify(users, null, 2)}</pre>
-}
+// const Users = () => {
+//   const [users] = useQuery(getUsers, {})
+//
+//   return <pre style={{maxWidth: "30rem"}}>{JSON.stringify(users, null, 2)}</pre>
+// }
 
 const UserStuff = () => {
   const session = useSession()
@@ -48,9 +48,11 @@ const UserStuff = () => {
       <Suspense fallback="Loading...">
         <CurrentUserInfo />
       </Suspense>
+      {/*
       <Suspense fallback="Loading...">
         <Users />
       </Suspense>
+        */}
       <button
         onClick={async () => {
           try {

--- a/examples/auth/app/pages/index.tsx
+++ b/examples/auth/app/pages/index.tsx
@@ -1,6 +1,6 @@
 import {Suspense} from "react"
 import {Head, Link, useSession, useRouterQuery, useMutation} from "blitz"
-// import getUser from "app/users/queries/getUser"
+import getUser from "app/users/queries/getUser"
 import trackView from "app/users/mutations/trackView"
 import Layout from "app/layouts/Layout"
 import {useCurrentUser} from "app/hooks/useCurrentUser"
@@ -45,9 +45,9 @@ const UserStuff = () => {
         onClick={async () => {
           try {
             // TODO - disabled until invoke() is added
-            // const user = await getUser({where: {id: session.userId as number}})
-            // alert(JSON.stringify(user))
-            alert("todo")
+            const user = await getUser({where: {id: session.userId as number}}, {} as any)
+            alert(JSON.stringify(user))
+            // alert("todo")
           } catch (error) {
             alert("error: " + JSON.stringify(error))
           }

--- a/examples/auth/app/pages/index.tsx
+++ b/examples/auth/app/pages/index.tsx
@@ -1,14 +1,21 @@
 import {Suspense} from "react"
-import {Head, Link, useSession, useRouterQuery, useMutation} from "blitz"
+import {Head, Link, useSession, useRouterQuery, useMutation, useQuery} from "blitz"
 import getUser from "app/users/queries/getUser"
 import trackView from "app/users/mutations/trackView"
 import Layout from "app/layouts/Layout"
 import {useCurrentUser} from "app/hooks/useCurrentUser"
+import getUsers from "app/users/queries/getUsers"
 
 const CurrentUserInfo = () => {
   const currentUser = useCurrentUser()
 
   return <pre>{JSON.stringify(currentUser, null, 2)}</pre>
+}
+
+const Users = () => {
+  const [users] = useQuery(getUsers, {})
+
+  return <pre style={{maxWidth: "30rem"}}>{JSON.stringify(users, null, 2)}</pre>
 }
 
 const UserStuff = () => {
@@ -40,6 +47,9 @@ const UserStuff = () => {
       <pre>{JSON.stringify(session, null, 2)}</pre>
       <Suspense fallback="Loading...">
         <CurrentUserInfo />
+      </Suspense>
+      <Suspense fallback="Loading...">
+        <Users />
       </Suspense>
       <button
         onClick={async () => {

--- a/examples/auth/app/users/queries/getUsers.ts
+++ b/examples/auth/app/users/queries/getUsers.ts
@@ -13,10 +13,11 @@ export default async function getUsers(
   {where, orderBy, cursor, take, skip}: GetUsersInput,
   {session}: Ctx,
 ) {
-  session.authorize(["admin"])
+  session.authorize(["admin", "user"])
 
   const users = await db.user.findMany({
     where,
+    select: {id: true},
     orderBy,
     cursor,
     take,

--- a/examples/auth/blitz.config.js
+++ b/examples/auth/blitz.config.js
@@ -7,7 +7,7 @@ module.exports = withBundleAnalyzer({
   middleware: [
     sessionMiddleware({
       unstable_isAuthorized: unstable_simpleRolesIsAuthorized,
-      // sessionExpiryMinutes: 2,
+      sessionExpiryMinutes: 4,
     }),
   ],
   /*

--- a/examples/auth/blitz.config.js
+++ b/examples/auth/blitz.config.js
@@ -7,7 +7,7 @@ module.exports = withBundleAnalyzer({
   middleware: [
     sessionMiddleware({
       unstable_isAuthorized: unstable_simpleRolesIsAuthorized,
-      // sessionExpiryMinutes: 1,
+      // sessionExpiryMinutes: 2,
     }),
   ],
   /*

--- a/packages/core/src/rpc.ts
+++ b/packages/core/src/rpc.ts
@@ -1,6 +1,6 @@
 import {deserializeError} from "serialize-error"
 import {queryCache} from "react-query"
-import {getQueryKey, isClient, isServer} from "./utils"
+import {getQueryKey, isClient, isServer, clientDebug} from "./utils"
 import {
   getAntiCSRFToken,
   publicDataStore,
@@ -28,6 +28,7 @@ export const executeRpcCall = <TInput, TResult>(
   opts: RpcOptions = {},
 ) => {
   if (isServer) return (Promise.resolve() as unknown) as CancellablePromise<TResult>
+  clientDebug("Starting request for", apiUrl)
 
   const headers: Record<string, any> = {
     "Content-Type": "application/json",
@@ -35,10 +36,10 @@ export const executeRpcCall = <TInput, TResult>(
 
   const antiCSRFToken = getAntiCSRFToken()
   if (antiCSRFToken) {
-    console.log("Adding antiCSRFToken cookie header", antiCSRFToken)
+    clientDebug("Adding antiCSRFToken cookie header", antiCSRFToken)
     headers[HEADER_CSRF] = antiCSRFToken
   } else {
-    console.log("No antiCSRFToken cookie found")
+    clientDebug("No antiCSRFToken cookie found")
   }
 
   let serialized: SuperJSONResult
@@ -70,14 +71,18 @@ export const executeRpcCall = <TInput, TResult>(
       signal: controller.signal,
     })
     .then(async (result) => {
+      clientDebug("Received request for", apiUrl)
       if (result.headers) {
         if (result.headers.get(HEADER_PUBLIC_DATA_TOKEN)) {
           publicDataStore.updateState()
+          clientDebug("Public data updated")
         }
         if (result.headers.get(HEADER_SESSION_REVOKED)) {
+          clientDebug("Sessin revoked")
           publicDataStore.clear()
         }
         if (result.headers.get(HEADER_CSRF_ERROR)) {
+          clientDebug("CSRF error")
           throw new AuthenticationError()
         }
       }

--- a/packages/core/src/rpc.ts
+++ b/packages/core/src/rpc.ts
@@ -9,7 +9,7 @@ import {
   HEADER_CSRF_ERROR,
   HEADER_PUBLIC_DATA_TOKEN,
 } from "./supertokens"
-import {CSRFTokenMismatchError} from "./errors"
+import {AuthenticationError} from "./errors"
 import {serialize, deserialize} from "superjson"
 import {
   ResolverType,
@@ -35,7 +35,10 @@ export const executeRpcCall = <TInput, TResult>(
 
   const antiCSRFToken = getAntiCSRFToken()
   if (antiCSRFToken) {
+    console.log("Adding antiCSRFToken cookie header", antiCSRFToken)
     headers[HEADER_CSRF] = antiCSRFToken
+  } else {
+    console.log("No antiCSRFToken cookie found")
   }
 
   let serialized: SuperJSONResult
@@ -75,7 +78,7 @@ export const executeRpcCall = <TInput, TResult>(
           publicDataStore.clear()
         }
         if (result.headers.get(HEADER_CSRF_ERROR)) {
-          throw new CSRFTokenMismatchError()
+          throw new AuthenticationError()
         }
       }
 

--- a/packages/core/src/supertokens.test.ts
+++ b/packages/core/src/supertokens.test.ts
@@ -1,11 +1,7 @@
 import {parsePublicDataToken, TOKEN_SEPARATOR} from "./supertokens"
-import {setMilliseconds} from "date-fns"
+
 describe("supertokens", () => {
   describe("parsePublicDataToken", () => {
-    // sets milliseconds to zero because of precision loss between strings and Dates
-    // const d = new Date()
-    // d != new Date(atob(btoa(d)))
-    const date = setMilliseconds(new Date(), 0)
     it("throws if token is empty", () => {
       const ret = () => parsePublicDataToken("")
       expect(ret).toThrow("[parsePublicDataToken] Failed: token is empty")
@@ -25,26 +21,10 @@ describe("supertokens", () => {
       })
     })
 
-    it("returns no expireAt value if not set", () => {
-      const data = `"foo"${TOKEN_SEPARATOR}`
+    it("only uses the first separated tokens", () => {
+      const data = `"foo"${TOKEN_SEPARATOR}123`
       expect(parsePublicDataToken(btoa(data))).toEqual({
         publicData: "foo",
-      })
-    })
-
-    it("parses the expireAt date", () => {
-      const data = `"foo"${TOKEN_SEPARATOR}${date}`
-      expect(parsePublicDataToken(btoa(data))).toEqual({
-        publicData: "foo",
-        expireAt: date,
-      })
-    })
-
-    it("only uses the first two separated tokens", () => {
-      const data = `"foo"${TOKEN_SEPARATOR}${date}${TOKEN_SEPARATOR}123`
-      expect(parsePublicDataToken(btoa(data))).toEqual({
-        publicData: "foo",
-        expireAt: date,
       })
     })
   })

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -99,13 +99,11 @@ export const getPublicDataToken = () => readCookie(COOKIE_PUBLIC_DATA_TOKEN)
 export const parsePublicDataToken = (token: string) => {
   assert(token, "[parsePublicDataToken] Failed: token is empty")
 
-  const [publicDataStr, expireAt] = atob(token).split(TOKEN_SEPARATOR)
+  const [publicDataStr] = atob(token).split(TOKEN_SEPARATOR)
   try {
     const publicData: PublicData = JSON.parse(publicDataStr)
     return {
       publicData,
-      // note: milliseconds are lost when converting from strings to Dates
-      expireAt: expireAt ? new Date(expireAt) : undefined,
     }
   } catch (error) {
     throw new Error(`[parsePublicDataToken] Failed to parse publicDataStr: ${publicDataStr}`)
@@ -138,12 +136,8 @@ export const publicDataStore = {
       return emptyPublicData
     }
 
-    const {publicData, expireAt} = parsePublicDataToken(publicDataToken)
+    const {publicData} = parsePublicDataToken(publicDataToken)
 
-    if (expireAt && expireAt.getTime() < Date.now()) {
-      this.clear()
-      return emptyPublicData
-    }
     return publicData
   },
   updateState() {
@@ -153,7 +147,7 @@ export const publicDataStore = {
     publicDataStore.observable.next(this.getData())
   },
   clear() {
-    // deleteCookie(COOKIE_CSRF_TOKEN)
+    deleteCookie(COOKIE_CSRF_TOKEN)
     deleteCookie(COOKIE_PUBLIC_DATA_TOKEN)
     queryCache.clear()
     this.updateState()

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -153,6 +153,7 @@ export const publicDataStore = {
     publicDataStore.observable.next(this.getData())
   },
   clear() {
+    // deleteCookie(COOKIE_CSRF_TOKEN)
     deleteCookie(COOKIE_PUBLIC_DATA_TOKEN)
     queryCache.clear()
     this.updateState()

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -18,3 +18,9 @@ export function isLocalhost(req: BlitzApiRequest | IncomingMessage): boolean {
   }
   return localhost
 }
+
+export function clientDebug(...args: any) {
+  if (typeof window !== "undefined" && (window as any)["DEBUG_BLITZ"]) {
+    console.log("[BLITZ]", ...args)
+  }
+}

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -518,7 +518,7 @@ export async function getSession(
       return null
     }
     if (enableCsrfProtection && persistedSession.antiCSRFToken !== antiCSRFToken) {
-      await revokeSession(req, res, handle)
+      // await revokeSession(req, res, handle)
       setHeader(res, HEADER_CSRF_ERROR, "true")
       throw new CSRFTokenMismatchError()
     }
@@ -588,7 +588,7 @@ export async function getSession(
     }
 
     if (enableCsrfProtection && payload.antiCSRFToken !== antiCSRFToken) {
-      await revokeSession(req, res, payload.handle, true)
+      // await revokeSession(req, res, payload.handle, true)
       setHeader(res, HEADER_CSRF_ERROR, "true")
       throw new CSRFTokenMismatchError()
     }

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -37,6 +37,7 @@ import {btoa, atob} from "b64-lite"
 import {getCookieParser} from "next/dist/next-server/server/api-utils"
 import {IncomingMessage, ServerResponse} from "http"
 import {log} from "@blitzjs/display"
+const debug = require("debug")("blitz:session")
 
 function assert(condition: any, message: string): asserts condition {
   if (!condition) throw new Error(message)
@@ -132,6 +133,7 @@ type SessionKernel = {
   handle: string
   publicData: PublicData
   jwtPayload: JwtPayload
+  antiCSRFToken: string
 }
 
 const isBlitzApiRequest = (req: BlitzApiRequest | IncomingMessage): req is BlitzApiRequest =>
@@ -157,10 +159,11 @@ export async function getSessionContext(
   let sessionKernel = await getSession(req, res)
 
   if (sessionKernel) {
-    // console.log("Got existing session", sessionKernel)
+    debug("Got existing session", sessionKernel)
   }
 
   if (!sessionKernel) {
+    debug("No session found, creating anonymous session")
     sessionKernel = await createAnonymousSession(req, res)
   }
 
@@ -404,7 +407,7 @@ export const setAnonymousSessionCookie = (
   req: IncomingMessage,
   res: ServerResponse,
   token: string,
-  expiresAt: Date = addYears(new Date(), 30),
+  expiresAt: Date,
 ) => {
   setCookie(
     res,
@@ -425,8 +428,9 @@ export const setCSRFCookie = (
   req: IncomingMessage,
   res: ServerResponse,
   antiCSRFToken: string,
-  expiresAt: Date = addYears(new Date(), 30),
+  expiresAt: Date,
 ) => {
+  debug("setCSRFCookie", antiCSRFToken)
   setCookie(
     res,
     cookie.serialize(COOKIE_CSRF_TOKEN, antiCSRFToken, {
@@ -445,7 +449,7 @@ export const setPublicDataCookie = (
   req: IncomingMessage,
   res: ServerResponse,
   publicDataToken: string,
-  expiresAt: Date = addYears(new Date(), 30),
+  expiresAt: Date,
 ) => {
   setHeader(res, HEADER_PUBLIC_DATA_TOKEN, "updated")
   setCookie(
@@ -477,10 +481,11 @@ export async function getSession(
   const antiCSRFToken = req.headers[HEADER_CSRF] as string
 
   if (sessionToken) {
+    debug("Request has sessionToken")
     const {handle, version, hashedPublicData} = parseSessionToken(sessionToken)
 
     if (!handle) {
-      // console.log("No session: no handle")
+      debug("No handle in sessionToken")
       return null
     }
 
@@ -493,21 +498,21 @@ export async function getSession(
 
     const persistedSession = await config.getSession(handle)
     if (!persistedSession) {
-      // console.log("No session: not in DB")
+      debug("Session not found in DB")
       return null
     }
-
-    if (enableCsrfProtection && persistedSession.antiCSRFToken !== antiCSRFToken) {
-      setHeader(res, HEADER_CSRF_ERROR, "true")
-      throw new CSRFTokenMismatchError()
-    }
     if (persistedSession.hashedSessionToken !== hash(sessionToken)) {
-      // console.log("No session: sessionToken hash did not match")
+      debug("sessionToken hash did not match")
       return null
     }
     if (persistedSession.expiresAt && isPast(persistedSession.expiresAt)) {
-      await revokeSession(req, res, handle)
+      debug("Session expired")
       return null
+    }
+    if (enableCsrfProtection && persistedSession.antiCSRFToken !== antiCSRFToken) {
+      await revokeSession(req, res, handle)
+      setHeader(res, HEADER_CSRF_ERROR, "true")
+      throw new CSRFTokenMismatchError()
     }
 
     /*
@@ -522,6 +527,9 @@ export async function getSession(
       // The publicData in the DB could have been updated since this client last made
       // a request. If so, then we generate a new access token
       const hasPublicDataChanged = hash(persistedSession.publicData) !== hashedPublicData
+      if (hasPublicDataChanged) {
+        debug("PublicData has changed since the last request")
+      }
 
       // Check if > 1/4th of the expiry time has passed
       // (since we are doing a rolling expiry window).
@@ -529,12 +537,19 @@ export async function getSession(
         persistedSession.expiresAt &&
         differenceInMinutes(persistedSession.expiresAt, new Date()) <
           0.75 * config.sessionExpiryMinutes
+      debug("diff mins", differenceInMinutes(persistedSession.expiresAt!, new Date()))
+      debug("compare mins", 0.75 * config.sessionExpiryMinutes)
+
+      if (hasQuarterExpiryTimePassed) {
+        debug("quarter expiry time has passed")
+      }
 
       if (hasPublicDataChanged || hasQuarterExpiryTimePassed) {
         await refreshSession(req, res, {
           handle,
           publicData: JSON.parse(persistedSession.publicData || ""),
           jwtPayload: null,
+          antiCSRFToken,
         })
       }
     }
@@ -543,19 +558,23 @@ export async function getSession(
       handle,
       publicData: JSON.parse(persistedSession.publicData || ""),
       jwtPayload: null,
+      antiCSRFToken,
     }
   } else if (idRefreshToken) {
     // TODO: advanced method
     return null
     // Important: check anonymousSessionToken token as the very last thing
   } else if (anonymousSessionToken) {
+    debug("Request has anonymousSessionToken")
     const payload = parseAnonymousSessionToken(anonymousSessionToken)
 
     if (!payload) {
+      debug("Payload empty")
       return null
     }
 
     if (enableCsrfProtection && payload.antiCSRFToken !== antiCSRFToken) {
+      await revokeSession(req, res, payload.handle, true)
       setHeader(res, HEADER_CSRF_ERROR, "true")
       throw new CSRFTokenMismatchError()
     }
@@ -564,6 +583,7 @@ export async function getSession(
       handle: payload.handle,
       publicData: payload.publicData,
       jwtPayload: payload,
+      antiCSRFToken,
     }
   }
 
@@ -587,6 +607,7 @@ export async function createNewSession(
   const antiCSRFToken = createAntiCSRFToken()
 
   if (opts.anonymous) {
+    debug("Creating new anonymous session")
     const handle = generateAnonymousSessionHandle()
     const payload: AnonymousSessionPayload = {
       isAnonymous: true,
@@ -597,9 +618,10 @@ export async function createNewSession(
     const anonymousSessionToken = createAnonymousSessionToken(payload)
     const publicDataToken = createPublicDataToken(publicData)
 
-    setAnonymousSessionCookie(req, res, anonymousSessionToken)
-    setCSRFCookie(req, res, antiCSRFToken)
-    setPublicDataCookie(req, res, publicDataToken)
+    const expiresAt = addYears(new Date(), 30)
+    setAnonymousSessionCookie(req, res, anonymousSessionToken, expiresAt)
+    setCSRFCookie(req, res, antiCSRFToken, expiresAt)
+    setPublicDataCookie(req, res, publicDataToken, expiresAt)
     // Clear the essential session cookie in case it was previously set
     setSessionCookie(req, res, "", new Date(0))
 
@@ -607,8 +629,10 @@ export async function createNewSession(
       handle,
       publicData,
       jwtPayload: payload,
+      antiCSRFToken,
     }
   } else if (config.method === "essential") {
+    debug("Creating new session")
     const newPublicData: PublicData = {
       // This carries over any public data from the anonymous session
       ...(opts.jwtPayload?.publicData || {}),
@@ -650,8 +674,8 @@ export async function createNewSession(
     })
 
     setSessionCookie(req, res, sessionToken, expiresAt)
-    setCSRFCookie(req, res, antiCSRFToken)
-    setPublicDataCookie(req, res, publicDataToken)
+    setCSRFCookie(req, res, antiCSRFToken, expiresAt)
+    setPublicDataCookie(req, res, publicDataToken, expiresAt)
     // Clear the anonymous session cookie in case it was previously set
     setAnonymousSessionCookie(req, res, "", new Date(0))
     removeHeader(res, HEADER_SESSION_REVOKED)
@@ -660,6 +684,7 @@ export async function createNewSession(
       handle,
       publicData: newPublicData,
       jwtPayload: null,
+      antiCSRFToken,
     }
   } else if (config.method === "advanced") {
     throw new Error("The advanced method is not yet supported")
@@ -683,6 +708,7 @@ export async function refreshSession(
   res: ServerResponse,
   sessionKernel: SessionKernel,
 ) {
+  debug("Refreshing session", sessionKernel)
   if (sessionKernel.jwtPayload?.isAnonymous) {
     const payload: AnonymousSessionPayload = {
       ...sessionKernel.jwtPayload,
@@ -691,15 +717,18 @@ export async function refreshSession(
     const anonymousSessionToken = createAnonymousSessionToken(payload)
     const publicDataToken = createPublicDataToken(sessionKernel.publicData)
 
-    setAnonymousSessionCookie(req, res, anonymousSessionToken)
-    setPublicDataCookie(req, res, publicDataToken)
+    const expiresAt = addYears(new Date(), 30)
+    setAnonymousSessionCookie(req, res, anonymousSessionToken, expiresAt)
+    setPublicDataCookie(req, res, publicDataToken, expiresAt)
+    setCSRFCookie(req, res, sessionKernel.antiCSRFToken, expiresAt)
   } else if (config.method === "essential") {
     const expiresAt = addMinutes(new Date(), config.sessionExpiryMinutes)
     const sessionToken = createSessionToken(sessionKernel.handle, sessionKernel.publicData)
     const publicDataToken = createPublicDataToken(sessionKernel.publicData, expiresAt)
 
     setSessionCookie(req, res, sessionToken, expiresAt)
-    setPublicDataCookie(req, res, publicDataToken)
+    setPublicDataCookie(req, res, publicDataToken, expiresAt)
+    setCSRFCookie(req, res, sessionKernel.antiCSRFToken, expiresAt)
 
     const hashedSessionToken = hash(sessionToken)
 
@@ -733,11 +762,15 @@ export async function revokeSession(
   req: IncomingMessage,
   res: ServerResponse,
   handle: string,
+  anonymous: boolean = false,
 ): Promise<void> {
-  try {
-    await config.deleteSession(handle)
-  } catch (error) {
-    // Ignore any errors, like if session doesn't exist in DB
+  debug("Revoking session", handle)
+  if (!anonymous) {
+    try {
+      await config.deleteSession(handle)
+    } catch (error) {
+      // Ignore any errors, like if session doesn't exist in DB
+    }
   }
   // This is used on the frontend to clear localstorage
   setHeader(res, HEADER_SESSION_REVOKED, "true")
@@ -745,6 +778,7 @@ export async function revokeSession(
   // Clear all cookies
   setSessionCookie(req, res, "", new Date(0))
   setAnonymousSessionCookie(req, res, "", new Date(0))
+  setCSRFCookie(req, res, "", new Date(0))
 }
 
 export async function revokeMultipleSessions(


### PR DESCRIPTION
### What are the changes and their implications?

- [x] Fix race condition that happened at 1/4 of the session expire time when the session needs refresh. What would happen is if two parallel requests refreshed the session, the end result would be a sessionToken mismatch that would result in being logged out or stuck with a CSRF error. The fix is to not regenerate the session token if expire time is only thing that changes.
- [x] Unify expiration times of all session cookies
- [x] Remove expire time from public data token, because we use cookie expiration instead


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
