### PR TITLE
Fix Safari compatibility: shim requestIdleCallback

### DIFF
--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -2,6 +2,7 @@ import {queryCache, QueryKey} from "react-query"
 import {serialize} from "superjson"
 import {Resolver, EnhancedResolverRpcClient, QueryFn} from "../types"
 import {isServer, isClient} from "."
+import {requestIdleCallback} from "./request-idle-callback"
 
 type MutateOptions = {
   refetch?: boolean
@@ -20,21 +21,6 @@ export interface QueryCacheFunctions<T> {
 
 export const getQueryCacheFunctions = <T>(queryKey: QueryKey): QueryCacheFunctions<T> => ({
   mutate: (newData, opts = {refetch: true}) => {
-    // Shim from https://developers.google.com/web/updates/2015/08/using-requestidlecallback
-    const requestIdleCallback =
-      window.requestIdleCallback ||
-      function (cb: any) {
-        var start = Date.now()
-        return setTimeout(function () {
-          cb({
-            didTimeout: false,
-            timeRemaining: function () {
-              return Math.max(0, 50 - (Date.now() - start))
-            },
-          })
-        }, 1)
-      }
-
     return new Promise((res) => {
       queryCache.setQueryData(queryKey, newData)
       let result: void | ReturnType<typeof queryCache.invalidateQueries>

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -3,21 +3,6 @@ import {serialize} from "superjson"
 import {Resolver, EnhancedResolverRpcClient, QueryFn} from "../types"
 import {isServer, isClient} from "."
 
-// Shim from https://developers.google.com/web/updates/2015/08/using-requestidlecallback
-const requestIdleCallback =
-  window.requestIdleCallback ||
-  function (cb: any) {
-    var start = Date.now()
-    return setTimeout(function () {
-      cb({
-        didTimeout: false,
-        timeRemaining: function () {
-          return Math.max(0, 50 - (Date.now() - start))
-        },
-      })
-    }, 1)
-  }
-
 type MutateOptions = {
   refetch?: boolean
 }
@@ -35,6 +20,21 @@ export interface QueryCacheFunctions<T> {
 
 export const getQueryCacheFunctions = <T>(queryKey: QueryKey): QueryCacheFunctions<T> => ({
   mutate: (newData, opts = {refetch: true}) => {
+    // Shim from https://developers.google.com/web/updates/2015/08/using-requestidlecallback
+    const requestIdleCallback =
+      window.requestIdleCallback ||
+      function (cb: any) {
+        var start = Date.now()
+        return setTimeout(function () {
+          cb({
+            didTimeout: false,
+            timeRemaining: function () {
+              return Math.max(0, 50 - (Date.now() - start))
+            },
+          })
+        }, 1)
+      }
+
     return new Promise((res) => {
       queryCache.setQueryData(queryKey, newData)
       let result: void | ReturnType<typeof queryCache.invalidateQueries>

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -3,8 +3,20 @@ import {serialize} from "superjson"
 import {Resolver, EnhancedResolverRpcClient, QueryFn} from "../types"
 import {isServer, isClient} from "."
 
-// Use setTimeout when requestIdleCallback is unavailable i.e. on Safari
-const requestIdleCallback = window.requestIdleCallback || ((cb) => setTimeout(cb, 1))
+// Shim from https://developers.google.com/web/updates/2015/08/using-requestidlecallback
+const requestIdleCallback =
+  window.requestIdleCallback ||
+  function (cb: any) {
+    var start = Date.now()
+    return setTimeout(function () {
+      cb({
+        didTimeout: false,
+        timeRemaining: function () {
+          return Math.max(0, 50 - (Date.now() - start))
+        },
+      })
+    }, 1)
+  }
 
 type MutateOptions = {
   refetch?: boolean

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -3,6 +3,9 @@ import {serialize} from "superjson"
 import {Resolver, EnhancedResolverRpcClient, QueryFn} from "../types"
 import {isServer, isClient} from "."
 
+// Use setTimeout when requestIdleCallback is unavailable i.e. on Safari
+const requestIdleCallback = window.requestIdleCallback || ((cb) => setTimeout(cb, 1))
+
 type MutateOptions = {
   refetch?: boolean
 }
@@ -28,7 +31,7 @@ export const getQueryCacheFunctions = <T>(queryKey: QueryKey): QueryCacheFunctio
       }
       if (isClient) {
         // Fix for https://github.com/blitz-js/blitz/issues/1174
-        window.requestIdleCallback(() => {
+        requestIdleCallback(() => {
           res(result)
         })
       } else {

--- a/packages/core/src/utils/request-idle-callback.ts
+++ b/packages/core/src/utils/request-idle-callback.ts
@@ -1,0 +1,18 @@
+import {isClient} from "."
+
+// Shim from https://developers.google.com/web/updates/2015/08/using-requestidlecallback
+function requestIdleCallbackShim(cb: any) {
+  var start = Date.now()
+  return setTimeout(function () {
+    cb({
+      didTimeout: false,
+      timeRemaining: function () {
+        return Math.max(0, 50 - (Date.now() - start))
+      },
+    })
+  }, 1)
+}
+
+export const requestIdleCallback = isClient
+  ? window.requestIdleCallback || requestIdleCallbackShim
+  : requestIdleCallbackShim

--- a/packages/core/test/react-query-utils.test.ts
+++ b/packages/core/test/react-query-utils.test.ts
@@ -4,11 +4,26 @@ import {queryCache} from "react-query"
 jest.mock("react-query")
 
 describe("getQueryCacheFunctions", () => {
+  const spyRefetchQueries = jest.spyOn(queryCache, "invalidateQueries")
+
+  beforeEach(() => spyRefetchQueries.mockReset())
+
   it("returns a mutate function with working options", async () => {
     window.requestIdleCallback = jest.fn((fn) => {
       fn({} as any)
     })
-    const spyRefetchQueries = jest.spyOn(queryCache, "invalidateQueries")
+    const {mutate} = getQueryCacheFunctions("testQueryKey")
+    expect(mutate).toBeTruthy()
+    await mutate({newData: true})
+    expect(spyRefetchQueries).toBeCalledTimes(1)
+    await mutate({newData: true}, {refetch: false})
+    expect(spyRefetchQueries).toBeCalledTimes(1)
+    await mutate({newData: true}, {refetch: true})
+    expect(spyRefetchQueries).toBeCalledTimes(2)
+  })
+
+  it("works even when requestIdleCallback is undefined", async () => {
+    window.requestIdleCallback = undefined as any
     const {mutate} = getQueryCacheFunctions("testQueryKey")
     expect(mutate).toBeTruthy()
     await mutate({newData: true})


### PR DESCRIPTION
Closes: #1214 

### What are the changes and their implications?

Adds a shim for `requestIdleCallback` when undefined. `requestIdleCallback` is not supported on every browser, see https://caniuse.com/requestidlecallback.

### Checklist

- [x] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
