### PR TITLE
Fix tree shaking for imports from queries/mutations

### DIFF
--- a/examples/store/app/products/queries/getProducts.ts
+++ b/examples/store/app/products/queries/getProducts.ts
@@ -25,6 +25,8 @@ export default async function getProducts(
     console.log("HTTP referer:", ctx.referer)
   }
 
+  console.log("this line should not be included in the frontend bundle")
+
   const products = await db.product.findMany({
     where,
     orderBy,

--- a/examples/store/assert-tree-shaking-works.js
+++ b/examples/store/assert-tree-shaking-works.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const glob = require("glob")
+const fs = require("fs")
+
+glob("./.next/static/chunks/**/*", {nodir: true}, (err, matches) => {
+  if (err) {
+    throw err
+  }
+
+  const offenders = []
+
+  for (const match of matches) {
+    const content = fs.readFileSync(match).toString()
+
+    if (content.includes("this line should not be included in the frontend bundle")) {
+      offenders.push(match)
+    }
+  }
+
+  if (offenders.length > 0) {
+    console.error(`tree-shaking failed: ${offenders} includes the forbidden words.`)
+    process.exit(1)
+  }
+})

--- a/examples/store/package.json
+++ b/examples/store/package.json
@@ -7,7 +7,7 @@
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "test:server": "blitz db migrate && blitz db seed && blitz start --production -p 3099",
-    "test": "start-server-and-test test:server http://localhost:3099 cy:run"
+    "test": "./assert-tree-shaking-works.js && start-server-and-test test:server http://localhost:3099 cy:run"
   },
   "prisma": {
     "schema": "db/schema.prisma"

--- a/packages/server/src/stages/rewrite-imports/index.ts
+++ b/packages/server/src/stages/rewrite-imports/index.ts
@@ -53,9 +53,7 @@ export function replaceImports(content: string) {
       closingQuotes,
     ] = args as (string | undefined)[]
 
-    const importsOnlyDefault = !!defaultImportName && !(starImport || namedImportNames)
-
-    const newOrigin = rewriteImportOrigin(origin!, !importsOnlyDefault)
+    const newOrigin = rewriteImportOrigin(origin!)
 
     return [
       importToken,
@@ -71,7 +69,7 @@ export function replaceImports(content: string) {
   })
 }
 
-export function rewriteImportOrigin(origin: string, importsNamedExports: boolean): string {
+export function rewriteImportOrigin(origin: string): string {
   const parts = origin.split("/")
 
   // If it's an import from a page, say from app/pages/mypage,
@@ -90,19 +88,6 @@ export function rewriteImportOrigin(origin: string, importsNamedExports: boolean
     }
 
     parts.splice(0, parts.indexOf("api"), "pages")
-  }
-
-  if (importsNamedExports) {
-    const indexOfQueries = parts.lastIndexOf("queries")
-    const indexOfMutations = parts.lastIndexOf("mutations")
-
-    if (indexOfQueries !== -1 || indexOfMutations !== -1) {
-      if (indexOfQueries === parts.length - 1 || indexOfMutations === parts.length - 1) {
-        parts.push("index")
-      }
-
-      parts[parts.length - 1] = parts[parts.length - 1] + ".named"
-    }
   }
 
   return parts.join("/")

--- a/packages/server/src/stages/rewrite-imports/index.ts
+++ b/packages/server/src/stages/rewrite-imports/index.ts
@@ -28,44 +28,13 @@ export const createStageRewriteImports: Stage = ({config: {cwd}}) => {
   return {stream}
 }
 
-export const patternImport = /(import\s*)(?:(\*\s+as\s+\w+)|(?:(\w+\s*)(,\s*)?)?(?:(\{\s*\w+\s*(?:,\s*\w+\s*)*\}))?)(\s+from\s+)?((?:\(\s*)?["'])([\w.\\/]+)(["'](?:\s*\))?)/gs
-
-// Whenever we see smth like `import { myFunc } from "app/queries/myQuery"`,
-//  we rewrite that to app/_resolvers/queries/myQuery
-//
-// When we see smth like `import myQuery, { myFunc } from "app/queries/myQuery"`,
-//  we rewrite it to the following two:
-//   import myQuery from "app/queries/myQuery"
-//   import { myFunc } from "app/_resolvers/queries/myQuery"
+export const patternImport = /(import.*?["'])(.+?)(["'])/gs
 
 export function replaceImports(content: string) {
   return content.replace(patternImport, (...args) => {
-    const [
-      ,
-      importToken,
-      starImport,
-      defaultImportName,
-      combinedComma,
-      namedImportNames,
-      fromToken,
-      openingQuotes,
-      origin,
-      closingQuotes,
-    ] = args as (string | undefined)[]
+    const [, start, resource, end] = args as string[]
 
-    const newOrigin = rewriteImportOrigin(origin!)
-
-    return [
-      importToken,
-      starImport ?? "",
-      defaultImportName ?? "",
-      combinedComma ?? "",
-      namedImportNames ?? "",
-      fromToken ?? "",
-      openingQuotes,
-      newOrigin,
-      closingQuotes,
-    ].join("")
+    return start + rewriteImportOrigin(resource) + end
   })
 }
 

--- a/packages/server/src/stages/rewrite-imports/rewrite-imports.test.ts
+++ b/packages/server/src/stages/rewrite-imports/rewrite-imports.test.ts
@@ -14,44 +14,38 @@ describe("rewrite-imports", () => {
           bar
         } from "./ding"`,
         expected: [
-          "import ",
-          ,
-          ,
-          ,
-          `{
+          `import {
           foo,
           bar
-        }`,
-          " from ",
-          '"',
+        } from "`,
           "./ding",
           '"',
         ],
       },
       {
         input: 'import { foo, bar } from "app/ding"',
-        expected: ["import ", , , , "{ foo, bar }", " from ", '"', "app/ding", '"'],
+        expected: ['import { foo, bar } from "', "app/ding", '"'],
       },
       {
         input: `
         import { someFunction } from "app/pages/index";
         `,
-        expected: ["import ", , , , "{ someFunction }", " from ", '"', "app/pages/index", '"'],
+        expected: ['import { someFunction } from "', "app/pages/index", '"'],
       },
       {
         input: 'import Default from "app/some/file"',
-        expected: ["import ", , "Default", , , " from ", '"', "app/some/file", '"'],
+        expected: ['import Default from "', "app/some/file", '"'],
       },
       {
         input: 'import {Suspense, useState} from "react"\n',
-        expected: ["import ", , , , "{Suspense, useState}", " from ", '"', "react", '"'],
+        expected: ['import {Suspense, useState} from "', "react", '"'],
       },
       {
         input: `import db, {ProductCreateArgs} from "db"
         type CreateProductInput = {
           data: ProductCreateArgs["data"]
         }`,
-        expected: ["import ", , "db", ", ", "{ProductCreateArgs}", " from ", '"', "db", '"'],
+        expected: [`import db, {ProductCreateArgs} from "`, "db", `"`],
       },
     ]
 
@@ -165,66 +159,6 @@ describe("rewrite-imports", () => {
               import { someFunction } from "pages/api/getUser";
               export function someOtherFunction() {
                 return someFunction();
-              }
-            `,
-          },
-        ],
-      }),
-    )
-  })
-
-  describe("a combined import from app/users/queries/getUser", () => {
-    it(
-      "is rewritten to app/users/queries/getUser.named",
-      makeTest({
-        input: [
-          {
-            path: normalize("/projects/blitz/blitz/app/anyFile.ts"),
-            contents: `
-              import query, { someFunction } from "app/users/queries/getUser";
-              export function someOtherFunction() {
-                return someFunction();
-              }
-            `,
-          },
-        ],
-        expectedOutput: [
-          {
-            path: normalize("/projects/blitz/blitz/app/anyFile.ts"),
-            contents: `
-              import query, { someFunction } from "app/users/queries/getUser.named";
-              export function someOtherFunction() {
-                return someFunction();
-              }
-            `,
-          },
-        ],
-      }),
-    )
-  })
-
-  describe("a dynamic import from app/users/queries/getUser", () => {
-    it(
-      "is rewritten to app/users/queries/getUser.named",
-      makeTest({
-        input: [
-          {
-            path: normalize("/projects/blitz/blitz/app/anyFile.ts"),
-            contents: `
-              export async function someOtherFunction() {
-                const getUser = await import("app/users/queries/getUser");
-                return getUser.someFunction();
-              }
-            `,
-          },
-        ],
-        expectedOutput: [
-          {
-            path: normalize("/projects/blitz/blitz/app/anyFile.ts"),
-            contents: `
-              export async function someOtherFunction() {
-                const getUser = await import("app/users/queries/getUser.named");
-                return getUser.someFunction();
               }
             `,
           },

--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -14,7 +14,7 @@ export function withBlitz(nextConfig: any) {
         reactMode: "concurrent",
         ...(normalizedConfig.experimental || {}),
       },
-      webpack(config: any, options: Record<any, any>) {
+      webpack(config: any, options: {isServer: boolean; webpack: any}) {
         if (options.isServer) {
           const originalEntry = config.entry
           config.entry = async () => ({
@@ -39,11 +39,28 @@ export function withBlitz(nextConfig: any) {
             config.module.rules.push({test: excluded, use: {loader: "null-loader"}})
           })
 
-          config.module.rules.push({
-            issuer: /(mutations|queries)(?!.*\.named)/,
-            resource: /_resolvers/,
-            use: {loader: "null-loader"},
-          })
+          config.plugins.push(
+            new options.webpack.NormalModuleReplacementPlugin(
+              /[\\\/]?(mutations|queries)[\\\/]/,
+              (resource: any) => {
+                const request = resource.request as string
+                if (request.includes("_resolvers")) {
+                  return
+                }
+
+                if (
+                  request.endsWith(".js") ||
+                  request.endsWith(".ts") ||
+                  request.endsWith(".jsx") ||
+                  request.endsWith(".tsx")
+                ) {
+                  return
+                }
+
+                resource.request = resource.request + ".client"
+              },
+            ),
+          )
         }
 
         if (typeof normalizedConfig.webpack === "function") {

--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -41,7 +41,7 @@ export function withBlitz(nextConfig: any) {
 
           config.plugins.push(
             new options.webpack.NormalModuleReplacementPlugin(
-              /[\\\/]?(mutations|queries)[\\\/]/,
+              /[/\\]?(mutations|queries)[/\\]/,
               (resource: any) => {
                 const request = resource.request as string
                 if (request.includes("_resolvers")) {


### PR DESCRIPTION
Before, the RPC generator produced files like this:

```ts
// getReferer.ts

import {getIsomorphicEnhancedResolver} from '@blitzjs/core'
import * as resolverModule from 'app/_resolvers/queries/getReferer'
export * from 'app/_resolvers/queries/getReferer'
export default getIsomorphicEnhancedResolver(
  resolverModule,
  'app/_resolvers/queries/getReferer',
  'getReferer',
  'query',
  undefined,
  {
    warmApiEndpoints: false
  }
)
```

People would import that (generated) file to access methods exported in line 3 of it - but they wouldn't want the rest of it to become part of the bundle.
Yet, this is precisely what happened: Because the whole `resolverModule` is passed into `getIsomorphicEnhancedResolver` ([which actually _may_ use it](https://github.com/blitz-js/blitz/blob/4d54e8962185b0475c513b82ec8c6b9dce86fd72/packages/core/src/rpc.ts#L217)), it couldn't be shaken away.

This commit fixes this. It introduces a new variant of the generated resolver file:

```ts
// getReferer.client.ts
import {getIsomorphicEnhancedResolver} from '@blitzjs/core'
export * from 'app/_resolvers/queries/getReferer'
export default getIsomorphicEnhancedResolver(
  undefined,
  'app/_resolvers/queries/getReferer',
  'getReferer',
  'query',
  undefined,
  {
    warmApiEndpoints: false
  }
)
```

The `NormalModuleReplacementPlugin` makes sure that the frontend build is rewritten to the `.client.ts` one, while the server build gets access too the full resolver.

I could locally verify that this allows `getProducts` from the store example to be successfully eliminated from the bundle.
I will add an integration test for that in the next commit.

Closes: ??

### What are the changes and their implications?

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
