### PR TITLE
Export missing `AuthenticatedSessionContext` type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export {
   useSession,
   SessionConfig, // new
   SessionContext,
+  AuthenticatedSessionContext,
 } from "./supertokens"
 
 // --------------------


### PR DESCRIPTION
Closes: #1326

### What are the changes and their implications?

`AuthenticatedSessionContext` type re-exported.

![image](https://user-images.githubusercontent.com/37031328/96047319-30f11300-0e75-11eb-9c58-8a5e8920c943.png)
