### PR TITLE
Fix blitz compiler to ignore gitignored files during processing

### DIFF
--- a/packages/file-pipeline/package.json
+++ b/packages/file-pipeline/package.json
@@ -37,6 +37,7 @@
     "fs-extra": "9.0.0",
     "gulp-if": "3.0.0",
     "merge-stream": "2.0.0",
+    "micromatch": "4.0.2",
     "ora": "4.0.4",
     "parallel-transform": "1.2.0",
     "pump": "3.0.0",

--- a/packages/file-pipeline/src/micromatch.d.ts
+++ b/packages/file-pipeline/src/micromatch.d.ts
@@ -1,0 +1,3 @@
+declare module "micromatch" {
+  export function isMatch(source: string, patterns: string[]): boolean
+}

--- a/packages/file-pipeline/src/pipeline.ts
+++ b/packages/file-pipeline/src/pipeline.ts
@@ -1,4 +1,5 @@
 import {Stats} from "fs"
+import micromatch from "micromatch"
 import {Writable} from "stream"
 import File from "vinyl"
 import {agnosticSource} from "./helpers/agnostic-source"
@@ -86,6 +87,20 @@ export function createPipeline(
   // Initialize each stage
   const initializedStages = stages.map((stage) => stage(api))
 
+  // Discard git ignored files
+  const globIgnore = config.ignore
+    .map((pattern) => ["**/" + pattern, "**/" + pattern + "/**/*"])
+    .flat()
+  const ignorer = through.obj((file, _, next) => {
+    if (file && file.path) {
+      const match = micromatch.isMatch(file.path, globIgnore)
+      if (match) {
+        return next() // skip chunk
+      }
+    }
+    next(null, file)
+  })
+
   const stream = pipeline(
     source.stream, // files come from file system
     input, // files coming via internal API
@@ -94,6 +109,9 @@ export function createPipeline(
     enrichFiles.stream,
     srcCache.stream,
     optimizer.triage,
+
+    // Filter files
+    ignorer,
 
     // Run business stages
     ...initializedStages.map((stage) => stage.stream),

--- a/packages/file-pipeline/src/transform-files/index.test.ts
+++ b/packages/file-pipeline/src/transform-files/index.test.ts
@@ -1,0 +1,82 @@
+import {normalize} from "path"
+import through2 from "through2"
+import File from "vinyl"
+import {testStreamItems} from "../test-utils"
+import {transformFiles} from "."
+
+function logFile(file: File | string) {
+  const out = typeof file === "string" ? file : file.path
+  return out
+}
+
+function generateFile(num: number) {
+  // const num = Math.random()
+  return new File({
+    path: normalize(`/foo/${num}.ts`),
+    content: Buffer.from(`${num}`),
+  })
+}
+
+describe("transformFiles", () => {
+  it("should ignore gitignored files", async () => {
+    process.env.MAX_DEBUG_PLS = "true"
+    const source = {
+      stream: through2.obj((f, _, next) => {
+        next(null, f)
+      }),
+    }
+
+    const writer = {
+      stream: through2.obj((f, _, next) => {
+        next(null, f)
+      }),
+    }
+
+    const files: File[] = []
+    for (let i = 0; i < 10; i++) {
+      files.push(generateFile(i))
+    }
+
+    files.forEach((f) => {
+      source.stream.write(f)
+    })
+
+    source.stream.write(
+      new File({
+        path: normalize(`/foo/.DS_Store`),
+        content: Buffer.from(`test`),
+      }),
+    )
+    source.stream.write(
+      new File({
+        path: normalize(`/foo/logs/stdout.log`),
+        content: Buffer.from(`test`),
+      }),
+    )
+    source.stream.write(
+      new File({
+        path: normalize(`/foo/.blitz/test.txt`),
+        content: Buffer.from(`test`),
+      }),
+    )
+
+    source.stream.write("ready")
+
+    await Promise.all([
+      testStreamItems(
+        writer.stream,
+        files
+          .map((f) => {
+            return normalize(f.path)
+          })
+          .concat(["ready"]),
+        logFile,
+      ),
+      transformFiles(normalize("/foo"), [], normalize("/bar"), {
+        source,
+        writer,
+        ignore: [".DS_Store", "*.log", ".blitz"],
+      }),
+    ])
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -13347,6 +13347,14 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
+micromatch@4.0.2, micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
+
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -13365,14 +13373,6 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
-
-micromatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
-  dependencies:
-    braces "^3.0.1"
-    picomatch "^2.0.5"
 
 miller-rabin@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
Closes: #1508

### What are the changes and their implications?

The change makes the package `file-pipeline` ignore the `.gitignore` patterns passed in the `config.ignore` configuration.

This changes requires another dependency to be added: `micromatch`. This library is already included by `fast-glob` so it shouldn't increase the bundle size.

I've added tests to make sure the ignored patterns are respected.

The "weak point" in this PR is that I've used an easy way to convert `.gitignore` patterns into glob patterns (supported by fast-glob/micromatch) by:

- prepending `**/` to gitignore patterns
- both prepending `**/` and appending `/**/*` to gitignore patterns

According to the tests it works on several patterns from `.gitignore` so we should be good.

### Checklist

- [x] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
