### PR TITLE
Fix useInfiniteQuery bug on canary where page params are empty

### DIFF
--- a/examples/store/app/products/pages/products/infinite.tsx
+++ b/examples/store/app/products/pages/products/infinite.tsx
@@ -16,7 +16,9 @@ const Products = () => {
       {groupedProducts.map((group, i) => (
         <Fragment key={i}>
           {group.products.map((product) => (
-            <p key={product.id}>{product.name}</p>
+            <p key={product.id} data-test="productName">
+              {product.name}
+            </p>
           ))}
         </Fragment>
       ))}

--- a/examples/store/cypress/integration/products.test.ts
+++ b/examples/store/cypress/integration/products.test.ts
@@ -54,4 +54,14 @@ describe("products#ssr page", () => {
   })
 })
 
+describe("products#infinite page", () => {
+  beforeEach(() => {
+    cy.visit("/products/infinite")
+  })
+
+  it("shows 3 products", () => {
+    cy.get('[data-test="productName"]').should("have.length", 3)
+  })
+})
+
 export {}

--- a/examples/store/db/seeds.ts
+++ b/examples/store/db/seeds.ts
@@ -24,7 +24,7 @@ const seed = async () => {
   for (let i = 0; i < 5; i++) {
     await db.product.create({data: randomProduct()})
   }
-  await db.user.create({data: {email: "foo@bar.com", name: "Foobar"}})
+  await db.user.create({data: {email: randomString(5) + "@bar.com", name: "Foobar"}})
 }
 
 export default seed

--- a/examples/store/package.json
+++ b/examples/store/package.json
@@ -6,7 +6,7 @@
     "build": "blitz db migrate && blitz build",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "test:start": "blitz db migrate && blitz start --production -p 3099",
+    "test:start": "blitz db migrate && blitz db seed && blitz start --production -p 3099",
     "test": "start-server-and-test test:start http://localhost:3099 cy:run"
   },
   "prisma": {

--- a/packages/core/src/use-query-hooks.ts
+++ b/packages/core/src/use-query-hooks.ts
@@ -121,15 +121,19 @@ export function useInfiniteQuery<
   }
 
   const enhancedResolverRpcClient = sanitize(queryFn)
-  const queryKey = getQueryKey(queryFn, params(undefined!))
+  const queryKey = getQueryKey(queryFn, params)
 
   const {data, ...queryRest} = useInfiniteReactQuery({
     // we need an extra cache key for infinite loading so that the cache for
     // for this query is stored separately since the hook result is an array of results.
     // Without this cache for usePaginatedQuery and this will conflict and break.
     queryKey: [...queryKey, "infinite"],
-    queryFn: (_apiUrl: string, _infinite: string, resultOfGetFetchMore: TFetchMoreResult) =>
-      enhancedResolverRpcClient(params(resultOfGetFetchMore), {fromQueryHook: true}),
+    queryFn: (
+      _apiUrl: string,
+      _args: any,
+      _infinite: string,
+      resultOfGetFetchMore: TFetchMoreResult,
+    ) => enhancedResolverRpcClient(params(resultOfGetFetchMore), {fromQueryHook: true}),
     config: {
       ...defaultQueryConfig,
       ...options,


### PR DESCRIPTION
Closes: #1399 

### What are the changes and their implications?

Fixes `useInfiniteQuery()` page values are undefined

### Checklist

- [x] Tests added for changes
