### PR TITLE
add @default(now())  to generated updatedAt field

### DIFF
--- a/examples/auth/db/schema.prisma
+++ b/examples/auth/db/schema.prisma
@@ -22,7 +22,7 @@ generator client {
 model User {
   id             Int       @default(autoincrement()) @id
   createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
+  updatedAt      DateTime  @default(now()) @updatedAt
   name           String?
   email          String    @unique
   hashedPassword String?
@@ -33,7 +33,7 @@ model User {
 model Session {
   id                 Int       @default(autoincrement()) @id
   createdAt          DateTime  @default(now())
-  updatedAt          DateTime  @updatedAt
+  updatedAt          DateTime  @default(now()) @updatedAt
   expiresAt          DateTime?
   handle             String    @unique
   user               User?     @relation(fields: [userId], references: [id])

--- a/examples/store/db/schema.prisma
+++ b/examples/store/db/schema.prisma
@@ -17,23 +17,22 @@ generator client {
   provider = "prisma-client-js"
 }
 
-
 // --------------------------------------
 
 model User {
-  id      Int      @default(autoincrement()) @id
+  id        Int      @id @default(autoincrement())
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  email   String   @unique
-  name    String?
-  role    String?
-  storeId Int?
+  updatedAt DateTime @default(now()) @updatedAt
+  email     String   @unique
+  name      String?
+  role      String?
+  storeId   Int?
 }
 
 model Product {
-  id          Int      @default(autoincrement()) @id
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id          Int      @id @default(autoincrement())
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @default(now()) @updatedAt
   handle      String   @unique
   name        String?
   description String?

--- a/packages/generator/src/prisma/field.ts
+++ b/packages/generator/src/prisma/field.ts
@@ -201,7 +201,7 @@ export class Field {
   }
 
   private getIsUpdatedAt() {
-    return this.isUpdatedAt ? "@updatedAt" : ""
+    return this.isUpdatedAt ? "@default(now()) @updatedAt" : ""
   }
 
   private getRelation() {

--- a/packages/generator/templates/app/db/schema.prisma
+++ b/packages/generator/templates/app/db/schema.prisma
@@ -13,9 +13,9 @@ generator client {
 // --------------------------------------
 
 model User {
-  id             Int       @default(autoincrement()) @id
+  id             Int       @id @default(autoincrement())
   createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
+  updatedAt      DateTime  @default(now()) @updatedAt
   name           String?
   email          String    @unique
   hashedPassword String?
@@ -24,9 +24,9 @@ model User {
 }
 
 model Session {
-  id                 Int       @default(autoincrement()) @id
+  id                 Int       @id @default(autoincrement())
   createdAt          DateTime  @default(now())
-  updatedAt          DateTime  @updatedAt
+  updatedAt          DateTime  @default(now()) @updatedAt
   expiresAt          DateTime?
   handle             String    @unique
   user               User?     @relation(fields: [userId], references: [id])


### PR DESCRIPTION
# What are the changes and their implications?

I noticed that the current schema setup generates something like:
```updatedAt     DateTime     @updatedAt```

The problem here is that when you first create a database entry using this model, it will have a `createdAt` value of `now()` but an `updatedAt` value of 1st Jan 1970

This PR should make it so that when a database entry is first created, the `createdAt` and `updatedAt` values will be the same.

It should now look like:

```updatedAt     DateTime     default(now()) @updatedAt```


### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
