### PR TITLE
Enforce NodeJS Version >= 12 for CLI

### DIFF
--- a/packages/blitz/src/bin/cli.ts
+++ b/packages/blitz/src/bin/cli.ts
@@ -22,7 +22,7 @@ async function main() {
         `You are using an unsupported version of Node.js. Please switch to v12 or newer.\n`,
       ),
     )
-    process.exit(1)
+    process.exit()
   }
 
   const globalBlitzPath = resolveFrom(__dirname, "blitz")

--- a/packages/blitz/src/bin/cli.ts
+++ b/packages/blitz/src/bin/cli.ts
@@ -19,9 +19,10 @@ async function main() {
   if (parseSemver(process.version).major < 12) {
     console.log(
       chalk.yellow(
-        `You are using an unsupported version of Node.js. Consider switching to v12 or newer.\n`,
+        `You are using an unsupported version of Node.js. Please switch to v12 or newer.\n`,
       ),
     )
+    process.exit(1)
   }
 
   const globalBlitzPath = resolveFrom(__dirname, "blitz")


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1162

### What are the changes and their implications?

Blitz officially requires NodeJS Version >= 12. Issues show that running it with nodejs below that version will result in problems. Therefore we enforce the version and exit the CLI if the nodejs version is lower than 12. This will save users from headaches. 

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
