### PR TITLE
Fix File not found with singular glob

### DIFF
--- a/packages/file-pipeline/src/helpers/agnostic-source/agnostic-source.test.ts
+++ b/packages/file-pipeline/src/helpers/agnostic-source/agnostic-source.test.ts
@@ -46,4 +46,37 @@ describe("agnosticSource", () => {
     await testStreamItems(stream, expected, logItem)
     await close()
   })
+
+  test("include a folder that doesn't exist", (done) => {
+    const expected = [resolve(cwd, "one"), resolve(cwd, "two")]
+    const {stream} = agnosticSource({
+      ignore: [],
+      include: ["**/*", "folder-that-doesnt-exist/"],
+      cwd,
+      watch: false,
+    })
+    const log: any[] = []
+    stream.on("data", (data) => {
+      if (data === "ready") {
+        stream.end()
+        expect(log).toEqual(expected)
+        return done()
+      }
+      log.push(data.path)
+    })
+  })
+
+  test("ignore a file", (done) => {
+    const expected = [resolve(cwd, "one")]
+    const {stream} = agnosticSource({ignore: ["two"], include: ["**/*"], cwd, watch: false})
+    const log: any[] = []
+    stream.on("data", (data) => {
+      if (data === "ready") {
+        stream.end()
+        expect(log).toEqual(expected)
+        return done()
+      }
+      log.push(data.path)
+    })
+  })
 })

--- a/packages/file-pipeline/src/helpers/agnostic-source/index.ts
+++ b/packages/file-pipeline/src/helpers/agnostic-source/index.ts
@@ -75,6 +75,7 @@ export function agnosticSource({ignore, include, cwd, watch: watching = false}: 
     read: true,
     dot: true,
     cwd,
+    allowEmpty: true,
   })
 
   const watcher = getWatcher(watching, cwd, include, ignore)


### PR DESCRIPTION
When reading `.gitignore` files, especially the global gitignore file, there may be
inclusion rules that refer to paths which don't actually exist in your project.

Closes: #1413 

### What are the changes and their implications?
This PR supersedes #1457 and fixes #1413 which crashes the file pipeline and prevents `blitz start` from working if your global gitignore contains an inclusion rule like this:

```
!TAGS/
```
and your Blitz project doesn't contain a `TAGS/` folder.

Allowing some included paths to not exist (using the `allowEmpty: true` option in vinyl-fs) fixes this problem. Although if there really are missing paths that should exist, vinyl-fs will no longer produce an error to warn you. 

### Checklist

- [x] Tests added for changes
~~PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
