### PR TITLE
(newapp) Add yarn/npx to global install instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ You need Node.js 12 or newer
 
 #### Install Blitz
 
-Run `npm install -g blitz`
+Run `npm install -g blitz` or `yarn global add blitz`
+
+_You can alternatively use [`npx`](https://www.npmjs.com/package/npx)_
 
 #### Create a New App
 


### PR DESCRIPTION
Helps with: #1003 

### What are the changes and their implications?

There is only a small change in the main `README.md` file. I was trying to install and run blitzjs for very first time and I had this same issue #1003 . Even I don't know how to fix real the problem, I found the answers in that issue helpful to be able to continue so I think is a good idea to let the other people know that they also have `yarn` and `npx` as options.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes
