### PR TITLE
Fix to allow for unicode chars in session data

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,7 @@
     "@blitzjs/config": "0.26.0",
     "@blitzjs/display": "0.26.0",
     "bad-behavior": "1.0.1",
+    "b64-lite": "1.4.0",
     "cookie-session": "1.4.0",
     "deepmerge": "4.2.2",
     "lodash": "^4.17.19",

--- a/packages/core/src/utils/tokens.test.ts
+++ b/packages/core/src/utils/tokens.test.ts
@@ -28,6 +28,13 @@ describe("supertokens", () => {
       })
     })
 
+    it("parses the public data containing unicode chars", () => {
+      const data = '"foo-κόσμε-żółć-平仮名"'
+      expect(parsePublicDataToken(toBase64(data))).toEqual({
+        publicData: "foo-κόσμε-żółć-平仮名",
+      })
+    })
+
     it("only uses the first separated tokens", () => {
       const data = `"foo"${TOKEN_SEPARATOR}123`
       expect(parsePublicDataToken(toBase64(data))).toEqual({

--- a/packages/core/src/utils/tokens.test.ts
+++ b/packages/core/src/utils/tokens.test.ts
@@ -1,5 +1,6 @@
 /* eslint @typescript-eslint/no-floating-promises: off */
 import {act} from "@testing-library/react-hooks"
+import {toBase64} from "b64-lite"
 import {renderHook} from "../../test/test-utils"
 import {TOKEN_SEPARATOR} from "../constants"
 import {publicDataStore} from "../public-data-store"
@@ -15,21 +16,21 @@ describe("supertokens", () => {
 
     it("throws if the token cannot be parsed", () => {
       const invalidJSON = "{"
-      const ret = () => parsePublicDataToken(btoa(invalidJSON))
+      const ret = () => parsePublicDataToken(toBase64(invalidJSON))
 
       expect(ret).toThrowError("[parsePublicDataToken] Failed to parse publicDataStr: {")
     })
 
     it("parses the public data", () => {
       const validJSON = '"foo"'
-      expect(parsePublicDataToken(btoa(validJSON))).toEqual({
+      expect(parsePublicDataToken(toBase64(validJSON))).toEqual({
         publicData: "foo",
       })
     })
 
     it("only uses the first separated tokens", () => {
       const data = `"foo"${TOKEN_SEPARATOR}123`
-      expect(parsePublicDataToken(btoa(data))).toEqual({
+      expect(parsePublicDataToken(toBase64(data))).toEqual({
         publicData: "foo",
       })
     })

--- a/packages/core/src/utils/tokens.ts
+++ b/packages/core/src/utils/tokens.ts
@@ -1,3 +1,4 @@
+import {fromBase64} from "b64-lite"
 import {TOKEN_SEPARATOR} from "../constants"
 import {PublicData} from "../types"
 
@@ -8,7 +9,7 @@ function assert(condition: any, message: string): asserts condition {
 export const parsePublicDataToken = (token: string) => {
   assert(token, "[parsePublicDataToken] Failed: token is empty")
 
-  const [publicDataStr] = atob(token).split(TOKEN_SEPARATOR)
+  const [publicDataStr] = fromBase64(token).split(TOKEN_SEPARATOR)
   try {
     const publicData: PublicData = JSON.parse(publicDataStr)
     return {

--- a/packages/server/src/supertokens.test.ts
+++ b/packages/server/src/supertokens.test.ts
@@ -9,7 +9,7 @@ import {
   SessionContext,
   TOKEN_SEPARATOR,
 } from "@blitzjs/core"
-import {atob} from "b64-lite"
+import {fromBase64} from "b64-lite"
 import http from "http"
 import fetch from "isomorphic-unfetch"
 import {apiResolver} from "next/dist/next-server/server/api-utils"
@@ -72,7 +72,7 @@ describe("supertokens", () => {
       expect(res.headers.get(HEADER_PUBLIC_DATA_TOKEN)).toBe("updated")
       expect(cookie(COOKIE_PUBLIC_DATA_TOKEN)).not.toBe(undefined)
 
-      const [publicDataStr, expireAtStr] = atob(cookie(COOKIE_PUBLIC_DATA_TOKEN)).split(
+      const [publicDataStr, expireAtStr] = fromBase64(cookie(COOKIE_PUBLIC_DATA_TOKEN)).split(
         TOKEN_SEPARATOR,
       )
 
@@ -105,7 +105,7 @@ describe("supertokens", () => {
       expect(res.headers.get(HEADER_CSRF)).not.toBe(undefined)
       expect(res.headers.get(HEADER_PUBLIC_DATA_TOKEN)).not.toBe(undefined)
 
-      const [publicDataStr, expireAtStr] = atob(
+      const [publicDataStr, expireAtStr] = fromBase64(
         res.headers.get(HEADER_PUBLIC_DATA_TOKEN) as string,
       ).split(TOKEN_SEPARATOR)
 

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -27,7 +27,7 @@ import {
   TOKEN_SEPARATOR,
 } from "@blitzjs/core"
 import {log} from "@blitzjs/display"
-import {atob, btoa} from "b64-lite"
+import {fromBase64, toBase64} from "b64-lite"
 import cookie from "cookie"
 import {addMinutes, addYears, differenceInMinutes, isPast} from "date-fns"
 import hasha, {HashaInput} from "hasha"
@@ -284,14 +284,14 @@ export const createSessionToken = (handle: string, publicData: PublicData | stri
   } else {
     publicDataString = JSON.stringify(publicData)
   }
-  return btoa(
+  return toBase64(
     [handle, generateToken(), hash(publicDataString), SESSION_TOKEN_VERSION_0].join(
       TOKEN_SEPARATOR,
     ),
   )
 }
 export const parseSessionToken = (token: string) => {
-  const [handle, id, hashedPublicData, version] = atob(token).split(TOKEN_SEPARATOR)
+  const [handle, id, hashedPublicData, version] = fromBase64(token).split(TOKEN_SEPARATOR)
 
   if (!handle || !id || !hashedPublicData || !version) {
     throw new AuthenticationError("Failed to parse session token")
@@ -307,7 +307,7 @@ export const parseSessionToken = (token: string) => {
 
 export const createPublicDataToken = (publicData: string | PublicData) => {
   const payload = [typeof publicData === "string" ? publicData : JSON.stringify(publicData)]
-  return btoa(payload.join(TOKEN_SEPARATOR))
+  return toBase64(payload.join(TOKEN_SEPARATOR))
 }
 
 export const createAntiCSRFToken = () => generateToken()


### PR DESCRIPTION
Closes: #1455 

### What are the changes and their implications?

Originally used `atob` and `btoa` methods from [`b64-lite`](https://github.com/kevlened/b64-lite) package don't support unicode characters. Fortunately, within the same package there are alternative methods that allow for unicode (`fromBase64` and `toBase64`). This PR basically replaces the former methods with the latter ones.

As for decoding public data on browser-end, [native `atob` method doesn't support unicode chars either](https://stackoverflow.com/a/30106551/3902198). To fix this we could use code snippet provided in the linked SO answer, but since the package we use for base64 operations is very small I just used its `fromBase64` method. 

### Checklist

- [x] Tests added for changes
- [ ] <s>PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes</s>

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
