### PR TITLE
Fix isBlitzRoot() for blank deps/devDeps

### DIFF
--- a/packages/cli/src/utils/is-blitz-root.ts
+++ b/packages/cli/src/utils/is-blitz-root.ts
@@ -39,7 +39,7 @@ export const isBlitzRoot = async (): Promise<{
   try {
     const local = await readJSON("./package.json")
     if (local) {
-      if (local.dependencies["blitz"] || local.devDependencies["blitz"]) {
+      if (local.dependencies?.["blitz"] || local.devDependencies?.["blitz"]) {
         return {err: false}
       } else {
         return {


### PR DESCRIPTION
### What are the changes and their implications?

`isBlitzRoot()` emit error without `err.message` because of object access error if `dependencies` or `devDependecies` does not exist.

I encountered this for `blitz install ...` for blank project to test `blitz install`.

### Checklist

- [ ] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
