### PR TITLE
Improve error message when attempting useQuery with regular functions

### DIFF
--- a/packages/core/src/use-mutation.ts
+++ b/packages/core/src/use-mutation.ts
@@ -4,6 +4,7 @@ import {
   MutationConfig,
   MutateConfig,
 } from "react-query"
+import {validateQueryFn} from "./utils/react-query-utils"
 
 /*
  * We have to override react-query's MutationFunction and MutationResultPair
@@ -37,6 +38,8 @@ export function useMutation<TResult, TError = unknown, TVariables = undefined, T
   mutationResolver: MutationFunction<TResult, TVariables>,
   config?: MutationConfig<TResult, TError, TVariables, TSnapshot>,
 ) {
+  validateQueryFn(mutationResolver)
+
   return useReactQueryMutation(mutationResolver, {
     throwOnError: true,
     ...config,

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -7,6 +7,10 @@ type MutateOptions = {
   refetch?: boolean
 }
 
+function isEnhancedResolverRpcClient(f: any): f is EnhancedResolverRpcClient<any, any> {
+  return !!f._meta
+}
+
 export interface QueryCacheFunctions<T> {
   mutate: (
     newData: T | ((oldData: T | undefined) => T),
@@ -51,6 +55,12 @@ export const sanitize = <TInput, TResult>(
   if (isServer) {
     // Prevents logging garbage during static pre-rendering
     return emptyQueryFn
+  }
+
+  if (!isEnhancedResolverRpcClient(queryFn)) {
+    throw new Error(
+      `It looks like you are trying to use Blitz's useQuery to fetch from third-party APIs. To do that, import useQuery directly from "react-query"`,
+    )
   }
 
   return queryFn as EnhancedResolverRpcClient<TInput, TResult>

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -49,6 +49,16 @@ export const emptyQueryFn: EnhancedResolverRpcClient<unknown, unknown> = (() => 
   return fn
 })()
 
+export const validateQueryFn = <TInput, TResult>(
+  queryFn: Resolver<TInput, TResult> | EnhancedResolverRpcClient<TInput, TResult>,
+) => {
+  if (!isEnhancedResolverRpcClient(queryFn)) {
+    throw new Error(
+      `It looks like you are trying to use Blitz's useQuery to fetch from third-party APIs. To do that, import useQuery directly from "react-query"`,
+    )
+  }
+}
+
 export const sanitize = <TInput, TResult>(
   queryFn: Resolver<TInput, TResult> | EnhancedResolverRpcClient<TInput, TResult>,
 ) => {
@@ -57,11 +67,7 @@ export const sanitize = <TInput, TResult>(
     return emptyQueryFn
   }
 
-  if (!isEnhancedResolverRpcClient(queryFn)) {
-    throw new Error(
-      `It looks like you are trying to use Blitz's useQuery to fetch from third-party APIs. To do that, import useQuery directly from "react-query"`,
-    )
-  }
+  validateQueryFn(queryFn)
 
   return queryFn as EnhancedResolverRpcClient<TInput, TResult>
 }

--- a/packages/core/test/__snapshots__/use-query.test.tsx.snap
+++ b/packages/core/test/__snapshots__/use-query.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useQuery a "query" that converts the string parameter to uppercase shouldn't work with regular functions 1`] = `"It looks like you are trying to use Blitz's useQuery to fetch from third-party APIs. To do that, import useQuery directly from \\"react-query\\""`;

--- a/packages/core/test/use-query.test.tsx
+++ b/packages/core/test/use-query.test.tsx
@@ -3,32 +3,29 @@ import {act, render, waitForElementToBeRemoved, screen} from "./test-utils"
 import {useQuery} from "../src/use-query-hooks"
 import {deserialize} from "superjson"
 
+// This enhance fn does what getIsomorphicEnhancedResolver does during build time
+const enhance = (fn: any) => {
+  const newFn = (...args: any) => {
+    const [data, ...rest] = args
+    return fn(deserialize(data), ...rest)
+  }
+  newFn._meta = {
+    name: "testResolver",
+    type: "query",
+    path: "app/test",
+    apiUrl: "test/url",
+  }
+  return newFn
+}
+
 describe("useQuery", () => {
   const setupHook = (
     params: any,
     queryFn: (...args: any) => Promise<any>,
   ): [{data?: any}, Function] => {
-    // This enhance fn does what getIsomorphicEnhancedResolver does during build time
-    const enhance = (fn: any) => {
-      const newFn = (...args: any) => {
-        const [data, ...rest] = args
-        return fn(deserialize(data), ...rest)
-      }
-      newFn._meta = {
-        name: "testResolver",
-        type: "query",
-        path: "app/test",
-        apiUrl: "test/url",
-      }
-      return newFn
-    }
     let res = {}
     function TestHarness() {
-      useQuery(
-        enhance((num: number) => num),
-        1,
-      )
-      const [data] = useQuery(enhance(queryFn), params)
+      const [data] = useQuery(queryFn, params)
       Object.assign(res, {data})
       return <div id="harness">{data ? "Ready" : "Missing Dependency"}</div>
     }
@@ -48,13 +45,17 @@ describe("useQuery", () => {
     const upcase = async (args: string): Promise<string> => {
       return args.toUpperCase()
     }
-    it("should work", async () => {
-      const [res] = setupHook("test", upcase)
+    it("should work with Blitz queries", async () => {
+      const [res] = setupHook("test", enhance(upcase))
       await waitForElementToBeRemoved(() => screen.getByText("Loading..."))
       await act(async () => {
         await screen.findByText("Ready")
         expect(res.data).toBe("TEST")
       })
+    })
+
+    it("shouldn't work with regular functions", () => {
+      expect(() => setupHook("test", upcase)).toThrowErrorMatchingSnapshot()
     })
   })
 })


### PR DESCRIPTION
Closes: #1206 

### What are the changes and their implications?

Displays the following error message when regular functions are used with `useQuery`, `useMutation` etc

```
It looks like you are trying to use Blitz's useQuery to fetch from third-party APIs. To do that, import useQuery directly from "react-query".
```

### Checklist

- [x] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
