### PR TITLE
Add custom type guards for error checking

### DIFF
--- a/examples/auth/app/pages/_app.tsx
+++ b/examples/auth/app/pages/_app.tsx
@@ -1,5 +1,12 @@
-import {AppProps, ErrorComponent, useRouter} from "blitz"
-import {ErrorBoundary} from "react-error-boundary"
+import {
+  AppProps,
+  BlitzError,
+  ErrorComponent,
+  isAuthenticationError,
+  isAuthorizationError,
+  useRouter,
+} from "blitz"
+import {ErrorBoundary, FallbackProps} from "react-error-boundary"
 import {queryCache} from "react-query"
 import LoginForm from "app/auth/components/LoginForm"
 
@@ -24,10 +31,10 @@ export default function App({Component, pageProps}: AppProps) {
   )
 }
 
-function RootErrorFallback({error, resetErrorBoundary}) {
-  if (error.name === "AuthenticationError") {
+function RootErrorFallback({error, resetErrorBoundary}: FallbackProps) {
+  if (isAuthenticationError(error)) {
     return <LoginForm onSuccess={resetErrorBoundary} />
-  } else if (error.name === "AuthorizationError") {
+  } else if (isAuthorizationError(error)) {
     return (
       <ErrorComponent
         statusCode={error.statusCode}
@@ -36,7 +43,10 @@ function RootErrorFallback({error, resetErrorBoundary}) {
     )
   } else {
     return (
-      <ErrorComponent statusCode={error.statusCode || 400} title={error.message || error.name} />
+      <ErrorComponent
+        statusCode={(error as BlitzError)?.statusCode || 400}
+        title={(error as BlitzError)?.message || (error as BlitzError)?.name}
+      />
     )
   }
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -39,6 +39,16 @@ export class NotFoundError extends Error {
   }
 }
 
+export const isAuthenticationError = (
+  maybeAuthenticationError: any,
+): maybeAuthenticationError is AuthenticationError =>
+  maybeAuthenticationError.name === AuthenticationError.name
+
+export const isAuthorizationError = (
+  maybeAuthorizationError: any,
+): maybeAuthorizationError is AuthorizationError =>
+  maybeAuthorizationError.name === AuthorizationError.name
+
 export type BlitzError =
   | AuthenticationError
   | CSRFTokenMismatchError

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -38,3 +38,9 @@ export class NotFoundError extends Error {
     return true
   }
 }
+
+export type BlitzError =
+  | AuthenticationError
+  | CSRFTokenMismatchError
+  | AuthorizationError
+  | NotFoundError

--- a/packages/generator/templates/app/app/pages/_app.tsx
+++ b/packages/generator/templates/app/app/pages/_app.tsx
@@ -1,4 +1,10 @@
-import {AppProps, AuthenticationError, AuthorizationError, BlitzError, ErrorComponent, useRouter} from "blitz"
+import {
+  AppProps,
+  BlitzError,
+  ErrorComponent,
+  isAuthenticationError, isAuthorizationError,
+  useRouter
+} from "blitz"
 import { ErrorBoundary, FallbackProps } from "react-error-boundary"
 import { queryCache } from "react-query"
 import LoginForm from "app/auth/components/LoginForm"
@@ -23,9 +29,9 @@ export default function App({ Component, pageProps }: AppProps) {
 }
 
 function RootErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
-  if (error instanceof AuthenticationError) {
+  if (isAuthenticationError(error)) {
     return <LoginForm onSuccess={resetErrorBoundary} />
-  } else if (error instanceof AuthorizationError) {
+  } else if (isAuthorizationError(error)) {
     return (
         <ErrorComponent
             statusCode={error.statusCode}

--- a/packages/generator/templates/app/app/pages/_app.tsx
+++ b/packages/generator/templates/app/app/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { AppProps, ErrorComponent, useRouter } from "blitz"
+import {AppProps, AuthenticationError, AuthorizationError, BlitzError, ErrorComponent, useRouter} from "blitz"
 import { ErrorBoundary, FallbackProps } from "react-error-boundary"
 import { queryCache } from "react-query"
 import LoginForm from "app/auth/components/LoginForm"
@@ -23,21 +23,18 @@ export default function App({ Component, pageProps }: AppProps) {
 }
 
 function RootErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
-  if (error?.name === "AuthenticationError") {
+  if (error instanceof AuthenticationError) {
     return <LoginForm onSuccess={resetErrorBoundary} />
-  } else if (error?.name === "AuthorizationError") {
+  } else if (error instanceof AuthorizationError) {
     return (
-      <ErrorComponent
-        statusCode={(error as any).statusCode}
-        title="Sorry, you are not authorized to access this"
-      />
+        <ErrorComponent
+            statusCode={error.statusCode}
+            title="Sorry, you are not authorized to access this"
+        />
     )
   } else {
     return (
-      <ErrorComponent
-        statusCode={(error as any)?.statusCode || 400}
-        title={error?.message || error?.name}
-      />
+        <ErrorComponent statusCode={(error as BlitzError)?.statusCode || 400} title={(error as BlitzError)?.message || (error as BlitzError)?.name} />
     )
   }
 }


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1356

### What are the changes and their implications?
With instanceof type guards TypeScript is able to infer the type of the error. This is only possible because the custom errors extend the default 'Error' type. Therefore it is not needed to cast an error to 'any'. As an extra addition I've added a union type for the different custom errors that are build in.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes
