### PR TITLE
Remove `as` prop from blitz generate page templates

### DIFF
--- a/examples/plain-js/app/projects/pages/projects/[id]/edit.js
+++ b/examples/plain-js/app/projects/pages/projects/[id]/edit.js
@@ -29,7 +29,7 @@ export const EditProject = () => {
               },
             })
             alert("Success!" + JSON.stringify(updated))
-            router.push("/projects/[id]", `/projects/${updated.id}`)
+            router.push(`/projects/${updated.id}`)
           } catch (error) {
             alert("Error creating project " + JSON.stringify(error, null, 2))
           }

--- a/examples/plain-js/app/projects/pages/projects/new.js
+++ b/examples/plain-js/app/projects/pages/projects/new.js
@@ -24,7 +24,7 @@ const NewProjectPage = () => {
                 },
               })
               alert("Success!" + JSON.stringify(project))
-              router.push("/projects/[id]", `/projects/${project.id}`)
+              router.push(`/projects/${project.id}`)
             } catch (error) {
               alert("Error creating project " + JSON.stringify(error, null, 2))
             }

--- a/packages/generator/templates/page/__modelIdParam__.tsx
+++ b/packages/generator/templates/page/__modelIdParam__.tsx
@@ -19,16 +19,12 @@ export const __ModelName__ = () => {
       <pre>{JSON.stringify(__modelName__, null, 2)}</pre>
 
       <if condition="parentModel">
-        <Link
-          href="/__parentModels__/__parentModelParam__/__modelNames__/__modelIdParam__/edit"
-          as={`/__parentModels__/${__parentModelId__}/__modelNames__/${__modelName__.id}/edit`}
-        >
+        <Link href={`/__parentModels__/${__parentModelId__}/__modelNames__/${__modelName__.id}/edit`}>
           <a>Edit</a>
         </Link>
         <else>
           <Link
-            href="/__modelNames__/__modelIdParam__/edit"
-            as={`/__modelNames__/${__modelName__.id}/edit`}
+            href={`/__modelNames__/${__modelName__.id}/edit`}
           >
             <a>Edit</a>
           </Link>
@@ -41,10 +37,7 @@ export const __ModelName__ = () => {
           if (window.confirm("This will be deleted")) {
             await delete__ModelName__Mutation({where: {id: __modelName__.id}})
             if (process.env.parentModel) {
-              router.push(
-                "/__parentModels__/__parentModelParam__/__modelNames__",
-                `/__parentModels__/${__parentModelId__}/__modelNames__`,
-              )
+              router.push(`/__parentModels__/${__parentModelId__}/__modelNames__`)
             } else {
               router.push("/__modelNames__")
             }
@@ -66,10 +59,7 @@ const Show__ModelName__Page: BlitzPage = () => {
     <div>
       <p>
         <if condition="parentModel">
-          <Link
-            href="/__parentModels__/__parentModelId__/__modelNames__"
-            as={`/__parentModels__/${__parentModelId__}/__modelNames__`}
-          >
+          <Link href={`/__parentModels__/${__parentModelId__}/__modelNames__`}>
             <a>__ModelNames__</a>
           </Link>
           <else>

--- a/packages/generator/templates/page/__modelIdParam__/edit.tsx
+++ b/packages/generator/templates/page/__modelIdParam__/edit.tsx
@@ -31,11 +31,8 @@ export const Edit__ModelName__ = () => {
             alert("Success!" + JSON.stringify(updated))
             router.push(
               process.env.parentModel
-                ? "/__parentModels__/__parentModelParam__/__modelNames__/__modelIdParam__"
-                : "/__modelNames__/__modelIdParam__",
-              process.env.parentModel
                 ? `/__parentModels__/${__parentModelId__}/__modelNames__/${updated.id}`
-                : `/__modelNames__/${updated.id}`,
+                : `/__modelNames__/${updated.id}`
             )
           } catch (error) {
             console.log(error)
@@ -60,10 +57,7 @@ const Edit__ModelName__Page: BlitzPage = () => {
 
       <p>
         <if condition="parentModel">
-          <Link
-            as="/__parentModels__/__parentModelId__/__modelNames__"
-            href={`/__parentModels__/${__parentModelId__}/__modelNames__`}
-          >
+          <Link href={`/__parentModels__/${__parentModelId__}/__modelNames__`}>
             <a>__ModelNames__</a>
           </Link>
           <else>

--- a/packages/generator/templates/page/index.tsx
+++ b/packages/generator/templates/page/index.tsx
@@ -29,10 +29,7 @@ export const __ModelNames__List = () => {
         <ul>
           {__modelNames__.map((__modelName__) => (
             <li key={__modelName__.id}>
-              <Link
-                href="/__parentModels__/__parentModelParam__/__modelNames__/__modelIdParam__"
-                as={`/__parentModels__/${__parentModelId__}/__modelNames__/${__modelName__.id}`}
-              >
+              <Link href={`/__parentModels__/${__parentModelId__}/__modelNames__/${__modelName__.id}`}>
                 <a>{__modelName__.name}</a>
               </Link>
             </li>
@@ -63,8 +60,7 @@ export const __ModelNames__List = () => {
           {__modelNames__.map((__modelName__) => (
             <li key={__modelName__.id}>
               <Link
-                href="/__modelNames__/__modelIdParam__"
-                as={`/__modelNames__/${__modelName__.id}`}
+                href={`/__modelNames__/${__modelName__.id}`}
               >
                 <a>{__modelName__.name}</a>
               </Link>
@@ -92,10 +88,7 @@ const __ModelNames__Page: BlitzPage = () => {
     <div>
       <p>
         <if condition="parentModel">
-          <Link
-            href="/__parentModels__/__parentModelId__/__modelNames__/new"
-            as={`/__parentModels__/${__parentModelId__}/__modelNames__/new`}
-          >
+          <Link href={`/__parentModels__/${__parentModelId__}/__modelNames__/new`}>
             <a>Create __ModelName__</a>
           </Link>
           <else>

--- a/packages/generator/templates/page/new.tsx
+++ b/packages/generator/templates/page/new.tsx
@@ -31,11 +31,8 @@ const New__ModelName__Page: BlitzPage = () => {
             alert("Success!" + JSON.stringify(__modelName__))
             router.push(
               process.env.parentModel
-                ? "/__parentModels__/__parentModelParam__/__modelNames__/__modelIdParam__"
-                : "/__modelNames__/__modelIdParam__",
-              process.env.parentModel
                 ? `/__parentModels__/${__parentModelId__}/__modelNames__/${__modelName__.id}`
-                : `/__modelNames__/${__modelName__.id}`,
+                : `/__modelNames__/${__modelName__.id}`
             )
           } catch (error) {
             alert("Error creating __modelName__ " + JSON.stringify(error, null, 2))
@@ -45,10 +42,7 @@ const New__ModelName__Page: BlitzPage = () => {
 
       <p>
         <if condition="parentModel">
-          <Link
-            as="/__parentModels__/__parentModelId__/__modelNames__"
-            href={`/__parentModels__/${__parentModelId__}/__modelNames__`}
-          >
+          <Link href={`/__parentModels__/${__parentModelId__}/__modelNames__`}>
             <a>__ModelNames__</a>
           </Link>
           <else>


### PR DESCRIPTION
Closes: #1405 

### What are the changes and their implications?

Removed `as` param from templates since [`Link`](https://nextjs.org/docs/api-reference/next/link) component and router such as [`router.push`](https://nextjs.org/docs/api-reference/next/router#routerpush) no longer need it.

It does not affect anything.

### Checklist

- [ ] Tests added for changes
- [ ] ~~PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~~
