### PR TITLE
Add `getConfig` export from core for next/config

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,6 +79,8 @@ export {default as dynamic} from "next/dynamic"
 
 export {default as ErrorComponent} from "next/error"
 
+export {default as getConfig} from "next/config"
+
 export type BlitzComponentType<C = NextPageContext, IP = {}, P = {}> = NextComponentType<C, IP, P>
 
 export interface AppProps<P = {}> extends NextAppProps<P> {


### PR DESCRIPTION
Closes: #1286

### What are the changes and their implications?
Exporting next/config in blitz/core

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
