### PR TITLE
Fix broken session cookies prefix

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -3,7 +3,17 @@ import {join} from "path"
 import {existsSync} from "fs"
 import {PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_SERVER} from "next/constants"
 
+export const getProjectRoot = () => {
+  return pkgDir.sync() || process.cwd()
+}
+
+export const getPackageJson = () => {
+  const projectRoot = getProjectRoot()
+  return require(join(projectRoot, "package.json"))
+}
+
 const configFiles = ["blitz.config.js", "next.config.js"]
+
 /**
  * @param {boolean | undefined} reload - reimport config files to reset global cache
  */
@@ -13,7 +23,7 @@ export const getConfig = (reload?: boolean): Record<string, unknown> => {
   }
 
   let blitzConfig = {}
-  const projectRoot = pkgDir.sync() || process.cwd()
+  const projectRoot = getProjectRoot()
 
   for (const configFile of configFiles) {
     if (existsSync(join(projectRoot, configFile))) {

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -3,9 +3,13 @@ import {publicDataStore} from "./public-data-store"
 import {useIsomorphicLayoutEffect} from "./utils/hooks"
 import {readCookie} from "./utils/cookie"
 
-const sessionPrefix = (process.env.SESSION_PREFIX ||
-  process.env.sessionPrefix ||
-  process.env.npm_package_name)!.replace(/[^a-zA-Z0-9-_]/g, "_")
+const sessionPrefix =
+  (
+    process.env.SESSION_PREFIX ||
+    process.env.sessionPrefix ||
+    process.env.npm_package_name ||
+    ""
+  ).replace(/[^a-zA-Z0-9-_]/g, "_") + "_"
 
 export const TOKEN_SEPARATOR = ";"
 export const HANDLE_SEPARATOR = ":"

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -3,13 +3,7 @@ import {publicDataStore} from "./public-data-store"
 import {useIsomorphicLayoutEffect} from "./utils/hooks"
 import {readCookie} from "./utils/cookie"
 
-const sessionPrefix =
-  (
-    process.env.SESSION_PREFIX ||
-    process.env.sessionPrefix ||
-    process.env.npm_package_name ||
-    ""
-  ).replace(/[^a-zA-Z0-9-_]/g, "_") + "_"
+const sessionPrefix = (process.env.SESSION_PREFIX || "").replace(/[^a-zA-Z0-9-_]/g, "_") + "_"
 
 export const TOKEN_SEPARATOR = ";"
 export const HANDLE_SEPARATOR = ":"

--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -1,6 +1,11 @@
 import pkgDir from "pkg-dir"
 import path from "path"
 import fs from "fs"
+import {getPackageJson} from "@blitzjs/config"
+
+if (!process.env.SESSION_PREFIX) {
+  process.env.SESSION_PREFIX = getPackageJson().name
+}
 
 export function withBlitz(nextConfig: any) {
   return (phase: string, nextOpts: any = {}) => {
@@ -15,7 +20,7 @@ export function withBlitz(nextConfig: any) {
         ...(normalizedConfig.experimental || {}),
       },
       env: {
-        sessionPrefix: process.env.SESSION_PREFIX || process.env.npm_package_name,
+        SESSION_PREFIX: process.env.SESSION_PREFIX,
         ...(normalizedConfig.env || {}),
       },
       webpack(config: any, options: Record<any, any>) {


### PR DESCRIPTION
### What are the changes and their implications?

Fix broken session cookies prefix which was added in `v0.24.0-canary.3` via https://github.com/blitz-js/blitz/pull/1229

Closes: https://github.com/blitz-js/blitz/issues/1153

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
