### PR TITLE
Fix to allow babel config modification in Recipes

### DIFF
--- a/packages/installer/src/utils/paths.ts
+++ b/packages/installer/src/utils/paths.ts
@@ -15,6 +15,9 @@ export const paths = {
   entry() {
     return `app/pages/index${ext(true)}`
   },
+  babelConfig() {
+    return "babel.config.js"
+  },
   blitzConfig() {
     return "blitz.config.js"
   },

--- a/packages/installer/test/utils/paths.test.ts
+++ b/packages/installer/test/utils/paths.test.ts
@@ -9,8 +9,9 @@ describe("path utils", () => {
     expect(paths.document()).toBe("app/pages/_document.tsx")
     expect(paths.app()).toBe("app/pages/_app.tsx")
     expect(paths.entry()).toBe("app/pages/index.tsx")
-    // blitz config is always JS, we shouldn't transform this extension
+    // Blitz and Babel configs are always JS, we shouldn't transform this extension
     expect(paths.blitzConfig()).toBe("blitz.config.js")
+    expect(paths.babelConfig()).toBe("babel.config.js")
   })
 
   // SKIP test because the fs mock is failing on windows
@@ -20,5 +21,6 @@ describe("path utils", () => {
     expect(paths.app()).toBe("app/pages/_app.js")
     expect(paths.entry()).toBe("app/pages/index.js")
     expect(paths.blitzConfig()).toBe("blitz.config.js")
+    expect(paths.babelConfig()).toBe("babel.config.js")
   })
 })


### PR DESCRIPTION
Closes: #1276 

### What are the changes and their implications?
Allows changing `babel.config.js` from recipes

### Checklist

- [x] Tests added for changes
- [ ] ~~PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~~
