### PR TITLE
Add tests for add-dependency-executor

### DIFF
--- a/packages/installer/jest.config.js
+++ b/packages/installer/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  moduleFileExtensions: ["ts", "js", "json"],
+  moduleFileExtensions: ["ts", "tsx", "js", "json"],
   coverageReporters: ["json", "lcov", "text", "clover"],
   // collectCoverage: !!`Boolean(process.env.CI)`,
   collectCoverageFrom: ["src/**/*.ts"],

--- a/packages/installer/src/executors/add-dependency-executor.tsx
+++ b/packages/installer/src/executors/add-dependency-executor.tsx
@@ -83,14 +83,20 @@ export const Propose: Executor["Propose"] = ({cliArgs, step, onProposalAccepted}
   )
 }
 
-function getPackageManager() {
+/**
+ * Exported for unit testing purposes
+ */
+export function getPackageManager() {
   if (fs.existsSync(path.resolve("package-lock.json"))) {
     return "npm"
   }
   return "yarn"
 }
 
-async function installPackages(packages: NpmPackage[], isDev = false) {
+/**
+ * Exported for unit testing purposes
+ */
+export async function installPackages(packages: NpmPackage[], isDev = false) {
   const packageManager = getPackageManager()
   const args: string[] = ["add"]
 

--- a/packages/installer/test/executors/add-dependency-executor.test.ts
+++ b/packages/installer/test/executors/add-dependency-executor.test.ts
@@ -1,0 +1,73 @@
+import * as AddDependencyExecutor from "../../src/executors/add-dependency-executor"
+import {existsSync} from "fs-extra"
+import {spawn} from "cross-spawn"
+import {mocked} from "ts-jest/utils"
+
+jest.mock("fs-extra")
+jest.mock("cross-spawn")
+
+describe("add dependency executor", () => {
+  const testConfiguration = {
+    stepId: "addDependencies",
+    stepName: "Add dependencies",
+    stepType: "add-dependency",
+    explanation: "This step will add some dependencies for testing purposes",
+    packages: [{name: "typescript", version: "4"}, {name: "ts-node"}],
+  }
+
+  it("should properly identify executor", () => {
+    const wrongConfiguration = {
+      stepId: "wrongStep",
+      stepName: "Wrong Step",
+      stepType: "wrong-type",
+      explanation: "This step is wrong",
+    }
+    expect(AddDependencyExecutor.isAddDependencyExecutor(wrongConfiguration)).toBeFalsy()
+    expect(AddDependencyExecutor.isAddDependencyExecutor(testConfiguration)).toBeTruthy()
+  })
+
+  it("should choose proper package manager according to lock file", () => {
+    mocked(existsSync).mockReturnValueOnce(true)
+    expect(AddDependencyExecutor.getPackageManager()).toEqual("npm")
+    expect(AddDependencyExecutor.getPackageManager()).toEqual("yarn")
+  })
+
+  it("should issue proper commands according to the specified packages", async () => {
+    const mockedSpawn = mockSpawn()
+    mocked(spawn).mockImplementation(mockedSpawn.spawn as any)
+
+    // NPM
+    mocked(existsSync).mockReturnValue(true)
+    await AddDependencyExecutor.installPackages(testConfiguration.packages, true)
+    await AddDependencyExecutor.installPackages(testConfiguration.packages, false)
+
+    // Yarn
+    mocked(existsSync).mockReturnValue(false)
+    await AddDependencyExecutor.installPackages(testConfiguration.packages, true)
+    await AddDependencyExecutor.installPackages(testConfiguration.packages, false)
+
+    expect(mockedSpawn.calls.length).toEqual(4)
+    expect(mockedSpawn.calls[0]).toEqual("npm add --save-dev typescript@4 ts-node")
+    expect(mockedSpawn.calls[1]).toEqual("npm add typescript@4 ts-node")
+    expect(mockedSpawn.calls[2]).toEqual("yarn add -D typescript@4 ts-node")
+    expect(mockedSpawn.calls[3]).toEqual("yarn add typescript@4 ts-node")
+  })
+})
+
+/**
+ * Primitive mock of spawn function
+ */
+const mockSpawn = () => {
+  let calls: string[] = []
+
+  return {
+    spawn: (command: string, args: string[], _: unknown = {}) => {
+      calls.push(`${command} ${args.join(" ")}`)
+
+      return {
+        on: (_: string, resolve: () => void) => resolve(),
+      }
+    },
+    calls,
+  }
+}


### PR DESCRIPTION
### What are the changes and their implications?
Added tests for `add-dependency-executor`. I decided to only test the actual functions that are doing real work(for example, spawning commands) instead of testing `Propose` and `Commit` components. The consequence of this is that I needed to export those functions, but I don't think it is a bad thing as I saw this in other places as well.

### Checklist

- [x] Tests added for changes
- [ ] ~~PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~~
