### PR TITLE
fix types of auth mutations in examples and generator

### DIFF
--- a/examples/auth/app/auth/mutations/login.ts
+++ b/examples/auth/app/auth/mutations/login.ts
@@ -1,8 +1,8 @@
 import {Ctx} from "blitz"
 import {authenticateUser} from "app/auth/auth-utils"
-import {LoginInput, LoginInputType} from "../validations"
+import {LoginInput} from "../validations"
 
-export default async function login(input: LoginInputType, {session}: Ctx) {
+export default async function login(input: unknown, {session}: Ctx) {
   // This throws an error if input is invalid
   const {email, password} = LoginInput.parse(input)
 

--- a/examples/auth/app/auth/mutations/signup.ts
+++ b/examples/auth/app/auth/mutations/signup.ts
@@ -1,9 +1,9 @@
 import {Ctx} from "blitz"
 import db from "db"
 import {hashPassword} from "app/auth/auth-utils"
-import {SignupInput, SignupInputType} from "app/auth/validations"
+import {SignupInput} from "app/auth/validations"
 
-export default async function signup(input: SignupInputType, {session}: Ctx) {
+export default async function signup(input: unknown, {session}: Ctx) {
   // This throws an error if input is invalid
   const {email, password} = SignupInput.parse(input)
 

--- a/packages/generator/templates/app/app/auth/mutations/login.ts
+++ b/packages/generator/templates/app/app/auth/mutations/login.ts
@@ -1,8 +1,8 @@
 import { Ctx } from "blitz"
 import { authenticateUser } from "app/auth/auth-utils"
-import { LoginInput, LoginInputType } from "../validations"
+import { LoginInput } from "../validations"
 
-export default async function login(input: LoginInputType, { session }: Ctx) {
+export default async function login(input: unknown, { session }: Ctx) {
   // This throws an error if input is invalid
   const { email, password } = LoginInput.parse(input)
 

--- a/packages/generator/templates/app/app/auth/mutations/signup.ts
+++ b/packages/generator/templates/app/app/auth/mutations/signup.ts
@@ -1,9 +1,9 @@
 import { Ctx } from "blitz"
 import db from "db"
 import { hashPassword } from "app/auth/auth-utils"
-import { SignupInput, SignupInputType } from "app/auth/validations"
+import { SignupInput } from "app/auth/validations"
 
-export default async function signup(input: SignupInputType, { session }: Ctx) {
+export default async function signup(input: unknown, { session }: Ctx) {
   // This throws an error if input is invalid
   const { email, password } = SignupInput.parse(input)
 


### PR DESCRIPTION
By typing them as `LoginInputType` and `SignupInputType`, the user could access fields in the object before validation. Now they can only do after validation.

<img width="813" alt="Screenshot 2020-10-21 at 1 33 30 AM" src="https://user-images.githubusercontent.com/217126/96641344-34d3d800-1342-11eb-969b-90a243cb68b7.png">


### What are the changes and their implications?

This change fixes a possible source of runtime type errors.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->

I don't think this kind of change requires adding a test?