### PR TITLE
Remove undocumented `hasOne` and `hasMany` options from `blitz generate model`

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -11,6 +11,7 @@ import {
 
 import {Command} from "../command"
 import {PromptAbortedError} from "../errors/prompt-aborted"
+import chalk from "chalk"
 
 const debug = require("debug")("blitz:generate")
 const pascalCase = (str: string) => require("camelcase")(str, {pascalCase: true})
@@ -116,27 +117,27 @@ export class Generate extends Command {
   }
 
   static examples = [
-    `# The 'crud' type will generate all queries & mutations for a model
+    `${chalk.dim("# The 'crud' type will generate all queries & mutations for a model")}
 > blitz generate crud productVariant
     `,
-    `# The 'all' generator will scaffold out everything possible for a model
+    `${chalk.dim("# The 'all' generator will scaffold out everything possible for a model")}
 > blitz generate all products
     `,
-    `# The '--context' flag will allow you to generate files in a nested folder
+    `${chalk.dim("# The '--context' flag will allow you to generate files in a nested folder")}
 > blitz generate pages projects --admin
     `,
-    `# Context can also be supplied in the model name directly
+    `${chalk.dim("# Context can also be supplied in the model name directly")}
 > blitz generate pages admin/projects
     `,
-    `# To generate nested routes for dependent models (e.g. Projects that contain
+    `${chalk.dim(`# To generate nested routes for dependent models (e.g. Projects that contain
 # Tasks), specify a parent model. For example, this command generates pages under
-# app/tasks/pages/projects/[projectId]/tasks/
+# app/tasks/pages/projects/[projectId]/tasks/`)}
 > blitz generate all tasks --parent=projects
     `,
-    `# Database models can also be generated directly from the CLI
+    `${chalk.dim(`# Database models can also be generated directly from the CLI
 # Model fields can be specified with any generator that generates
 # a database model ("all", "model", "resource"). Both of the below
-# will generate the proper database model for a Task.
+# will generate the proper database model for a Task.`)}
 > blitz generate model task \\
     name:string \\
     completed:boolean:default[false] \\
@@ -146,9 +147,9 @@ export class Generate extends Command {
     completed:boolean:default[false] \\
     belongsTo:project?
     `,
-    `# Sometimes you want just a single query with no generated
+    `${chalk.dim(`# Sometimes you want just a single query with no generated
 # logic. Generating "query" instead of "queries" will give you a more
-# customizable template.
+# customizable template.`)}
 > blitz generate query getUserSession`,
   ]
 

--- a/packages/generator/src/prisma/field.ts
+++ b/packages/generator/src/prisma/field.ts
@@ -11,8 +11,6 @@ export enum FieldType {
 }
 
 export enum Relation {
-  hasOne,
-  hasMany,
   belongsTo,
 }
 
@@ -86,16 +84,6 @@ export class Field {
       fieldType = singlePascal(fieldType)
 
       switch (relationType) {
-        case Relation.hasOne:
-          // current model gets single association field
-          isList = false
-          break
-        case Relation.hasMany:
-          // current model gets single association field
-          fieldName = uncapitalize(fieldName)
-          isList = true
-          isRequired = true
-          break
         case Relation.belongsTo:
           // current model gets two fields:
           //   modelName    ModelName   @relation(fields: [modelNameId], references: [id])

--- a/packages/generator/test/prisma/field.test.ts
+++ b/packages/generator/test/prisma/field.test.ts
@@ -58,25 +58,6 @@ describe("Field model", () => {
     expect(() => Field.parse(":int")).toThrow()
   })
 
-  it("handles hasOne relations", () => {
-    expect(Field.parse("hasOne:task").toString()).toMatchInlineSnapshot(`"task  Task"`)
-    expect(Field.parse("hasOne:tasks").toString()).toMatchInlineSnapshot(`"tasks  Task"`)
-    expect(Field.parse("hasOne:task?").toString()).toMatchInlineSnapshot(`"task  Task?"`)
-    expect(Field.parse("hasOne:tasks?").toString()).toMatchInlineSnapshot(`"tasks  Task?"`)
-    // list identifier should be ignored for singular relations
-    expect(Field.parse("hasOne:task[]").toString()).toMatchInlineSnapshot(`"task  Task"`)
-    expect(Field.parse("hasOne:tasks[]").toString()).toMatchInlineSnapshot(`"tasks  Task"`)
-  })
-
-  it("handles hasMany relations", () => {
-    expect(Field.parse("hasMany:task").toString()).toMatchInlineSnapshot(`"task  Task[]"`)
-    expect(Field.parse("hasMany:tasks").toString()).toMatchInlineSnapshot(`"tasks  Task[]"`)
-    expect(Field.parse("hasMany:task[]").toString()).toMatchInlineSnapshot(`"task  Task[]"`)
-    expect(Field.parse("hasMany:tasks[]").toString()).toMatchInlineSnapshot(`"tasks  Task[]"`)
-    // can't have optional lists, should erase optional param
-    expect(Field.parse("hasMany:task?").toString()).toMatchInlineSnapshot(`"task  Task[]"`)
-  })
-
   it("handles belongsTo relations", () => {
     expect(Field.parse("belongsTo:task").join("\n")).toMatchInlineSnapshot(`
       "task  Task  @relation(fields: [taskId], references: [id])


### PR DESCRIPTION
### What are the changes and their implications?

This removes `hasOne` and `hasMany` options from `blitz generate model`.

Until now we've supported two syntaxes for these relations as shown in the below example. This is confusing and hard to properly document. In fact, hasMany and hasOne aren't even documented at all. 

We have a third option `belongsTo` which is actually needed because that adds two fields and the required prisma relation syntax. Whereas `hasMany` and `hasOne` don't do anything extra.

So now it's much simpler. All you have to remember is that `belongsTo` is the only special name.

```diff
blitz generate model project hasMany:tasks
blitz generate model project tasks:task[]

blitz generate model project hasOne:task
blitz generate model project task:task
```


### Checklist

- [x] Tests added for changes