### PR TITLE
(newapp) Change `useCurrentUser` hook to not use `useSession` (fixes UX)

### DIFF
--- a/examples/auth/app/hooks/useCurrentUser.ts
+++ b/examples/auth/app/hooks/useCurrentUser.ts
@@ -1,7 +1,7 @@
-import {useQuery, useSession} from "blitz"
+import {useQuery} from "blitz"
 import getCurrentUser from "app/users/queries/getCurrentUser"
 
 export const useCurrentUser = () => {
-  const [user] = useQuery(getCurrentUser, null, {enabled: !!session.userId})
-  return session.userId ? user : null
+  const [user] = useQuery(getCurrentUser, null)
+  return user
 }

--- a/examples/auth/app/hooks/useCurrentUser.ts
+++ b/examples/auth/app/hooks/useCurrentUser.ts
@@ -2,9 +2,6 @@ import {useQuery, useSession} from "blitz"
 import getCurrentUser from "app/users/queries/getCurrentUser"
 
 export const useCurrentUser = () => {
-  // We wouldn't have to useSession() here, but doing so improves perf on initial
-  // load since we can skip the getCurrentUser() request.
-  const session = useSession()
   const [user] = useQuery(getCurrentUser, null, {enabled: !!session.userId})
   return session.userId ? user : null
 }

--- a/examples/fauna/app/hooks/useCurrentUser.ts
+++ b/examples/fauna/app/hooks/useCurrentUser.ts
@@ -1,10 +1,7 @@
-import { useQuery, useSession } from "blitz"
+import { useQuery } from "blitz"
 import getCurrentUser from "app/users/queries/getCurrentUser"
 
 export const useCurrentUser = () => {
-  // We wouldn't have to useSession() here, but doing so improves perf on initial
-  // load since we can skip the getCurrentUser() request.
-  const session = useSession()
-  const [user] = useQuery(getCurrentUser, null, { enabled: !!session.userId })
-  return session.userId ? user : null
+  const [user] = useQuery(getCurrentUser, null)
+  return user
 }

--- a/packages/generator/templates/app/app/hooks/useCurrentUser.ts
+++ b/packages/generator/templates/app/app/hooks/useCurrentUser.ts
@@ -1,10 +1,7 @@
-import { useQuery, useSession } from "blitz"
+import { useQuery } from "blitz"
 import getCurrentUser from "app/users/queries/getCurrentUser"
 
 export const useCurrentUser = () => {
-  // We wouldn't have to useSession() here, but doing so improves perf on initial
-  // load since we can skip the getCurrentUser() request.
-  const session = useSession()
-  const [user] = useQuery(getCurrentUser, null, { enabled: !!session.userId })
-  return session.userId ? user : null
+  const [user] = useQuery(getCurrentUser, null)
+  return user
 }


### PR DESCRIPTION
### What are the changes and their implications?

Change `useCurrentUser` hook to not use `useSession` (fixes UX)
