### PR TITLE
Fix bug where `blitz db seed` will error silently

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -309,7 +309,9 @@ ${require("chalk").bold(
     if (command === "seed") {
       try {
         return await runSeed()
-      } catch {
+      } catch (err) {
+        log.error("Could not seed database:")
+        log.error(err)
         process.exit(1)
       }
     }


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1507

### What are the changes and their implications?

`db seed` command error failed silently. Now, it displays the error as-is. I guess it's a first step, we could improve error handling for this command.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->


👉 It's my first contribution, I may have missed something