### PR TITLE
Fix lint warnings

### DIFF
--- a/packages/server/src/stages/rewrite-imports/index.ts
+++ b/packages/server/src/stages/rewrite-imports/index.ts
@@ -28,7 +28,7 @@ export const createStageRewriteImports: Stage = ({config: {cwd}}) => {
   return {stream}
 }
 
-export const patternImport = /(import\s*)(?:(\*\s+as\s+\w+)|(?:(\w+\s*)(,\s*)?)?(?:(\{\s*\w+\s*(?:,\s*\w+\s*)*\}))?)(\s+from\s+)?((?:\(\s*)?["'])([\w\.\\\/]+)(["'](?:\s*\))?)/gs
+export const patternImport = /(import\s*)(?:(\*\s+as\s+\w+)|(?:(\w+\s*)(,\s*)?)?(?:(\{\s*\w+\s*(?:,\s*\w+\s*)*\}))?)(\s+from\s+)?((?:\(\s*)?["'])([\w.\\/]+)(["'](?:\s*\))?)/gs
 
 // Whenever we see smth like `import { myFunc } from "app/queries/myQuery"`,
 //  we rewrite that to app/_resolvers/queries/myQuery

--- a/packages/server/src/stages/rewrite-imports/rewrite-imports.test.ts
+++ b/packages/server/src/stages/rewrite-imports/rewrite-imports.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-sparse-arrays */
 import {normalize} from "path"
 import File from "vinyl"
 import {mockStageArgs} from "../stage-test-utils"


### PR DESCRIPTION
Closes: ??

### What are the changes and their implications?

Get rid of lint warnings

```
$ yarn lint
yarn run v1.22.10
$ eslint --ignore-path .gitignore --ext ".js,.ts,.tsx" .
/Users/alex/dev/blitz/packages/server/src/stages/rewrite-imports/index.ts
  31:150  warning  Unnecessary escape character: \.  no-useless-escape
  31:154  warning  Unnecessary escape character: \/  no-useless-escape

/Users/alex/dev/blitz/packages/server/src/stages/rewrite-imports/rewrite-imports.test.ts
  15:19  warning  Unexpected comma in middle of array  no-sparse-arrays
  32:19  warning  Unexpected comma in middle of array  no-sparse-arrays
  38:19  warning  Unexpected comma in middle of array  no-sparse-arrays
  42:19  warning  Unexpected comma in middle of array  no-sparse-arrays
  46:19  warning  Unexpected comma in middle of array  no-sparse-arrays
  53:19  warning  Unexpected comma in middle of array  no-sparse-arrays

✖ 8 problems (0 errors, 8 warnings)
```
### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
