### PR TITLE
Fix db.connect error when using without prisma

### DIFF
--- a/packages/server/src/stages/rpc/index.ts
+++ b/packages/server/src/stages/rpc/index.ts
@@ -42,12 +42,12 @@ let db${useTypes ? ": any" : ""}
 let connect${useTypes ? ": any" : ""}
 try {
   db = require('db').default
-  connect = require('db').connect ?? (() => db.$connect ? db.$connect() : db.connect())
-}catch(err){}
+  connect = require('db').connect ?? db?.$connect ?? db?.connect ?? (() => {})
+} catch(err) {}
 export default rpcApiHandler(
   enhancedResolver,
   getAllMiddlewareForModule(enhancedResolver),
-  () => db && connect(),
+  () => db && connect?.(),
 )
 export const config = {
   api: {


### PR DESCRIPTION
Closes: #1331 

### What are the changes and their implications?

Where the `db` and `connect` functions are imported in the generated code for the API file, there wasn't a check for if the `db` doesn't have a connect function (or is `undefined` itself). Added this so that an error is not thrown if somebody uses this without Prisma or another `db` setup

### Checklist

- [ ] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
