### PR TITLE
Fix recipes to add their providers at the root of App's return function

### DIFF
--- a/recipes/chakra/index.ts
+++ b/recipes/chakra/index.ts
@@ -6,7 +6,12 @@ import {Collection} from "jscodeshift/src/Collection"
 // Copied from https://github.com/blitz-js/blitz/pull/805, let's add this to the @blitzjs/installer
 function wrapComponentWithThemeProvider(program: Collection<j.Program>) {
   program
-    .find(j.JSXExpressionContainer, {expression: {callee: {name: "getLayout"}}})
+    .find(j.JSXElement)
+    .filter(
+      (path) =>
+        path.parent?.parent?.parent?.value?.id?.name === "App" &&
+        path.parent?.value.type === j.ReturnStatement.toString(),
+    )
     .forEach((path: NodePath) => {
       const {node} = path
       path.replace(

--- a/recipes/emotion/index.ts
+++ b/recipes/emotion/index.ts
@@ -5,7 +5,12 @@ import {Collection} from "jscodeshift/src/Collection"
 
 function wrapComponentWithCacheProvider(program: Collection<j.Program>) {
   program
-    .find(j.JSXExpressionContainer, {expression: {callee: {name: "getLayout"}}})
+    .find(j.JSXElement)
+    .filter(
+      (path) =>
+        path.parent?.parent?.parent?.value?.id?.name === "App" &&
+        path.parent?.value.type === j.ReturnStatement.toString(),
+    )
     .forEach((path) => {
       const {node} = path
       path.replace(

--- a/recipes/material-ui/index.ts
+++ b/recipes/material-ui/index.ts
@@ -300,7 +300,12 @@ This will let the next.js app opt out of the React.Strict mode wrapping. Once yo
       })
 
       program
-        .find(j.JSXExpressionContainer, {expression: {callee: {name: "getLayout"}}})
+        .find(j.JSXElement)
+        .filter(
+          (path) =>
+            path.parent?.parent?.parent?.value?.id?.name === "App" &&
+            path.parent?.value.type === j.ReturnStatement.toString(),
+        )
         .forEach((path) => {
           const {node} = path
           path.replace(


### PR DESCRIPTION
Closes: #1305 

### What are the changes and their implications?

This PR makes recipes to add their providers at the root of JSX element returned by custom App component.

In my approach, firstly, all JSX elements are found and then those that are first level children of return statement of App function declaration are chosen to get wrapped with providers. This approach won't work as desired if someone changes the name of App component however I think it's rarely the case.

Another approach could be finding `<Component />` JSX element and then recursively checking if its parent is at the root of the return statement -- if so wrap it with providers. So if you prefer it over the original one, let me know. 

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
