### PR TITLE
Remove React imports from page templates

### DIFF
--- a/packages/generator/templates/page/__modelIdParam__.tsx
+++ b/packages/generator/templates/page/__modelIdParam__.tsx
@@ -1,4 +1,4 @@
-import React, {Suspense} from "react"
+import {Suspense} from "react"
 import Layout from "app/layouts/Layout"
 import {Link, useRouter, useQuery, useParam, BlitzPage, useMutation} from "blitz"
 import get__ModelName__ from "app/__modelNamesPath__/queries/get__ModelName__"

--- a/packages/generator/templates/page/__modelIdParam__/edit.tsx
+++ b/packages/generator/templates/page/__modelIdParam__/edit.tsx
@@ -1,4 +1,4 @@
-import React, {Suspense} from "react"
+import {Suspense} from "react"
 import Layout from "app/layouts/Layout"
 import {Link, useRouter, useQuery, useMutation, useParam, BlitzPage} from "blitz"
 import get__ModelName__ from "app/__modelNamesPath__/queries/get__ModelName__"

--- a/packages/generator/templates/page/index.tsx
+++ b/packages/generator/templates/page/index.tsx
@@ -1,4 +1,4 @@
-import React, {Suspense} from "react"
+import {Suspense} from "react"
 import Layout from "app/layouts/Layout"
 if (process.env.parentModel) {
   import {Link, usePaginatedQuery, useRouter, useParam, BlitzPage} from "blitz"

--- a/packages/generator/templates/page/new.tsx
+++ b/packages/generator/templates/page/new.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import Layout from "app/layouts/Layout"
 if (process.env.parentModel) {
   import {Link, useRouter, useMutation, useParam, BlitzPage} from "blitz"


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1415

### What are the changes and their implications?

Removes react imports in [all of the page templates](https://github.com/blitz-js/blitz/tree/canary/packages/generator/templates/page).

### Checklist

- [x] Tests added for changes (Does this matter?)
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
