### PR TITLE
Add missing dependencies to `config` and `display` packages

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -31,5 +31,9 @@
     "type": "git",
     "url": "https://github.com/blitz-js/blitz"
   },
+  "dependencies": {
+    "next": "10.0.2",
+    "pkg-dir": "4.2.0"
+  },
   "gitHead": "d3b9fce0bdd251c2b1890793b0aa1cd77c1c0922"
 }

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -34,6 +34,7 @@
     "url": "git+https://github.com/blitz-js/blitz.git"
   },
   "dependencies": {
+    "@blitzjs/config": "0.27.0-canary.0",
     "chalk": "4.0.0",
     "ora": "4.0.4",
     "tslog": "2.9.1"


### PR DESCRIPTION
Closes: #1556 

### What are the changes and their implications?

This PR adds missing required dependencies for `@blitzjs/config` and `@blitzjs/display` packages. Therefore fixes the problem with modules not found when installing recipes.

### Checklist

- [ ] <s>Tests added for changes</s>
- [ ] <s>PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes</s>

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
