### PR TITLE
Fix image component external domains not working in production

### DIFF
--- a/packages/server/src/build.ts
+++ b/packages/server/src/build.ts
@@ -1,4 +1,4 @@
-import {move, pathExists, remove} from "fs-extra"
+import {copy, pathExists, remove} from "fs-extra"
 import {resolve} from "path"
 import {saveBuild} from "./build-hash"
 import {normalize, ServerConfig} from "./config"
@@ -43,7 +43,7 @@ export async function build(
   }
 
   if (await pathExists(buildNextFolder)) {
-    await move(buildNextFolder, rootNextFolder)
+    await copy(buildNextFolder, rootNextFolder)
   }
 
   await saveBuild(buildFolder)

--- a/packages/server/src/prod.ts
+++ b/packages/server/src/prod.ts
@@ -7,9 +7,9 @@ export async function prod(
   config: ServerConfig,
   readyForNextProd: Promise<any> = Promise.resolve(),
 ) {
-  const {rootFolder, buildFolder, nextBin} = await normalize(config)
+  const {buildFolder, nextBin} = await normalize(config)
   if (!(await alreadyBuilt(buildFolder))) {
     await build(config, readyForNextProd)
   }
-  await nextStart(nextBin, rootFolder, config)
+  await nextStart(nextBin, buildFolder, config)
 }


### PR DESCRIPTION
Closes: #1459

### What are the changes and their implications?

With the new image component, Next.js is now reading the `next.config.js` file at _runtime_. Our compiled `next.config.js` file is in `.blitz/caches/build` but we execute `next start` with a cwd of the original project which doesn't have `next.config.js`.

So this fix leaves `.next` inside `.blitz/caches/build/` **and** it runs `next start` in the context of `.blitz/caches/build/`.

During a serverless build on Vercel, we already add `next.config.js` so that should keep working. However for other serverless environments like serverless framework, I think this problem may still exist.

The ultimate solution, imo, is to make a PR to Next.js that copies the next.config.js file into `.next` and then change `next start` to read from there. We can investigate this later.
