### PR TITLE
(newapp) Fix validateDOMNesting error from default home page

### DIFF
--- a/packages/generator/templates/app/app/pages/index.tsx
+++ b/packages/generator/templates/app/app/pages/index.tsx
@@ -76,16 +76,23 @@ const Home: BlitzPage = () => {
         <pre>
           <code>blitz db migrate</code>
         </pre>
-
-        <p>
-          Then <strong>restart the server</strong>
-            <pre><code>Ctrl + c</code></pre>
-            <pre><code>blitz start</code></pre>
+        <div>
+          <p>
+            Then <strong>restart the server</strong>
+          </p>
+          <pre>
+            <code>Ctrl + c</code>
+          </pre>
+          <pre>
+            <code>blitz start</code>
+          </pre>
+          <p>
             and go to{" "}
-          <Link href="/projects">
-            <a>/projects</a>
-          </Link>
-        </p>
+            <Link href="/projects">
+              <a>/projects</a>
+            </Link>
+          </p>
+        </div>
         <div className="buttons" style={{ marginTop: "5rem" }}>
           <a
             className="button"
@@ -231,6 +238,7 @@ const Home: BlitzPage = () => {
           background: #fafafa;
           border-radius: 5px;
           padding: 0.75rem;
+          text-align: center;
         }
         code {
           font-size: 0.9rem;


### PR DESCRIPTION
A `<pre>` cannot appear as a descendant of `<p>`. This will throw an error on a newly created project.

<img width="625" alt="Screen Shot 2020-10-08 at 21 25 39" src="https://user-images.githubusercontent.com/692542/95505672-09023b00-09af-11eb-8f21-c62e96b78cc5.png">

I'm quite new to the codebase and didn't really know how to create a project using the updated template. I've only tested it by copying pasting the code to a project created with my global installed blitz CLI.

### What are the changes and their implications?
Changed to remove the `<pre>` from inside the `<p>`. I tried to keep the same design and to do that added an empty `<div>` and a `text-align: center;` to the `pre` selector.

**Here is a screenshot of the visually unchanged page:**
<img width="607" alt="Screen Shot 2020-10-08 at 21 27 17" src="https://user-images.githubusercontent.com/692542/95505668-07d10e00-09af-11eb-9a45-19d3398c2723.png">

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
