### PR TITLE
Remove "--experimental" from "blitz db studio"

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -255,7 +255,7 @@ ${require("chalk").bold(
     }
 
     if (command === "studio") {
-      return runPrismaExitOnError(["studio", schemaArg, "--experimental"])
+      return runPrismaExitOnError(["studio", schemaArg])
     }
 
     if (command === "reset") {

--- a/packages/cli/test/commands/db.test.ts
+++ b/packages/cli/test/commands/db.test.ts
@@ -188,7 +188,7 @@ describe("Db command", () => {
   it("runs db studio", async () => {
     await Db.run(["studio"])
 
-    expect(spawn).toHaveBeenCalledWith(prismaBin, ["studio", schemaArg, "--experimental"], {
+    expect(spawn).toHaveBeenCalledWith(prismaBin, ["studio", schemaArg], {
       stdio: "inherit",
       env: process.env,
     })


### PR DESCRIPTION
Running `blitz db studio` outputs `warn --experimental is no longer required for this command` to the terminal

I guess this is since Prisma made Studio stable, so `experimental` is no longer required.

Closes: ??

### What are the changes and their implications?

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
