### PR TITLE
Omit inclusion rules found in the global gitignore

### DIFF
--- a/packages/server/test/parse-chokidar-rules-from-gitignore.test.ts
+++ b/packages/server/test/parse-chokidar-rules-from-gitignore.test.ts
@@ -75,6 +75,7 @@ describe("getAllGitIgnores", () => {
         {
           prefix: "",
           gitIgnore: globalIgnore,
+          isGlobal: true,
         },
       ])
     })
@@ -126,6 +127,7 @@ describe("getAllGitIgnores", () => {
         {
           prefix: "",
           gitIgnore: localIgnoreValue,
+          isGlobal: false,
         },
       ])
     })
@@ -152,6 +154,7 @@ describe("getAllGitIgnores", () => {
         {
           prefix: "some/nested/submodule/",
           gitIgnore: nestedIgnoreValue,
+          isGlobal: false,
         },
       ])
     })
@@ -168,6 +171,7 @@ describe("chokidarRulesFromGitignore", () => {
 .db_log
 !migrations
         `,
+          isGlobal: false,
         }),
       ).toEqual({
         ignoredPaths: ["src/app/db/.db_log"],


### PR DESCRIPTION
Closes #1413 

### What are the changes and their implications?
It would be better to use glob's `allowEmpty` option, but since we cannot, and some inclusion rules which may not apply to a Blitz project cause `blitz start` to fail with this error:
`Error: File not found with singular glob`
I just omit the inclusion rules that we find in the global gitignore file. 

The downside is that if you meant for those inclusion rules in your global gitignore file to apply to your Blitz projects, you may now encounter a mysterious situation where those files are ignored by an exclusion rule in your global gitignore file.

My preference would be to avoid reading the global gitignore file and just accept the performance hit from monitoring extra files that might be ignored in the global gitignore. 

But out of respect for the author's intent, I submit this PR. I'm happy to discuss it. And I can add tests for my solution here if you think it makes sense. 

### Checklist

- [ ] Tests added for changes
- ~~PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
