### PR TITLE
Fix: disable useQuery on first render, when router params don't exist yet AND fix TS type for useRouter()

### DIFF
--- a/examples/store/app/admin/pages/admin/products/[id].tsx
+++ b/examples/store/app/admin/pages/admin/products/[id].tsx
@@ -1,11 +1,16 @@
 import {Suspense} from "react"
 import {Link, useRouter, useQuery, useParam} from "blitz"
+import {useRouter as useNextRouter} from "next/router"
 import getProduct from "app/products/queries/getProduct"
 import ProductForm from "app/products/components/ProductForm"
 
 function Product() {
   const router = useRouter()
+  const nextRouter = useNextRouter()
   const id = useParam("id", "number")
+  console.log("id", id)
+  console.log("bRouter", router.params)
+  console.log("nRouter", nextRouter.query)
   const [product] = useQuery(getProduct, {where: {id}})
 
   return (

--- a/examples/store/app/admin/pages/admin/products/[id].tsx
+++ b/examples/store/app/admin/pages/admin/products/[id].tsx
@@ -1,16 +1,11 @@
 import {Suspense} from "react"
 import {Link, useRouter, useQuery, useParam} from "blitz"
-import {useRouter as useNextRouter} from "next/router"
 import getProduct from "app/products/queries/getProduct"
 import ProductForm from "app/products/components/ProductForm"
 
 function Product() {
   const router = useRouter()
-  const nextRouter = useNextRouter()
   const id = useParam("id", "number")
-  console.log("id", id)
-  console.log("bRouter", router.params)
-  console.log("nRouter", nextRouter.query)
   const [product] = useQuery(getProduct, {where: {id}})
 
   return (

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,7 +1,15 @@
 import {IncomingMessage, ServerResponse} from "http"
+import {NextRouter} from "next/router"
 import {AuthenticateOptions, Strategy} from "passport"
 import {MutateConfig, MutationResult} from "react-query"
 import {BlitzApiRequest, BlitzApiResponse} from "."
+import {useParams} from "./use-params"
+import {useRouterQuery} from "./use-router-query"
+
+export interface BlitzRouter extends NextRouter {
+  query: ReturnType<typeof useRouterQuery>
+  params: ReturnType<typeof useParams>
+}
 
 export interface DefaultPublicData {
   userId: any

--- a/packages/core/src/use-query-hooks.ts
+++ b/packages/core/src/use-query-hooks.ts
@@ -12,6 +12,7 @@ import {
   useQuery as useReactQuery,
 } from "react-query"
 import {FirstParam, PromiseReturnType, QueryFn} from "./types"
+import {useRouterIsReady} from "./use-router"
 import {
   defaultQueryConfig,
   getQueryCacheFunctions,
@@ -38,6 +39,7 @@ export function useQuery<T extends QueryFn, TResult = PromiseReturnType<T>>(
     throw new Error("useQuery is missing the first argument - it must be a query function")
   }
 
+  const routerIsReady = useRouterIsReady()
   const enhancedResolverRpcClient = sanitize(queryFn)
   const queryKey = getQueryKey(queryFn, params)
 
@@ -47,6 +49,7 @@ export function useQuery<T extends QueryFn, TResult = PromiseReturnType<T>>(
       enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true}),
     config: {
       ...defaultQueryConfig,
+      enabled: routerIsReady,
       ...options,
     },
   })
@@ -74,6 +77,7 @@ export function usePaginatedQuery<T extends QueryFn, TResult = PromiseReturnType
     throw new Error("usePaginatedQuery is missing the first argument - it must be a query function")
   }
 
+  const routerIsReady = useRouterIsReady()
   const enhancedResolverRpcClient = sanitize(queryFn)
   const queryKey = getQueryKey(queryFn, params)
 
@@ -83,6 +87,7 @@ export function usePaginatedQuery<T extends QueryFn, TResult = PromiseReturnType
       enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true}),
     config: {
       ...defaultQueryConfig,
+      enabled: routerIsReady,
       ...options,
     },
   })
@@ -120,6 +125,7 @@ export function useInfiniteQuery<
     throw new Error("useInfiniteQuery is missing the first argument - it must be a query function")
   }
 
+  const routerIsReady = useRouterIsReady()
   const enhancedResolverRpcClient = sanitize(queryFn)
   const queryKey = getQueryKey(queryFn, params)
 
@@ -136,6 +142,7 @@ export function useInfiniteQuery<
     ) => enhancedResolverRpcClient(params(resultOfGetFetchMore), {fromQueryHook: true}),
     config: {
       ...defaultQueryConfig,
+      enabled: routerIsReady,
       ...options,
     },
   })

--- a/packages/core/src/use-router.ts
+++ b/packages/core/src/use-router.ts
@@ -15,3 +15,17 @@ export function useRouter(): BlitzRouter {
     return {...router, query, params}
   }, [params, query, router]) as BlitzRouter
 }
+
+// ------------------------------------------------------------------------
+// FOR INTERNAL USE ONLY
+// from: https://github.com/vercel/next.js/issues/8259#issuecomment-650225962
+// TODO: switch to next.js router.isReady once this issue is fixed there
+// ------------------------------------------------------------------------
+export function useRouterIsReady() {
+  const router = useNextRouter()
+
+  const hasParams = /\[.+\]/.test(router.route) || /\?./.test(router.asPath)
+  const ready = !hasParams || Object.keys(router.query).length > 0
+
+  return ready
+}

--- a/packages/core/src/use-router.ts
+++ b/packages/core/src/use-router.ts
@@ -1,18 +1,17 @@
-import {NextRouter, useRouter as useNextRouter} from "next/router"
+import {useRouter as useNextRouter} from "next/router"
 import {useMemo} from "react"
+import {BlitzRouter} from "./types"
 import {useParams} from "./use-params"
 import {useRouterQuery} from "./use-router-query"
 
 // TODO - we have to explicitly define the return type otherwise TS complains about
 // NextHistoryState and TransitionOptions not being exported from Next.js code
-export function useRouter(): NextRouter &
-  ReturnType<typeof useRouterQuery> &
-  ReturnType<typeof useParams> {
-  const router: any = useNextRouter()
+export function useRouter(): BlitzRouter {
+  const router = useNextRouter()
   const query = useRouterQuery()
   const params = useParams()
 
   return useMemo(() => {
     return {...router, query, params}
-  }, [params, query, router])
+  }, [params, query, router]) as BlitzRouter
 }


### PR DESCRIPTION
Closes: #1344 

### What are the changes and their implications?

This adds a default `enabled` flag to all `useQuery` hooks that disables the queries until the second render when the router params exist.

For cases where useQuery doesn't depend on route params, these queries will also be delayed till the second render which should be always be fine. For any edge cases where this is not ok, you can pass `enabled: true` to override this default config.

### Checklist

- ~[ ] Tests added for changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
