### PR TITLE
Revert react query to 2.5.12 because of concurrent mode bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dist
 .blitz-*
 .blitz-cli-cache
 .vscode
+.tsbuildinfo

--- a/examples/store/package.json
+++ b/examples/store/package.json
@@ -6,8 +6,8 @@
     "build": "blitz db migrate && blitz build",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "test:start": "blitz db migrate && blitz db seed && blitz start --production -p 3099",
-    "test": "start-server-and-test test:start http://localhost:3099 cy:run"
+    "test:server": "blitz db migrate && blitz db seed && blitz start --production -p 3099",
+    "test": "start-server-and-test test:server http://localhost:3099 cy:run"
   },
   "prisma": {
     "schema": "db/schema.prisma"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
     "lodash-es": "^4.17.15",
     "passport": "0.4.1",
     "pretty-ms": "6.0.1",
-    "react-query": "2.5.11",
+    "react-query": "2.6.0",
     "superjson": "1.3.0",
     "url": "0.11.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
     "lodash-es": "^4.17.15",
     "passport": "0.4.1",
     "pretty-ms": "6.0.1",
-    "react-query": "2.6.0",
+    "react-query": "2.5.12",
     "superjson": "1.3.0",
     "url": "0.11.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
     "lodash-es": "^4.17.15",
     "passport": "0.4.1",
     "pretty-ms": "6.0.1",
-    "react-query": "2.23.0",
+    "react-query": "2.5.11",
     "superjson": "1.3.0",
     "url": "0.11.0"
   },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,6 @@
 import {IncomingMessage, ServerResponse} from "http"
 import {AuthenticateOptions, Strategy} from "passport"
-import {MutateConfig, MutationResult} from "react-query"
+import {MutateOptions, MutationResult} from "react-query"
 import {BlitzApiRequest, BlitzApiResponse} from "."
 
 export interface DefaultPublicData {
@@ -162,7 +162,7 @@ export declare type MutateFunction<
   TSnapshot = unknown
 > = (
   variables?: TVariables,
-  config?: MutateConfig<TResult, TError, TVariables, TSnapshot>,
+  config?: MutateOptions<TResult, TError, TVariables, TSnapshot>,
 ) => Promise<TResult>
 
 export declare type MutationResultPair<TResult, TError, TVariables, TSnapshot> = [

--- a/packages/core/src/use-mutation.ts
+++ b/packages/core/src/use-mutation.ts
@@ -1,4 +1,4 @@
-import {MutationConfig, useMutation as useReactQueryMutation} from "react-query"
+import {MutationOptions, useMutation as useReactQueryMutation} from "react-query"
 import {MutationFunction, MutationResultPair} from "./types"
 import {sanitize} from "./utils/react-query-utils"
 
@@ -13,7 +13,7 @@ import {sanitize} from "./utils/react-query-utils"
 
 export function useMutation<TResult, TError = unknown, TVariables = undefined, TSnapshot = unknown>(
   mutationResolver: MutationFunction<TResult, TVariables>,
-  config?: MutationConfig<TResult, TError, TVariables, TSnapshot>,
+  config?: MutationOptions<TResult, TError, TVariables, TSnapshot>,
 ) {
   const enhancedResolverRpcClient = sanitize(mutationResolver)
 
@@ -22,6 +22,6 @@ export function useMutation<TResult, TError = unknown, TVariables = undefined, T
     {
       throwOnError: true,
       ...config,
-    },
+    } as any,
   ) as MutationResultPair<TResult, TError, TVariables, TSnapshot>
 }

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -99,7 +99,7 @@ export function invalidateQuery<TInput, TResult, T extends QueryFn>(
   }
 
   const fullQueryKey = getQueryKey(resolver, params)
-  let queryKey: QueryKey
+  let queryKey: QueryKey<any>
   if (params) {
     queryKey = fullQueryKey
   } else {

--- a/packages/core/test/react-query-utils.test.ts
+++ b/packages/core/test/react-query-utils.test.ts
@@ -50,7 +50,7 @@ describe("invalidateQuery", () => {
   it("invalidates a query given resolver and params", async () => {
     await invalidateQuery(enhanceQueryFn(isEmpty), "a")
     expect(spyRefetchQueries).toBeCalledTimes(1)
-    const calledWith = spyRefetchQueries.mock.calls[0][0] as Array<any>
+    const calledWith = spyRefetchQueries.mock.calls[0][0] as any
     // json of the queryKey is "a"
     expect(calledWith[1].json).toEqual("a")
   })
@@ -80,7 +80,7 @@ describe("setQueryData", () => {
     expect(spyRefetchQueries).toBeCalledTimes(1)
     expect(spySetQueryData).toBeCalledTimes(1)
 
-    const invalidateCalledWith = spyRefetchQueries.mock.calls[0][0] as Array<any>
+    const invalidateCalledWith = spyRefetchQueries.mock.calls[0][0] as any
     expect(invalidateCalledWith[1].json).toEqual("params")
 
     const calledWith = spySetQueryData.mock.calls[0] as Array<any>

--- a/packages/core/test/use-query.test.tsx
+++ b/packages/core/test/use-query.test.tsx
@@ -82,7 +82,7 @@ describe("useInfiniteQuery", () => {
     function TestHarness() {
       // TODO - fix typing
       //@ts-ignore
-      const [groupedData] = useInfiniteQuery(queryFn, params)
+      const [groupedData] = useInfiniteQuery(queryFn, params, {getFetchMore: () => {}})
       Object.assign(res, {groupedData})
       return (
         <div id="harness">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,8 @@
     "moduleResolution": "node",
     "jsx": "react",
     "esModuleInterop": true,
+    "incremental": true,
+    "tsBuildInfoFile": ".tsbuildinfo",
     "noEmit": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15969,10 +15969,10 @@ react-is@16.13.1, react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4, react-i
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-query@2.5.11:
-  version "2.5.11"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.5.11.tgz#fdac3f19d9765c4673e1694ad52f80b7c60c961b"
-  integrity sha512-QwKR+gOENQVQqx45+zMtEE99Us39Ybx3OXUYyLRMzZfHSM2FPf337iiOCwko4RRTF7Q0HgiC2+DIbVQiH1Rk9A==
+react-query@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.6.0.tgz#a1ec81dd4c8cb9ef8b19dde7380d0d754d793eea"
+  integrity sha512-eaigvwT/Rq6yhjmo5hP2CRGT4+CSoj2dcYK12e4HmWvDptEALlA3yoU6KQBAhstCRUAlpF48MxVZlykm/AuasQ==
   dependencies:
     ts-toolbelt "^6.9.4"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1904,7 +1904,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@7.11.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.5.5":
+"@babel/runtime@7.11.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -15969,12 +15969,12 @@ react-is@16.13.1, react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4, react-i
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-query@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.23.0.tgz#9f9552a30380dfc1da2c165b5011465a78128ace"
-  integrity sha512-LHBhrr7ntstjpt85ssEaW3cGJx4BqQBFleTM3fXMO0MFzaMDQx0oxdUur+iQSOpLGPlrpToJbrjFNMQTpEExdA==
+react-query@2.5.11:
+  version "2.5.11"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.5.11.tgz#fdac3f19d9765c4673e1694ad52f80b7c60c961b"
+  integrity sha512-QwKR+gOENQVQqx45+zMtEE99Us39Ybx3OXUYyLRMzZfHSM2FPf337iiOCwko4RRTF7Q0HgiC2+DIbVQiH1Rk9A==
   dependencies:
-    "@babel/runtime" "^7.5.5"
+    ts-toolbelt "^6.9.4"
 
 react-reconciler@^0.24.0:
   version "0.24.0"
@@ -18569,6 +18569,11 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+ts-toolbelt@^6.9.4:
+  version "6.9.9"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.9.9.tgz#e6cfd8ec7d425d2a06bda3b4fe9577ceaf2abda8"
+  integrity sha512-5a8k6qfbrL54N4Dw+i7M6kldrbjgDWb5Vit8DnT+gwThhvqMg8KtxLE5Vmnft+geIgaSOfNJyAcnmmlflS+Vdg==
 
 tsconfig-paths@3.9.0, tsconfig-paths@^3.9.0:
   version "3.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15969,10 +15969,10 @@ react-is@16.13.1, react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4, react-i
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-query@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.6.0.tgz#a1ec81dd4c8cb9ef8b19dde7380d0d754d793eea"
-  integrity sha512-eaigvwT/Rq6yhjmo5hP2CRGT4+CSoj2dcYK12e4HmWvDptEALlA3yoU6KQBAhstCRUAlpF48MxVZlykm/AuasQ==
+react-query@2.5.12:
+  version "2.5.12"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.5.12.tgz#f48be402886b9d95f892d836c2476ee3fdd3e479"
+  integrity sha512-ni2Hrz8tU/WCc5EQj+QB0jzSgxKdVL3tznFvTrXDmGjTxFj9hg1vXoxEPAn8d4pXy+lgPAflcjxht3IakUgHzg==
   dependencies:
     ts-toolbelt "^6.9.4"
 


### PR DESCRIPTION
Closes: #1282 

### What are the changes and their implications?

Revert react query to 2.5.12 because of concurrent mode bugs

### Checklist

- [x] Tests added for changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
