### PR TITLE
(newapp) Fix tests not working out of box

### DIFF
--- a/packages/generator/templates/app/jest.config.js
+++ b/packages/generator/templates/app/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
     "^.+\\.(ts|tsx)$": "babel-jest",
   },
   // This makes absolute imports work
-  moduleDirectories: ["node_modules", "."],
+  moduleDirectories: ["node_modules", "<rootDir>"],
   modulePathIgnorePatterns: [".blitz"],
   moduleNameMapper: {
     // This ensures any path aliases in tsconfig also work in jest


### PR DESCRIPTION
## What are the changes and their implications?
Currently `blitz new test; cd test; blitz db migrate; blitz test` would fail with
```
TypeError: Cannot read property 'createContext' of undefined
````

This is caused by react-query has `require("react")` inside a folder named react, and adding `"."` to moduleDirectories seems to make jest add current directory to module path for ALL dependencies.

Fix this by using `"<rootDir>"` instead of `"."`.

