### PR TITLE
Fix global CLI on canary by dynamically require server package

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,3 +1,4 @@
+import {build as ServerBuild} from "@blitzjs/server"
 import {Command} from "@oclif/command"
 
 export class Build extends Command {
@@ -10,7 +11,8 @@ export class Build extends Command {
     }
 
     try {
-      await require("@blitzjs/server").build(config)
+      const build: typeof ServerBuild = require("@blitzjs/server").build
+      await build(config)
     } catch (err) {
       console.error(err)
       process.exit(1) // clean up?

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,4 +1,4 @@
-import {dev, prod} from "@blitzjs/server"
+import {dev as Dev, prod as Prod} from "@blitzjs/server"
 import {Command, flags} from "@oclif/command"
 
 export class Start extends Command {
@@ -39,8 +39,10 @@ export class Start extends Command {
 
     try {
       if (flags.production) {
+        const prod: typeof Prod = require("@blitzjs/server").prod
         await prod(config)
       } else {
+        const dev: typeof Dev = require("@blitzjs/server").dev
         await dev(config)
       }
     } catch (err) {


### PR DESCRIPTION
### What are the changes and their implications?

This fixes an issue on canary where react-dom can't be found when using blitz cli.


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
