### PR TITLE
Add invoke() — the new way to imperatively call queries/mutations

### DIFF
--- a/examples/auth/app/pages/index.tsx
+++ b/examples/auth/app/pages/index.tsx
@@ -1,5 +1,5 @@
 import {Suspense} from "react"
-import {Head, Link, useSession, useRouterQuery, useMutation} from "blitz"
+import {Head, Link, useSession, useRouterQuery, useMutation, invoke} from "blitz"
 import getUser from "app/users/queries/getUser"
 import trackView from "app/users/mutations/trackView"
 import Layout from "app/layouts/Layout"
@@ -56,10 +56,8 @@ const UserStuff = () => {
       <button
         onClick={async () => {
           try {
-            // TODO - disabled until invoke() is added
-            const user = await getUser({where: {id: session.userId as number}}, {} as any)
+            const user = await invoke(getUser, {where: {id: session.userId as number}})
             alert(JSON.stringify(user))
-            // alert("todo")
           } catch (error) {
             alert("error: " + JSON.stringify(error))
           }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ import {AppProps as NextAppProps} from "next/app"
 
 export * from "./use-query-hooks"
 export {useMutation} from "./use-mutation"
+export {invoke} from "./invoke"
 export * from "./use-params"
 export * from "./ssr-query"
 export * from "./rpc"

--- a/packages/core/src/invoke.ts
+++ b/packages/core/src/invoke.ts
@@ -1,0 +1,21 @@
+import {QueryFn, FirstParam, PromiseReturnType, Resolver, EnhancedResolverRpcClient} from "./types"
+import {isClient} from "./utils"
+
+export function invoke<T extends QueryFn, TInput = FirstParam<T>, TResult = PromiseReturnType<T>>(
+  queryFn: T,
+  params: TInput,
+) {
+  if (typeof queryFn === "undefined") {
+    throw new Error(
+      "invoke is missing the first argument - it must be a query or mutation function",
+    )
+  }
+
+  if (isClient) {
+    const fn = (queryFn as unknown) as EnhancedResolverRpcClient<TInput, TResult>
+    return fn(params, {fromInvoke: true})
+  } else {
+    const fn = queryFn as Resolver<TInput, TResult>
+    return fn(params) as ReturnType<T>
+  }
+}

--- a/packages/core/src/rpc.ts
+++ b/packages/core/src/rpc.ts
@@ -27,6 +27,12 @@ export const executeRpcCall = <TInput, TResult>(
   params: TInput,
   opts: RpcOptions = {},
 ) => {
+  if (!opts.fromQueryHook && !opts.fromInvoke) {
+    console.warn(
+      "[Deprecation] Directly calling queries/mutations is deprecated in favor of invoke(queryFn, params)",
+    )
+  }
+
   if (isServer) return (Promise.resolve() as unknown) as CancellablePromise<TResult>
   clientDebug("Starting request for", apiUrl)
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -32,6 +32,7 @@ export type ResolverModule<TInput, TResult> = {
 
 export type RpcOptions = {
   fromQueryHook?: boolean
+  fromInvoke?: boolean
   alreadySerialized?: boolean
 }
 


### PR DESCRIPTION
### What are the changes and their implications?

Add invoke() — the new way to imperatively call queries/mutations

With this addition, directly calling query/mutations are now deprecated. A warning message is logged stating such if you do this.

### Checklist

- [x] Tests added for changes — nothing to test
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
