### PR TITLE
Fix middleware test for win and mac

### DIFF
--- a/packages/core/src/middleware.test.ts
+++ b/packages/core/src/middleware.test.ts
@@ -6,8 +6,6 @@ import {apiResolver} from "next/dist/next-server/server/api-utils"
 import {BlitzApiRequest, BlitzApiResponse} from "."
 import {Middleware, handleRequestWithMiddleware} from "./middleware"
 
-const testIfNotWindows = process.platform === "win32" ? it.skip : it
-
 describe("handleRequestWithMiddleware", () => {
   it("works without await", async () => {
     const middleware: Middleware[] = [
@@ -68,7 +66,7 @@ describe("handleRequestWithMiddleware", () => {
   })
 
   // Failing on windows for unknown reason
-  testIfNotWindows("middleware can throw", async () => {
+  it("middleware can throw", async () => {
     console.log = jest.fn()
     console.error = jest.fn()
     const forbiddenMiddleware = jest.fn()
@@ -87,7 +85,7 @@ describe("handleRequestWithMiddleware", () => {
   })
 
   // Failing on windows for unknown reason
-  testIfNotWindows("middleware can return error", async () => {
+  it("middleware can return error", async () => {
     console.log = jest.fn()
     const forbiddenMiddleware = jest.fn()
     const middleware: Middleware[] = [
@@ -107,8 +105,13 @@ describe("handleRequestWithMiddleware", () => {
 
 async function mockServer(middleware: Middleware[], callback: (url: string) => Promise<void>) {
   const apiEndpoint = async (req: BlitzApiRequest, res: BlitzApiResponse) => {
-    await handleRequestWithMiddleware(req, res, middleware)
-    res.end()
+    try {
+      await handleRequestWithMiddleware(req, res, middleware)
+    } catch (err) {
+      res.status(500)
+    } finally {
+      res.end()
+    }
     return
   }
 


### PR DESCRIPTION
### What are the changes and their implications?

Middleware emit sync and async error so I wrap them try catch.

According to comment, it fails on win but also my local mac.

### Checklist

- [x] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes
