### PR TITLE
Fix issue where `blitz start --production` rebuilds during deployment

### DIFF
--- a/packages/server/src/build-hash.ts
+++ b/packages/server/src/build-hash.ts
@@ -6,21 +6,7 @@ export async function getInputArtefactsHash() {
   const options = {
     algo: "md5",
     folders: {
-      exclude: [
-        "node_modules",
-        ".blitz-build",
-        ".blitz",
-        "cypress",
-        ".next",
-        ".heroku",
-        ".profile.d",
-        ".cache",
-        ".config",
-        "test",
-        "tests",
-        "spec",
-        "specs",
-      ],
+      exclude: [".*", "node_modules", "cypress", "test", "tests", "spec", "specs"],
     },
   }
   const tree = await hashElement(".", options)


### PR DESCRIPTION
### What are the changes and their implications?

`blitz build` computes a hash of all the files, that if changes causes `blitz start --production` to do a full rebuild instead of re-using the existing build.

This reduces cases where the hash changes by ignoring all folders starting with `.`


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
