### PR TITLE
Fix DocumentContext import in Material UI recipe

### DIFF
--- a/recipes/material-ui/index.ts
+++ b/recipes/material-ui/index.ts
@@ -51,7 +51,7 @@ This will let the next.js app opt out of the React.Strict mode wrapping. Once yo
           )
         }
       })
-      program.find(j.ImportDeclaration, {source: "blitz"}).forEach((blitzImportPath) => {
+      program.find(j.ImportDeclaration, {source: {value: "blitz"}}).forEach((blitzImportPath) => {
         if (
           !blitzImportPath.value.specifiers
             .filter((spec) => j.ImportSpecifier.check(spec))


### PR DESCRIPTION
Closes: #1248 

### What are the changes and their implications?

Fixes Material UI recipe not importing `DocumentContext` type which is later used in `getInitialProps` method of custom Document class.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
