### PR TITLE
Upon `blitz new`, prompt user for upgrade if blitz version is outdated

### DIFF
--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -103,7 +103,7 @@ export class New extends Command {
             if (newVersion[0] && newVersion[0] === latestVersion) {
               this.log(
                 chalk.green(
-                  `Upgraded blitz global package to ${newVersion}, running blitz new command...`,
+                  `Upgraded blitz global package to ${newVersion[0]}, running blitz new command...`,
                 ),
               )
 

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -87,13 +87,9 @@ export class New extends Command {
             ? ["i", "-g", "blitz@latest"]
             : ["global", "add", "blitz"]
 
-          spawn.sync(flags.npm ? "npm" : "yarn", upgradeOpts, {
-            stdio: "inherit",
-          })
+          spawn.sync(flags.npm ? "npm" : "yarn", upgradeOpts, {stdio: "inherit"})
 
-          const versionResult = spawn.sync("blitz", ["--version"], {
-            stdio: "pipe",
-          })
+          const versionResult = spawn.sync("blitz", ["--version"], {stdio: "pipe"})
           
           if (versionResult.stdout) {
             const newVersion = versionResult.stdout
@@ -112,17 +108,11 @@ export class New extends Command {
                 [],
               )
 
-              const cmdResult = spawn.sync(
+              spawn.sync(
                 "blitz",
                 ["new", ...Object.values(args), ...flagsArr, "--skip-upgrade"],
-                {
-                  stdio: "inherit",
-                },
+                {stdio: "inherit"},
               )
-
-              if (cmdResult.error !== null) {
-                this.error("Error while running blitz new command, please try again")
-              }
 
               return
             }

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -78,7 +78,7 @@ export class New extends Command {
         const promptUpgrade: any = await this.enquirer.prompt({
           type: "select",
           name: "upgrade",
-          message: "Your blitz CLI version is outdated. Upgrade?",
+          message: "Your global blitz version is outdated. Upgrade?",
           choices: upgradeChoices,
         })
 

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -83,9 +83,11 @@ export class New extends Command {
         })
 
         if (promptUpgrade.upgrade === "yes") {
-          const upgradeOpts = flags.npm ? ["i", "-g", "blitz@latest"] : ["global", "add", "blitz"]
+          const checkYarn = spawn.sync("yarn", ["global", "list"], {stdio: "pipe"})
+          const useYarn = checkYarn.stdout.toString().includes("blitz@")
+          const upgradeOpts = useYarn ? ["global", "add", "blitz"] : ["i", "-g", "blitz@latest"]
 
-          spawn.sync(flags.npm ? "npm" : "yarn", upgradeOpts, {stdio: "inherit"})
+          spawn.sync(useYarn ? "yarn" : "npm", upgradeOpts, {stdio: "inherit"})
 
           const versionResult = spawn.sync("blitz", ["--version"], {stdio: "pipe"})
 

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -28,7 +28,7 @@ export class New extends Command {
     },
   ]
 
-  static flags = {
+  static flags: {[flag: string]: any} = {
     help: flags.help({char: "h"}),
     js: flags.boolean({
       description: "Generates a JS project. TypeScript is the default unless you add this flag.",
@@ -83,18 +83,15 @@ export class New extends Command {
         })
 
         if (promptUpgrade.upgrade === "yes") {
-          const upgradeOpts = flags.npm
-            ? ["i", "-g", "blitz@latest"]
-            : ["global", "add", "blitz"]
+          const upgradeOpts = flags.npm ? ["i", "-g", "blitz@latest"] : ["global", "add", "blitz"]
 
           spawn.sync(flags.npm ? "npm" : "yarn", upgradeOpts, {stdio: "inherit"})
 
           const versionResult = spawn.sync("blitz", ["--version"], {stdio: "pipe"})
-          
+
           if (versionResult.stdout) {
-            const newVersion = versionResult.stdout
-              .toString()
-              .match(/(?<=blitz: )(.*)(?= \(global\))/) || []
+            const newVersion =
+              versionResult.stdout.toString().match(/(?<=blitz: )(.*)(?= \(global\))/) || []
 
             if (newVersion[0] && newVersion[0] === latestVersion) {
               this.log(
@@ -108,11 +105,9 @@ export class New extends Command {
                 [],
               )
 
-              spawn.sync(
-                "blitz",
-                ["new", ...Object.values(args), ...flagsArr, "--skip-upgrade"],
-                {stdio: "inherit"},
-              )
+              spawn.sync("blitz", ["new", ...Object.values(args), ...flagsArr, "--skip-upgrade"], {
+                stdio: "inherit",
+              })
 
               return
             }


### PR DESCRIPTION
Closes: #1017 

### What are the changes and their implications?

- If blitz global package is outdated, it will ask the user if they wish to upgrade

![image](https://user-images.githubusercontent.com/19371989/97654965-ff945c00-1a9e-11eb-8b8e-e3cc759f71f7.png)

*Note:* While this is working and ready for review, I have some questions:

- Do we need to check if the global package was installed by `yarn` or `npm`? i.e. if it was installed by `npm` and `yarn` is installed, upgrade via `npm` instead of `yarn`. 
- Is testing the output required and possible? I saw in `new.test.ts` that the tests do not cover everything (e.g. that all the flags are working as intended) and I had some difficulty on writing tests against the code that I am adding, so I am wondering if this is something that is possible and that the tests should be more comprehensive.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
