### PR TITLE
(newapp) Fix docs link on default homepage

### DIFF
--- a/packages/generator/templates/app/app/pages/index.tsx
+++ b/packages/generator/templates/app/app/pages/index.tsx
@@ -89,7 +89,7 @@ const Home: BlitzPage = () => {
         <div className="buttons" style={{ marginTop: "5rem" }}>
           <a
             className="button"
-            href="https://github.com/blitz-js/blitz/blob/master/USER_GUIDE.md?utm_source=blitz-new&utm_medium=app-template&utm_campaign=blitz-new"
+            href="https://blitzjs.com/docs/getting-started?utm_source=blitz-new&utm_medium=app-template&utm_campaign=blitz-new"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
I had this issue earlier today when a new app linked to a github page while we have pretty good documentation on the website.

Closes: ??