### PR TITLE
Fix `blitz new --js` #1208

### DIFF
--- a/packages/generator/src/generators/app-generator.ts
+++ b/packages/generator/src/generators/app-generator.ts
@@ -45,79 +45,33 @@ export class AppGenerator extends Generator<AppGeneratorOptions> {
   async preCommit() {
     this.fs.move(this.destinationPath("gitignore"), this.destinationPath(".gitignore"))
     const pkg = this.fs.readJSON(this.destinationPath("package.json"))
+    const ext = this.options.useTs ? "tsx" : "js"
+    let type: string
 
     switch (this.options.form) {
       case "React Final Form":
-        this.fs.move(
-          this.destinationPath(
-            this.options.useTs ? "_forms/finalform/Form.tsx" : "_forms/finalform/Form.js",
-          ),
-          this.destinationPath(
-            this.options.useTs ? "app/components/Form.tsx" : "app/components/Form.js",
-          ),
-        )
-        this.fs.move(
-          this.destinationPath(
-            this.options.useTs
-              ? "_forms/finalform/LabeledTextField.tsx"
-              : "_forms/finalform/LabeledTextField.js",
-          ),
-          this.destinationPath(
-            this.options.useTs
-              ? "app/components/LabeledTextField.tsx"
-              : "app/components/LabeledTextField.js",
-          ),
-        )
+        type = "finalform"
         pkg.dependencies["final-form"] = "4.x"
         pkg.dependencies["react-final-form"] = "6.x"
         break
       case "React Hook Form":
-        this.fs.move(
-          this.destinationPath(
-            this.options.useTs ? "_forms/hookform/Form.tsx" : "_forms/hookform/Form.js",
-          ),
-          this.destinationPath(
-            this.options.useTs ? "app/components/Form.tsx" : "app/components/Form.js",
-          ),
-        )
-        this.fs.move(
-          this.destinationPath(
-            this.options.useTs
-              ? "_forms/hookform/LabeledTextField.tsx"
-              : "_forms/hookform/LabeledTextField.js",
-          ),
-          this.destinationPath(
-            this.options.useTs
-              ? "app/components/LabeledTextField.tsx"
-              : "app/components/LabeledTextField.js",
-          ),
-        )
+        type = "hookform"
         pkg.dependencies["react-hook-form"] = "6.x"
         break
       case "Formik":
-        this.fs.move(
-          this.destinationPath(
-            this.options.useTs ? "_forms/formik/Form.tsx" : "_forms/formik/Form.js",
-          ),
-          this.destinationPath(
-            this.options.useTs ? "app/components/Form.tsx" : "app/components/Form.js",
-          ),
-        )
-        this.fs.move(
-          this.destinationPath(
-            this.options.useTs
-              ? "_forms/formik/LabeledTextField.tsx"
-              : "_forms/formik/LabeledTextField.js",
-          ),
-          this.destinationPath(
-            this.options.useTs
-              ? "app/components/LabeledTextField.tsx"
-              : "app/components/LabeledTextField.js",
-          ),
-        )
+        type = "formik"
         pkg.dependencies["formik"] = "2.x"
         break
     }
+    this.fs.move(
+      this.destinationPath(`_forms/${type}/Form.${ext}`),
+      this.destinationPath(`app/components/Form.${ext}`),
+    )
+    this.fs.move(
+      this.destinationPath(`_forms/${type}/LabeledTextField.${ext}`),
+      this.destinationPath(`app/components/LabeledTextField.${ext}`),
+    )
+
     this.fs.delete(this.destinationPath("_forms"))
 
     this.fs.writeJSON(this.destinationPath("package.json"), pkg)

--- a/packages/generator/src/generators/app-generator.ts
+++ b/packages/generator/src/generators/app-generator.ts
@@ -49,35 +49,71 @@ export class AppGenerator extends Generator<AppGeneratorOptions> {
     switch (this.options.form) {
       case "React Final Form":
         this.fs.move(
-          this.destinationPath("_forms/finalform/Form.tsx"),
-          this.destinationPath("app/components/Form.tsx"),
+          this.destinationPath(
+            this.options.useTs ? "_forms/finalform/Form.tsx" : "_forms/finalform/Form.js",
+          ),
+          this.destinationPath(
+            this.options.useTs ? "app/components/Form.tsx" : "app/components/Form.js",
+          ),
         )
         this.fs.move(
-          this.destinationPath("_forms/finalform/LabeledTextField.tsx"),
-          this.destinationPath("app/components/LabeledTextField.tsx"),
+          this.destinationPath(
+            this.options.useTs
+              ? "_forms/finalform/LabeledTextField.tsx"
+              : "_forms/finalform/LabeledTextField.js",
+          ),
+          this.destinationPath(
+            this.options.useTs
+              ? "app/components/LabeledTextField.tsx"
+              : "app/components/LabeledTextField.js",
+          ),
         )
         pkg.dependencies["final-form"] = "4.x"
         pkg.dependencies["react-final-form"] = "6.x"
         break
       case "React Hook Form":
         this.fs.move(
-          this.destinationPath("_forms/hookform/Form.tsx"),
-          this.destinationPath("app/components/Form.tsx"),
+          this.destinationPath(
+            this.options.useTs ? "_forms/hookform/Form.tsx" : "_forms/hookform/Form.js",
+          ),
+          this.destinationPath(
+            this.options.useTs ? "app/components/Form.tsx" : "app/components/Form.js",
+          ),
         )
         this.fs.move(
-          this.destinationPath("_forms/hookform/LabeledTextField.tsx"),
-          this.destinationPath("app/components/LabeledTextField.tsx"),
+          this.destinationPath(
+            this.options.useTs
+              ? "_forms/hookform/LabeledTextField.tsx"
+              : "_forms/hookform/LabeledTextField.js",
+          ),
+          this.destinationPath(
+            this.options.useTs
+              ? "app/components/LabeledTextField.tsx"
+              : "app/components/LabeledTextField.js",
+          ),
         )
         pkg.dependencies["react-hook-form"] = "6.x"
         break
       case "Formik":
         this.fs.move(
-          this.destinationPath("_forms/formik/Form.tsx"),
-          this.destinationPath("app/components/Form.tsx"),
+          this.destinationPath(
+            this.options.useTs ? "_forms/formik/Form.tsx" : "_forms/formik/Form.js",
+          ),
+          this.destinationPath(
+            this.options.useTs ? "app/components/Form.tsx" : "app/components/Form.js",
+          ),
         )
         this.fs.move(
-          this.destinationPath("_forms/formik/LabeledTextField.tsx"),
-          this.destinationPath("app/components/LabeledTextField.tsx"),
+          this.destinationPath(
+            this.options.useTs
+              ? "_forms/formik/LabeledTextField.tsx"
+              : "_forms/formik/LabeledTextField.js",
+          ),
+          this.destinationPath(
+            this.options.useTs
+              ? "app/components/LabeledTextField.tsx"
+              : "app/components/LabeledTextField.js",
+          ),
         )
         pkg.dependencies["formik"] = "2.x"
         break


### PR DESCRIPTION
Closes: #1208 

### What are the changes and their implications?
This PR fixes the AssertionError that occurs after selecting a form to use for the template when creating a new Blitz JavaScript app. Adds in a simple ternary operator to the bit that moves the form files to make sure proper file extension is used. 
