### PR TITLE
Add initialPublicData param to useSession hook to allow server-fetched sessions

### DIFF
--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -100,8 +100,8 @@ export const parsePublicDataToken = (token: string) => {
   }
 }
 
-export const useSession = () => {
-  const [publicData, setPublicData] = useState(publicDataStore.emptyPublicData)
+export const useSession = (initialPublicData?: PublicData) => {
+  const [publicData, setPublicData] = useState(initialPublicData ?? publicDataStore.emptyPublicData)
   const [isLoading, setIsLoading] = useState(true)
 
   useIsomorphicLayoutEffect(() => {

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -102,12 +102,15 @@ export const parsePublicDataToken = (token: string) => {
 
 export const useSession = (initialPublicData?: PublicData) => {
   const [publicData, setPublicData] = useState(initialPublicData ?? publicDataStore.emptyPublicData)
-  const [isLoading, setIsLoading] = useState(true)
+  // skip loading if initial public data is provided
+  const [isLoading, setIsLoading] = useState(!initialPublicData)
 
   useIsomorphicLayoutEffect(() => {
-    // Initialize on mount
-    setPublicData(publicDataStore.getData())
-    setIsLoading(false)
+    if (!initialPublicData) {
+      // Initialize on mount
+      setPublicData(publicDataStore.getData())
+      setIsLoading(false)
+    }
     const subscription = publicDataStore.observable.subscribe(setPublicData)
     return subscription.unsubscribe
   }, [])


### PR DESCRIPTION
### What are the changes and their implications?

Currently, if someone is using `getSessionContext` in `getServerSideProps`, the session still has to be re-fetched from `PublicDataStore` when using the `useSession` hook.

When working on my own app, i wanted to avoid the flickering of a login screen while the session was being fetched:
```ts
export const getServerSideProps: GetServerSideProps = async ({
  req,
  res,
}) => {
  const session = await getSessionContext(req, res);
  const publicData = session?.publicData;

  return { props: { publicData } }
}

// in render
const Home: BlitzPage = () => {
  const session = useSession(); // => useSession is undefined while loading, despite being fetched server-side
}
```

This change would allow public to be optionally passed to the session and avoid any brief flickering / loading states while the publicData is being fetched from `PublicDataStore`.

```ts
const Home: BlitzPage = ({ publicData }) => {
  const session = useSession(publicData); // => useSession is undefined while loading, despite being fetched server-side
}
```

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

I plan to add tests to this dependent on https://github.com/blitz-js/blitz/pull/1258 being merged.
