### PR TITLE
Fix all recipes to add their context providers above getLayout()

### DIFF
--- a/recipes/chakra/index.ts
+++ b/recipes/chakra/index.ts
@@ -5,21 +5,24 @@ import {Collection} from "jscodeshift/src/Collection"
 
 // Copied from https://github.com/blitz-js/blitz/pull/805, let's add this to the @blitzjs/installer
 function wrapComponentWithThemeProvider(program: Collection<j.Program>) {
-  program.find(j.JSXIdentifier, {name: "Component"}).forEach((path: NodePath) => {
-    j(path.parent).replaceWith(
-      j.jsxElement(
-        j.jsxOpeningElement(j.jsxIdentifier("ThemeProvider")),
-        j.jsxClosingElement(j.jsxIdentifier("ThemeProvider")),
-        [
-          j.jsxText("\n"),
-          j.jsxElement(j.jsxOpeningElement(j.jsxIdentifier("CSSReset"), [], true)),
-          j.jsxText("\n"),
-          path.parent.parent.node,
-          j.jsxText("\n"),
-        ],
-      ),
-    )
-  })
+  program
+    .find(j.JSXExpressionContainer, {expression: {callee: {name: "getLayout"}}})
+    .forEach((path: NodePath) => {
+      const {node} = path
+      path.replace(
+        j.jsxElement(
+          j.jsxOpeningElement(j.jsxIdentifier("ThemeProvider")),
+          j.jsxClosingElement(j.jsxIdentifier("ThemeProvider")),
+          [
+            j.jsxText("\n"),
+            j.jsxElement(j.jsxOpeningElement(j.jsxIdentifier("CSSReset"), [], true)),
+            j.jsxText("\n"),
+            node,
+            j.jsxText("\n"),
+          ],
+        ),
+      )
+    })
   return program
 }
 

--- a/recipes/emotion/index.ts
+++ b/recipes/emotion/index.ts
@@ -4,17 +4,23 @@ import j from "jscodeshift"
 import {Collection} from "jscodeshift/src/Collection"
 
 function wrapComponentWithCacheProvider(program: Collection<j.Program>) {
-  program.find(j.JSXIdentifier, {name: "Component"}).forEach((path) => {
-    j(path.parent).replaceWith(
-      j.jsxElement(
-        j.jsxOpeningElement(j.jsxIdentifier("CacheProvider"), [
-          j.jsxAttribute(j.jsxIdentifier("value"), j.jsxExpressionContainer(j.identifier("cache"))),
-        ]),
-        j.jsxClosingElement(j.jsxIdentifier("CacheProvider")),
-        [j.jsxText("\n"), path.parent.parent.node, j.jsxText("\n")],
-      ),
-    )
-  })
+  program
+    .find(j.JSXExpressionContainer, {expression: {callee: {name: "getLayout"}}})
+    .forEach((path) => {
+      const {node} = path
+      path.replace(
+        j.jsxElement(
+          j.jsxOpeningElement(j.jsxIdentifier("CacheProvider"), [
+            j.jsxAttribute(
+              j.jsxIdentifier("value"),
+              j.jsxExpressionContainer(j.identifier("cache")),
+            ),
+          ]),
+          j.jsxClosingElement(j.jsxIdentifier("CacheProvider")),
+          [j.jsxText("\n"), node, j.jsxText("\n")],
+        ),
+      )
+    })
   return program
 }
 

--- a/recipes/material-ui/index.ts
+++ b/recipes/material-ui/index.ts
@@ -298,27 +298,30 @@ This will let the next.js app opt out of the React.Strict mode wrapping. Once yo
           node.body.body.splice(0, 0, removeServerSideInjectedCss)
         }
       })
-      program.find(j.JSXElement, {openingElement: {name: {name: "Component"}}}).forEach((path) => {
-        const {node} = path
-        path.replace(
-          j.jsxElement(
-            j.jsxOpeningElement(j.jsxIdentifier("ThemeProvider"), [
-              j.jsxAttribute(
-                j.jsxIdentifier("theme"),
-                j.jsxExpressionContainer(j.identifier("theme")),
-              ),
-            ]),
-            j.jsxClosingElement(j.jsxIdentifier("ThemeProvider")),
-            [
-              j.literal("\n"),
-              j.jsxElement(j.jsxOpeningElement(j.jsxIdentifier("CssBaseline"), [], true)),
-              j.literal("\n"),
-              node,
-              j.literal("\n"),
-            ],
-          ),
-        )
-      })
+
+      program
+        .find(j.JSXExpressionContainer, {expression: {callee: {name: "getLayout"}}})
+        .forEach((path) => {
+          const {node} = path
+          path.replace(
+            j.jsxElement(
+              j.jsxOpeningElement(j.jsxIdentifier("ThemeProvider"), [
+                j.jsxAttribute(
+                  j.jsxIdentifier("theme"),
+                  j.jsxExpressionContainer(j.identifier("theme")),
+                ),
+              ]),
+              j.jsxClosingElement(j.jsxIdentifier("ThemeProvider")),
+              [
+                j.literal("\n"),
+                j.jsxElement(j.jsxOpeningElement(j.jsxIdentifier("CssBaseline"), [], true)),
+                j.literal("\n"),
+                node,
+                j.literal("\n"),
+              ],
+            ),
+          )
+        })
 
       // import React if it wasn't already imported
       if (!isReactImported) {


### PR DESCRIPTION
Closes: #950 

### What are the changes and their implications?

This PR makes recipes wrap not only `Component` but also `getLayout` with context providers.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
