### PR TITLE
Fix `blitz db seed` not working

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -149,6 +149,8 @@ export function getDbName(connectionString: string): string {
 }
 
 async function runSeed() {
+  require("../utils/setup-ts-node").setupTsnode()
+                                                      
   const projectRoot = require("../utils/get-project-root").projectRoot
   const seedPath = require("path").join(projectRoot, "db/seeds")
   const dbPath = require("path").join(projectRoot, "db/index")


### PR DESCRIPTION
Closes: #1221 

The `seed` method tries to load the `db/seeds.ts` TypeScript module which fails unless ts-node is imported.
It was working in development mode because oclif automatically sets up ts-node.
The current unite tests were passing because loading of the `db/seeds.ts` is mocked.

### What are the changes and their implications?

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
