### PR TITLE
Fix query cache not being invalidated on route navigation

### DIFF
--- a/examples/store/app/admin/pages/admin/products/[id].tsx
+++ b/examples/store/app/admin/pages/admin/products/[id].tsx
@@ -2,7 +2,6 @@ import {Suspense} from "react"
 import {Link, useRouter, useQuery, useParam} from "blitz"
 import getProduct from "app/products/queries/getProduct"
 import ProductForm from "app/products/components/ProductForm"
-import {queryCache} from "react-query"
 
 function Product() {
   const router = useRouter()
@@ -14,7 +13,6 @@ function Product() {
       product={product}
       onSuccess={async () => {
         await router.push("/admin/products")
-        queryCache.invalidateQueries("/api/products/queries/getProducts")
       }}
     />
   )

--- a/packages/core/src/use-query-hooks.ts
+++ b/packages/core/src/use-query-hooks.ts
@@ -8,6 +8,7 @@ import {
   useInfiniteQuery as useInfiniteReactQuery,
   InfiniteQueryResult,
   InfiniteQueryConfig as RQInfiniteQueryConfig,
+  queryCache,
 } from "react-query"
 import {FirstParam, QueryFn, PromiseReturnType} from "./types"
 import {
@@ -18,6 +19,11 @@ import {
   getInfiniteQueryKey,
   defaultQueryConfig,
 } from "./utils/react-query-utils"
+import {Router} from "./index"
+
+Router.events.on("routeChangeComplete", async () => {
+  await queryCache.invalidateQueries()
+})
 
 // -------------------------
 // useQuery


### PR DESCRIPTION
Closes: #1196 

### What are the changes and their implications?

We effectively had a regression in the last release which updated react-query and RQ changed to not auto invalidate query cache when in suspense mode.

So this fixes that regression, and ensures all query cache is invalidated on route change.

### Checklist

- [x] Tests added for changes
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
