### PR TITLE
Fix message in the `blitz generate pages` edit page

### DIFF
--- a/packages/generator/templates/page/__modelIdParam__/edit.tsx
+++ b/packages/generator/templates/page/__modelIdParam__/edit.tsx
@@ -36,7 +36,7 @@ export const Edit__ModelName__ = () => {
             )
           } catch (error) {
             console.log(error)
-            alert("Error creating __modelName__ " + JSON.stringify(error, null, 2))
+            alert("Error editing __modelName__ " + JSON.stringify(error, null, 2))
           }
         }}
       />


### PR DESCRIPTION
### What are the changes and their implications?

Modified the alert text that is triggered when a resource edit throws an error. Before it was displaying the same value as the "Creation" of the resource.

### Checklist

- [x] Tests added for changes *n/a*
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes *n/a*

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
