### PR TITLE
Fix broken static pre-rendering with useQuery

### DIFF
--- a/examples/auth/app/pages/index.test.tsx
+++ b/examples/auth/app/pages/index.test.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import {render} from "test/utils"
 
 import Home from "./index"

--- a/examples/auth/test/utils.tsx
+++ b/examples/auth/test/utils.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import {RouterContext, BlitzRouter} from "blitz"
 import {render as defaultRender} from "@testing-library/react"
 import {renderHook as defaultRenderHook} from "@testing-library/react-hooks"

--- a/examples/store/app/admin/pages/admin/products/[id].tsx
+++ b/examples/store/app/admin/pages/admin/products/[id].tsx
@@ -8,6 +8,9 @@ function Product() {
   const id = useParam("id", "number")
   const [product] = useQuery(getProduct, {where: {id}})
 
+  // Here to test for https://github.com/blitz-js/blitz/issues/1443
+  if (!product) throw new Error("useQuery did not throw!")
+
   return (
     <ProductForm
       product={product}

--- a/examples/store/app/pages/_app.tsx
+++ b/examples/store/app/pages/_app.tsx
@@ -2,6 +2,10 @@ import {AppProps, ErrorComponent} from "blitz"
 import {ErrorBoundary} from "react-error-boundary"
 import {queryCache} from "react-query"
 
+if (typeof window !== "undefined") {
+  window["DEBUG_BLITZ"] = 1
+}
+
 export default function App({Component, pageProps}: AppProps) {
   return (
     <ErrorBoundary

--- a/packages/core/src/use-query-hooks.ts
+++ b/packages/core/src/use-query-hooks.ts
@@ -38,11 +38,11 @@ export function useQuery<T extends QueryFn, TResult = PromiseReturnType<T>>(
   const queryKey = getQueryKey(queryFn, params)
 
   const {data, ...queryRest} = useReactQuery({
-    queryKey,
-    queryFn: (_apiUrl: string, params: any) =>
-      (routerIsReady
-        ? enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true})
-        : emptyQueryFn) as any,
+    queryKey: routerIsReady ? queryKey : ["_routerNotReady_"],
+    queryFn: routerIsReady
+      ? (_apiUrl: string, params: any) =>
+          enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true})
+      : (emptyQueryFn as any),
     config: {
       ...defaultQueryConfig,
       ...options,
@@ -77,11 +77,11 @@ export function usePaginatedQuery<T extends QueryFn, TResult = PromiseReturnType
   const queryKey = getQueryKey(queryFn, params)
 
   const {resolvedData, ...queryRest} = usePaginatedReactQuery({
-    queryKey,
-    queryFn: (_apiUrl: string, params: any) =>
-      (routerIsReady
-        ? enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true})
-        : emptyQueryFn) as any,
+    queryKey: routerIsReady ? queryKey : ["_routerNotReady_"],
+    queryFn: routerIsReady
+      ? (_apiUrl: string, params: any) =>
+          enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true})
+      : (emptyQueryFn as any),
     config: {
       ...defaultQueryConfig,
       ...options,
@@ -133,16 +133,11 @@ export function useInfiniteQuery<
     // we need an extra cache key for infinite loading so that the cache for
     // for this query is stored separately since the hook result is an array of results.
     // Without this cache for usePaginatedQuery and this will conflict and break.
-    queryKey: [...queryKey, "infinite"],
-    queryFn: ((
-      _apiUrl: string,
-      _args: any,
-      _infinite: string,
-      resultOfGetFetchMore: TFetchMoreResult,
-    ) =>
-      routerIsReady
-        ? enhancedResolverRpcClient(params(resultOfGetFetchMore), {fromQueryHook: true})
-        : emptyQueryFn) as any,
+    queryKey: routerIsReady ? [...queryKey, "infinite"] : ["_routerNotReady_"],
+    queryFn: routerIsReady
+      ? (_apiUrl: string, _args: any, _infinite: string, resultOfGetFetchMore: TFetchMoreResult) =>
+          enhancedResolverRpcClient(params(resultOfGetFetchMore), {fromQueryHook: true})
+      : (emptyQueryFn as any),
     config: {
       ...defaultQueryConfig,
       ...options,

--- a/packages/core/src/use-query-hooks.ts
+++ b/packages/core/src/use-query-hooks.ts
@@ -12,6 +12,7 @@ import {FirstParam, PromiseReturnType, QueryFn} from "./types"
 import {useRouterIsReady} from "./use-router"
 import {
   defaultQueryConfig,
+  emptyQueryFn,
   getQueryCacheFunctions,
   getQueryKey,
   QueryCacheFunctions,
@@ -39,10 +40,11 @@ export function useQuery<T extends QueryFn, TResult = PromiseReturnType<T>>(
   const {data, ...queryRest} = useReactQuery({
     queryKey,
     queryFn: (_apiUrl: string, params: any) =>
-      enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true}),
+      (routerIsReady
+        ? enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true})
+        : emptyQueryFn) as any,
     config: {
       ...defaultQueryConfig,
-      enabled: routerIsReady,
       ...options,
     },
   })
@@ -77,10 +79,11 @@ export function usePaginatedQuery<T extends QueryFn, TResult = PromiseReturnType
   const {resolvedData, ...queryRest} = usePaginatedReactQuery({
     queryKey,
     queryFn: (_apiUrl: string, params: any) =>
-      enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true}),
+      (routerIsReady
+        ? enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true})
+        : emptyQueryFn) as any,
     config: {
       ...defaultQueryConfig,
-      enabled: routerIsReady,
       ...options,
     },
   })
@@ -136,10 +139,12 @@ export function useInfiniteQuery<
       _args: any,
       _infinite: string,
       resultOfGetFetchMore: TFetchMoreResult,
-    ) => enhancedResolverRpcClient(params(resultOfGetFetchMore), {fromQueryHook: true})) as any,
+    ) =>
+      routerIsReady
+        ? enhancedResolverRpcClient(params(resultOfGetFetchMore), {fromQueryHook: true})
+        : emptyQueryFn) as any,
     config: {
       ...defaultQueryConfig,
-      enabled: routerIsReady,
       ...options,
     },
   })

--- a/packages/core/src/use-router.ts
+++ b/packages/core/src/use-router.ts
@@ -25,7 +25,9 @@ export function useRouterIsReady() {
   const router = useNextRouter()
 
   const hasParams = /\[.+\]/.test(router.route) || /\?./.test(router.asPath)
-  const ready = !hasParams || Object.keys(router.query).length > 0
+  const queryKeys = Object.keys(router.query)
+  const queryIsEmpty = queryKeys.length === 0 || (queryKeys.length === 1 && queryKeys[0] === "amp")
+  const ready = !hasParams || !queryIsEmpty
 
   return ready
 }

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -29,7 +29,10 @@ export const getQueryCacheFunctions = <TInput, TResult, T extends QueryFn>(
 })
 
 export const emptyQueryFn: EnhancedResolverRpcClient<unknown, unknown> = (() => {
-  const fn = () => new Promise(() => {})
+  const fn = () =>
+    new Promise(() => {
+      console.log("Running emptyQueryFn")
+    })
   fn._meta = {
     name: "emptyQueryFn",
     type: "n/a" as any,

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -29,10 +29,7 @@ export const getQueryCacheFunctions = <TInput, TResult, T extends QueryFn>(
 })
 
 export const emptyQueryFn: EnhancedResolverRpcClient<unknown, unknown> = (() => {
-  const fn = () =>
-    new Promise(() => {
-      console.log("Running emptyQueryFn")
-    })
+  const fn = () => new Promise(() => {})
   fn._meta = {
     name: "emptyQueryFn",
     type: "n/a" as any,


### PR DESCRIPTION
Closes: #1443 

### What are the changes and their implications?

Fix broken static pre-rendering with useQuery. Stop using the `enabled` flag since that messes with suspense loading. Instead use an empty query function during pre-rendering so the actual query resolver doesn't get called.

### Checklist

- [x] Tests added for changes
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
