### PR TITLE
fix: add postcss to tailwind recipe

### DIFF
--- a/recipes/tailwind/index.ts
+++ b/recipes/tailwind/index.ts
@@ -18,6 +18,7 @@ We'll install the Tailwind library itself, as well as PostCSS for removing unuse
     packages: [
       {name: "tailwindcss", version: "2"},
       {name: "autoprefixer", version: "10", isDevDep: true},
+      {name: "postcss", version: "8", isDevDep: true},
     ],
   })
   .addNewFilesStep({


### PR DESCRIPTION
Closes #1535 

### What are the changes and their implications?
I just tried blitz.js the first time and wanted to play around with the recipes.
Installing the tailwindcss recipe broke the app due to to css import errors displaying a prompt to also install postcss which solved the issue, so I guess it makes sense to fix at the recipe level?

### Checklist
- [ ] Tests added for changes

I didn't add tests for it as I wasn't sure how to test this without running the recipe and building the app.