### PR TITLE
Add log level option to `blitz.config.js`

### DIFF
--- a/examples/auth/app/pages/index.tsx
+++ b/examples/auth/app/pages/index.tsx
@@ -25,8 +25,6 @@ const UserStuff = () => {
 
   if (session.isLoading) return <div>Loading...</div>
 
-  console.log(session.views)
-
   return (
     <div>
       {!session.userId && (

--- a/examples/auth/app/users/queries/getUser.ts
+++ b/examples/auth/app/users/queries/getUser.ts
@@ -7,7 +7,6 @@ type GetUserInput = {
 
 export default async function getUser({where}: GetUserInput, ctx: Ctx) {
   ctx.session.authorize()
-  console.log(ctx.session.userId)
 
   const user = await db.user.findFirst({where})
 

--- a/examples/auth/blitz.config.js
+++ b/examples/auth/blitz.config.js
@@ -10,6 +10,9 @@ module.exports = withBundleAnalyzer({
       sessionExpiryMinutes: 4,
     }),
   ],
+  log: {
+    // level: "fatal",
+  },
   /*
   webpack: (config, {buildId, dev, isServer, defaultLoaders, webpack}) => {
     // Note: we provide webpack above so you should not `require` it

--- a/examples/auth/blitz.config.js
+++ b/examples/auth/blitz.config.js
@@ -11,7 +11,7 @@ module.exports = withBundleAnalyzer({
     }),
   ],
   log: {
-    // level: "fatal",
+    level: "trace",
   },
   /*
   webpack: (config, {buildId, dev, isServer, defaultLoaders, webpack}) => {

--- a/packages/blitz/package.json
+++ b/packages/blitz/package.json
@@ -45,6 +45,8 @@
     "@blitzjs/generator": "0.26.2",
     "@blitzjs/installer": "0.26.2",
     "@blitzjs/server": "0.26.2",
+    "@blitzjs/config": "0.26.2",
+    "@blitzjs/display": "0.26.2",
     "envinfo": "7.7.2",
     "os-name": "3.1.0",
     "pkg-dir": "4.2.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,13 +1,7 @@
 {
   "name": "@blitzjs/config",
-  "description": "Loads the blitz app config",
-  "keywords": [
-    "next.config.js",
-    "blitz.config.js",
-    "config"
-  ],
-  "author": "Fran Zekan <zekan.fran369@gmail.com>",
   "version": "0.26.2",
+  "description": "Loads the blitz app config",
   "license": "MIT",
   "scripts": {
     "clean": "rimraf dist",
@@ -27,6 +21,12 @@
       "<rootDir>/jest.setup.js"
     ]
   },
+  "keywords": [
+    "next.config.js",
+    "blitz.config.js",
+    "config"
+  ],
+  "author": "Fran Zekan <zekan.fran369@gmail.com>",
   "repository": {
     "type": "git",
     "url": "https://github.com/blitz-js/blitz"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,8 +40,6 @@
     "url": "https://github.com/blitz-js/blitz"
   },
   "dependencies": {
-    "@blitzjs/config": "0.26.2",
-    "@blitzjs/display": "0.26.2",
     "b64-lite": "1.4.0",
     "bad-behavior": "1.0.1",
     "cookie-session": "1.4.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,9 +5,10 @@
   "license": "MIT",
   "scripts": {
     "clean": "rimraf dist",
-    "predev": "yarn wait:display",
     "wait:display": "wait-on ../display/dist/packages/display/src/index.d.ts",
+    "predev": "yarn wait:display",
     "dev": "tsdx watch --verbose",
+    "prebuild": "yarn predev",
     "build": "tsdx build",
     "test": "tsdx test --env=jest-environment-jsdom-sixteen",
     "test:watch": "tsdx test --watch --env=jest-environment-jsdom-sixteen"

--- a/packages/core/src/invoke.ts
+++ b/packages/core/src/invoke.ts
@@ -52,7 +52,7 @@ export async function invokeWithMiddleware<TInput, TResult>(
   }
 
   middleware.push(async (_req, res, next) => {
-    const log = baseLogger.getChildLogger({prefix: [enhancedResolver._meta.name + "()"]})
+    const log = baseLogger().getChildLogger({prefix: [enhancedResolver._meta.name + "()"]})
     displayLog.newline()
     try {
       log.info(chalk.dim("Starting with input:"), params)

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -65,20 +65,20 @@ export async function handleRequestWithMiddleware(
     log.newline()
     if (req.method === "GET") {
       // This GET method check is so we don't .end() the request for SSR requests
-      baseLogger.error("Error while processing the request")
+      baseLogger().error("Error while processing the request")
     } else if (res.writableFinished) {
-      baseLogger.error(
+      baseLogger().error(
         "Error occured in middleware after the response was already sent to the browser",
       )
     } else {
       res.statusCode = (error as any).statusCode || (error as any).status || 500
       res.end(error.message || res.statusCode.toString())
-      baseLogger.error("Error while processing the request")
+      baseLogger().error("Error while processing the request")
     }
     if (error._clearStack) {
       delete error.stack
     }
-    baseLogger.prettyError(error)
+    baseLogger().prettyError(error)
     log.newline()
     if (throwOnError) throw error
   }

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -5,6 +5,9 @@
   "homepage": "https://github.com/blitz-js/blitz#readme",
   "license": "MIT",
   "scripts": {
+    "clean": "rimraf dist",
+    "predev": "yarn wait:config",
+    "wait:config": "wait-on ../config/dist/packages/config/src/index.d.ts",
     "dev": "tsdx watch --verbose",
     "build": "tsdx build",
     "test": "tsdx test",

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -6,9 +6,10 @@
   "license": "MIT",
   "scripts": {
     "clean": "rimraf dist",
-    "predev": "yarn wait:config",
     "wait:config": "wait-on ../config/dist/packages/config/src/index.d.ts",
+    "predev": "yarn wait:config",
     "dev": "tsdx watch --verbose",
+    "prebuild": "yarn predev",
     "build": "tsdx build",
     "test": "tsdx test",
     "test:watch": "tsdx test --watch"

--- a/packages/display/src/index.ts
+++ b/packages/display/src/index.ts
@@ -5,16 +5,22 @@ import readline from "readline"
 import {Logger} from "tslog"
 
 type LogConfig = {
-  level?: "trace" | "debug" | "info" | "warn" | "error" | "fatal"
+  level: "trace" | "debug" | "info" | "warn" | "error" | "fatal"
+}
+
+const defaultConfig: LogConfig = {
+  level: "info",
 }
 
 const getLogConfig = (): LogConfig => {
   const config = getConfig()
 
   // TODO - validate log config and print helpfull error if invalid
-  if (config.log && typeof config.log === "object") return config.log as any
+  if (config.log && typeof config.log === "object") {
+    return {...defaultConfig, ...config.log} as any
+  }
 
-  return {}
+  return defaultConfig
 }
 
 export const chalk = c
@@ -170,7 +176,7 @@ export const baseLogger = () => {
   globalThis._blitz_baseLogger =
     globalThis._blitz_baseLogger ??
     new Logger({
-      minLevel: getLogConfig().level ?? "trace",
+      minLevel: getLogConfig().level,
       dateTimePattern:
         process.env.NODE_ENV === "production"
           ? "year-month-day hour:minute:second.millisecond"

--- a/packages/file-pipeline/package.json
+++ b/packages/file-pipeline/package.json
@@ -5,9 +5,10 @@
   "homepage": "https://github.com/blitz-js/blitz#readme",
   "license": "MIT",
   "scripts": {
-    "predev": "yarn wait:display",
     "wait:display": "wait-on ../display/dist/packages/display/src/index.d.ts",
+    "predev": "yarn wait:display",
     "dev": "tsdx watch --verbose",
+    "prebuild": "yarn predev",
     "build": "tsdx build",
     "test": "tsdx test",
     "test:watch": "tsdx test --watch"

--- a/packages/file-pipeline/package.json
+++ b/packages/file-pipeline/package.json
@@ -5,6 +5,8 @@
   "homepage": "https://github.com/blitz-js/blitz#readme",
   "license": "MIT",
   "scripts": {
+    "predev": "yarn wait:display",
+    "wait:display": "wait-on ../display/dist/packages/display/src/index.d.ts",
     "dev": "tsdx watch --verbose",
     "build": "tsdx build",
     "test": "tsdx test",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,8 +34,6 @@
     ]
   },
   "dependencies": {
-    "@blitzjs/config": "0.26.2",
-    "@blitzjs/display": "0.26.2",
     "@blitzjs/file-pipeline": "0.26.2",
     "b64-lite": "1.4.0",
     "cookie": "0.4.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,6 +17,7 @@
     "wait:config": "wait-on ../config/dist/packages/config/src/index.d.ts",
     "predev": "yarn wait:config && yarn wait:file-pipeline && yarn wait:core",
     "dev": "tsdx watch --verbose",
+    "prebuild": "yarn predev",
     "build": "tsdx build",
     "test": "tsdx test"
   },

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -21,7 +21,7 @@ export async function dev(config: ServerConfig) {
   const versionMatched = await isVersionMatched(devFolder)
 
   const stages = configureStages({writeManifestFile, isTypescript})
-  
+
   const {manifest} = await transformFiles(rootFolder, stages, devFolder, {
     ignore,
     include,

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -15,7 +15,7 @@ const rpcMiddleware = <TInput, TResult>(
   connectDb?: () => any,
 ): Middleware => {
   return async (req, res, next) => {
-    const log = baseLogger.getChildLogger({prefix: [resolver._meta.name + "()"]})
+    const log = baseLogger().getChildLogger({prefix: [resolver._meta.name + "()"]})
 
     if (req.method === "HEAD") {
       // Warm the lamda and connect to DB
@@ -46,8 +46,7 @@ const rpcMiddleware = <TInput, TResult>(
         const result = await resolver(data, res.blitzCtx)
 
         const duration = prettyMs(new Date().getTime() - startTime)
-        log.info(chalk.dim("Finished", "in", duration))
-        displayLog.newline()
+        log.info(chalk.dim("Finished", "in", duration) + "\n")
 
         res.blitzResult = result
 

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -46,7 +46,9 @@ const rpcMiddleware = <TInput, TResult>(
         const result = await resolver(data, res.blitzCtx)
 
         const duration = prettyMs(new Date().getTime() - startTime)
-        log.info(chalk.dim("Finished", "in", duration) + "\n")
+        log.debug(chalk.dim("Result:"), result)
+        log.info(chalk.dim("Finished", "in", duration))
+        displayLog.newline()
 
         res.blitzResult = result
 


### PR DESCRIPTION
Closes: #1550 

### What are the changes and their implications?

Adds a log level option to `blitz.config.js`. Default level is `info`. To remove all blitz logs, set level to `fatal`

```
module.exports = {
  log: {
    level: 'fatal'
  }
}
```


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
