### PR TITLE
Fix an import edgecase by only rewriting relative paths imports for files in special folders (patch)

### DIFF
--- a/packages/server/src/stages/relative/index.ts
+++ b/packages/server/src/stages/relative/index.ts
@@ -4,7 +4,10 @@ import slash from "slash"
 
 const isJavaScriptFile = (filepath: string) => filepath.match(/\.(ts|tsx|js|jsx)$/)
 
-const isInAppFolder = (s: string, cwd: string) => s.replace(cwd + path.sep, "").indexOf("app") === 0
+const isInSpecialFolderInAppFolder = (s: string, cwd: string) => {
+  const filepath = s.replace(cwd + path.sep, "")
+  return /^app\/.*(pages|queries|mutations)\//.test(filepath)
+}
 
 /**
  * Returns a Stage that converts relative files paths to absolute
@@ -15,7 +18,11 @@ export const createStageRelative: Stage = ({config: {cwd}}) => {
     const filecontents = file.contents
     const filepath = file.path
 
-    if (!isJavaScriptFile(filepath) || !isInAppFolder(filepath, cwd) || filecontents === null) {
+    if (
+      !isJavaScriptFile(filepath) ||
+      !isInSpecialFolderInAppFolder(filepath, cwd) ||
+      filecontents === null
+    ) {
       return file
     }
 

--- a/packages/server/src/stages/relative/index.ts
+++ b/packages/server/src/stages/relative/index.ts
@@ -6,7 +6,7 @@ const isJavaScriptFile = (filepath: string) => filepath.match(/\.(ts|tsx|js|jsx)
 
 const isInSpecialFolderInAppFolder = (s: string, cwd: string) => {
   const filepath = s.replace(cwd + path.sep, "")
-  return /^app\/.*(pages|queries|mutations)\//.test(filepath)
+  return /^app[/\\].*(pages|queries|mutations)[/\\]/.test(filepath)
 }
 
 /**

--- a/packages/server/src/stages/relative/relative-paths.test.ts
+++ b/packages/server/src/stages/relative/relative-paths.test.ts
@@ -48,10 +48,10 @@ describe("relativeToAbsolute", () => {
 
 describe("replaceRelativeImports", () => {
   it("should replace all relativeImports", () => {
-    const input = `import {getFoo} from 'app/foo/bar';    
+    const input = `import {getFoo} from 'app/foo/bar';
 import from "../thing/bar"
 import from '../thing/bar'`
-    const expected = `import {getFoo} from 'app/foo/bar';    
+    const expected = `import {getFoo} from 'app/foo/bar';
 import from "Hello"
 import from 'Hello'`
     expect(replaceRelativeImports(input, (_s: string) => "Hello")).toBe(expected)

--- a/packages/server/src/stages/relative/relative.test.ts
+++ b/packages/server/src/stages/relative/relative.test.ts
@@ -5,36 +5,15 @@ import {testStreamItems} from "../stage-test-utils"
 import {createStageRelative} from "."
 describe("relative", () => {
   test("test relative stream", async () => {
-    const expected = [
+    const files = [
       {
-        path: normalize("/projects/blitz/blitz/app/users/pages.ts"),
-        contents: `import {getFoo} from 'app/foo/bar';
-import from "app/thing/bar"
-import from 'app/thing/bar'
-import 'app/thing/bar'
-const Component = dynamic(() => import("app/thing/bar"), {})`,
-      },
-      {
-        path: normalize("/projects/blitz/blitz/app/users/foo.jpeg"),
+        path: normalize("/projects/blitz/blitz/app/users/pages/index.ts"),
         contents: `import {getFoo} from 'app/foo/bar';
 import from "../thing/bar"
-import from '../thing/bar'`,
+import from '../thing/bar'
+import '../thing/bar'
+const Component = dynamic(() => import("../thing/bar"), {})`,
       },
-      {
-        path: normalize("/projects/blitz/blitz/app/users/bar.tsx"),
-        contents: `import {getFoo} from 'app/foo/bar';
-import from "app/thing/bar"
-import from 'app/thing/bar'`,
-      },
-      {
-        path: normalize("/projects/blitz/blitz/app/users/baz.js"),
-        contents: `import {getFoo} from 'app/foo/bar';
-import from "app/thing/bar"
-import from 'app/thing/bar'`,
-      },
-    ]
-
-    const files = [
       {
         path: normalize("/projects/blitz/blitz/app/users/pages.ts"),
         contents: `import {getFoo} from 'app/foo/bar';
@@ -50,16 +29,89 @@ import from "../thing/bar"
 import from '../thing/bar'`,
       },
       {
-        path: normalize("/projects/blitz/blitz/app/users/bar.tsx"),
+        path: normalize("/projects/blitz/blitz/app/users/pages/bar.tsx"),
         contents: `import {getFoo} from 'app/foo/bar';
-import from "../thing/bar"
-import from '../thing/bar'`,
+import from "../../thing/bar"
+import from '../../thing/bar'`,
+      },
+      {
+        path: normalize("/projects/blitz/blitz/app/users/baz/pages/hey.js"),
+        contents: `import {getFoo} from 'app/foo/bar';
+import from "../../../thing/bar"
+import from '../../../thing/bar'`,
       },
       {
         path: normalize("/projects/blitz/blitz/app/users/baz.js"),
         contents: `import {getFoo} from 'app/foo/bar';
 import from "../thing/bar"
 import from '../thing/bar'`,
+      },
+      {
+        path: normalize("/projects/blitz/blitz/app/queries/baz.js"),
+        contents: `import {getFoo} from 'app/foo/bar';
+import from "../thing/bar"
+import from '../thing/bar'`,
+      },
+      {
+        path: normalize("/projects/blitz/blitz/app/mutations/baz.js"),
+        contents: `import {getFoo} from 'app/foo/bar';
+import from "../thing/bar"
+import from '../thing/bar'`,
+      },
+    ]
+
+    const expected = [
+      {
+        path: normalize("/projects/blitz/blitz/app/users/pages/index.ts"),
+        contents: `import {getFoo} from 'app/foo/bar';
+import from "app/users/thing/bar"
+import from 'app/users/thing/bar'
+import 'app/users/thing/bar'
+const Component = dynamic(() => import("app/users/thing/bar"), {})`,
+      },
+      {
+        path: normalize("/projects/blitz/blitz/app/users/pages.ts"),
+        contents: `import {getFoo} from 'app/foo/bar';
+import from "../thing/bar"
+import from '../thing/bar'
+import '../thing/bar'
+const Component = dynamic(() => import("../thing/bar"), {})`,
+      },
+      {
+        path: normalize("/projects/blitz/blitz/app/users/foo.jpeg"),
+        contents: `import {getFoo} from 'app/foo/bar';
+import from "../thing/bar"
+import from '../thing/bar'`,
+      },
+      {
+        path: normalize("/projects/blitz/blitz/app/users/pages/bar.tsx"),
+        contents: `import {getFoo} from 'app/foo/bar';
+import from "app/thing/bar"
+import from 'app/thing/bar'`,
+      },
+      {
+        path: normalize("/projects/blitz/blitz/app/users/baz/pages/hey.js"),
+        contents: `import {getFoo} from 'app/foo/bar';
+import from "app/thing/bar"
+import from 'app/thing/bar'`,
+      },
+      {
+        path: normalize("/projects/blitz/blitz/app/users/baz.js"),
+        contents: `import {getFoo} from 'app/foo/bar';
+import from "../thing/bar"
+import from '../thing/bar'`,
+      },
+      {
+        path: normalize("/projects/blitz/blitz/app/queries/baz.js"),
+        contents: `import {getFoo} from 'app/foo/bar';
+import from "app/thing/bar"
+import from 'app/thing/bar'`,
+      },
+      {
+        path: normalize("/projects/blitz/blitz/app/mutations/baz.js"),
+        contents: `import {getFoo} from 'app/foo/bar';
+import from "app/thing/bar"
+import from 'app/thing/bar'`,
       },
     ]
     const {stream} = createStageRelative(mockStageArgs({cwd: normalize("/projects/blitz/blitz")}))


### PR DESCRIPTION
### What are the changes and their implications?

I encountered in issue in where https://github.com/blitz-js/blitzjs.com/pull/269 where [babel-plugin-macros](https://github.com/kentcdodds/babel-plugin-macros) doesn't work with absolute imports. And our relative server stage is rewriting all imports to be absolute which breaks it.

So this changes this stage to only rewrite relative imports for pages/queries/mutations since those are the only files that move, breaking the original import path.

I think we should also change to rewriting relative imports to a new relative import instead of absolute: https://github.com/blitz-js/blitz/issues/1497

### Checklist

- [x] Tests added for changes
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
