### PR TITLE
Fix `blitz generate model` to add fields to existing model instead of duplicating

### DIFF
--- a/packages/generator/src/generators/model-generator.ts
+++ b/packages/generator/src/generators/model-generator.ts
@@ -28,6 +28,8 @@ export class ModelGenerator extends Generator<ModelGeneratorOptions> {
       if (!this.fs.exists(path.resolve("db/schema.prisma"))) {
         throw new Error("Prisma schema file was not found")
       }
+      let updatedOrCreated = 'created';
+
       const extraArgs =
         this.options.extraArgs.length === 1 && this.options.extraArgs[0].includes(" ")
           ? this.options.extraArgs[0].split(" ")
@@ -57,12 +59,13 @@ export class ModelGenerator extends Generator<ModelGeneratorOptions> {
 
             //replace all content with the newly added fields for the already existing model
             this.fs.write(path.resolve("db/schema.prisma"), schema.replace(model, newModel))
+            updatedOrCreated = "updated";
           }
         }
       }
       log.success(
         `Model for '${this.options.modelName}'${
-          this.options.dryRun ? "" : " created successfully"
+          this.options.dryRun ? "" : ` ${updatedOrCreated} successfully`
         }:\n`,
       )
       modelDefinition.toString().split("\n").map(log.progress)

--- a/packages/generator/src/prisma/model.ts
+++ b/packages/generator/src/prisma/model.ts
@@ -71,6 +71,12 @@ export class Model {
       .join("")
   }
 
+  public getNewFields() {
+    return stringifyFieldsForPrinting([...this.fields])
+      .map((field) => `  ${field}\n`)
+      .join("")
+  }
+
   toString() {
     return `model ${this.name} {${this.getFields()}\n}`
   }

--- a/packages/generator/src/utils/match-between.ts
+++ b/packages/generator/src/utils/match-between.ts
@@ -1,0 +1,10 @@
+export function matchBetween(test: string, start: string, end: string) {
+  const re = new RegExp(`${start}([\\s\\S]*?)${end}`, "g")
+  const match = test.match(re)
+
+  if (match) {
+    return match[0]
+  }
+
+  return match
+}

--- a/packages/generator/test/utils/match-between.test.ts
+++ b/packages/generator/test/utils/match-between.test.ts
@@ -1,0 +1,49 @@
+import {matchBetween} from "../../src/utils/match-between"
+
+const model = `model User {
+  id             Int       @default(autoincrement()) @id
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+  name           String?
+  email          String    @unique
+  hashedPassword String?
+  role           String    @default("user")
+  sessions       Session[]
+}
+
+model Session {
+  id                 Int       @default(autoincrement()) @id
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+  expiresAt          DateTime?
+  handle             String    @unique
+  user               User?     @relation(fields: [userId], references: [id])
+  userId             Int?
+  hashedSessionToken String?
+  antiCSRFToken      String?
+  publicData         String?
+  privateData        String?
+}`
+
+describe("gets string between start and end", () => {
+  it("includes start and endpoint", () => {
+    const expected = `model User {
+  id             Int       @default(autoincrement()) @id
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+  name           String?
+  email          String    @unique
+  hashedPassword String?
+  role           String    @default("user")
+  sessions       Session[]
+}`
+
+    const actual = matchBetween(model, "model User", "}")
+    expect(actual).toBe(expected)
+  })
+
+  it("returns null if no match is found", () => {
+    const actual = matchBetween(model, "model Project", "}")
+    expect(actual).toBe(null)
+  })
+})


### PR DESCRIPTION
Updates the existing model only with missing fields.

Closes: #1210

### What are the changes and their implications?
Right now if a user generates a model that already exists a new model is added to the `schema.prisma`. This changes the behavior to update the existing model only with the fields that do not exist yet.

### Checklist

- [X ] Tests added for changes
- [X ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes - [PR](https://github.com/blitz-js/blitzjs.com/pull/214)

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
