### PR TITLE
Adds test to assert useMutation validation

### DIFF
--- a/packages/core/test/__snapshots__/use-mutation.test.tsx.snap
+++ b/packages/core/test/__snapshots__/use-mutation.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useMutation useMutation calls the resolver with the argument shouldn't work with regular functions 1`] = `"It looks like you are trying to use Blitz's useQuery to fetch from third-party APIs. To do that, import useQuery directly from \\"react-query\\""`;

--- a/packages/core/test/use-mutation.test.tsx
+++ b/packages/core/test/use-mutation.test.tsx
@@ -32,7 +32,7 @@ describe("useMutation", () => {
   describe("useMutation calls the resolver with the argument", () => {
     // eslint-disable-next-line require-await
     const mutateFn = jest.fn()
-    it("should work with Blitz queries", async () => {
+    it("should work with Blitz mutations", async () => {
       const [res] = setupHook(enhance(mutateFn))
       await act(async () => {
         await res.mutate!("data")
@@ -40,6 +40,10 @@ describe("useMutation", () => {
         expect(mutateFn).toHaveBeenCalledTimes(1)
         expect(mutateFn).toHaveBeenCalledWith("data", {fromQueryHook: true})
       })
+    })
+
+    it("shouldn't work with regular functions", () => {
+      expect(() => setupHook(mutateFn)).toThrowErrorMatchingSnapshot()
     })
   })
 })


### PR DESCRIPTION
Closes: ??

Relates to the discussion I raised on: https://blitzjs.slack.com/archives/C011EQ0J75M/p1603015853243500

I was looking into the reasons why we cannot test components using `useMutation` and `useQuery`, then I looked at blitz core code I noticed that the validation of the `useMutation` query is not being tested. Therefore we can accidentally introduce a regression so I took the time to add the test case for that.

### What are the changes and their implications?
It increases the confidence while making changes on `useMutation` 🙌 

### Checklist
- [x] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
