### PR TITLE
(newapp) Fix tests not found if app has blitz in the name

### DIFF
--- a/packages/generator/templates/app/jest.config.js
+++ b/packages/generator/templates/app/jest.config.js
@@ -16,7 +16,8 @@ module.exports = {
   },
   // This makes absolute imports work
   moduleDirectories: ["node_modules", "<rootDir>"],
-  modulePathIgnorePatterns: [".blitz"],
+  // Ignore the build directories
+  modulePathIgnorePatterns: ["<rootDir>/.blitz", "<rootDir>/.next"],
   moduleNameMapper: {
     // This ensures any path aliases in tsconfig also work in jest
     ...pathsToModuleNameMapper(compilerOptions.paths || {}),


### PR DESCRIPTION
Closes: #1296 

### What are the changes and their implications?

The newapp jest config had `modulePathIgnorePatterns: [".blitz"]` to ignore the blitz build directory, but this is a regex and so if the project name had "blitz" in it, then all tests in the project would be ignored.

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
