### PR TITLE
Fix `blitz install` by reworking dependencies

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -31,5 +31,8 @@
     "type": "git",
     "url": "https://github.com/blitz-js/blitz"
   },
+  "dependencies": {
+    "pkg-dir": "4.2.0"
+  },
   "gitHead": "d3b9fce0bdd251c2b1890793b0aa1cd77c1c0922"
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,7 +1,5 @@
 import {existsSync} from "fs"
-import {PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_SERVER} from "next/constants"
 import {join} from "path"
-import pkgDir from "pkg-dir"
 
 const configFiles = ["blitz.config.js", "next.config.js"]
 /**
@@ -11,6 +9,9 @@ export const getConfig = (reload?: boolean): Record<string, unknown> => {
   if (global.blitzConfig && Object.keys(global.blitzConfig).length > 0 && !reload) {
     return global.blitzConfig
   }
+
+  const pkgDir = require("pkg-dir")
+  const {PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_SERVER} = require("next/constants")
 
   let blitzConfig = {}
   const projectRoot = pkgDir.sync() || process.cwd()

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,5 +1,6 @@
 import {existsSync} from "fs"
 import {join} from "path"
+import pkgDir from "pkg-dir"
 
 const configFiles = ["blitz.config.js", "next.config.js"]
 /**
@@ -10,8 +11,15 @@ export const getConfig = (reload?: boolean): Record<string, unknown> => {
     return global.blitzConfig
   }
 
-  const pkgDir = require("pkg-dir")
-  const {PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_SERVER} = require("next/constants")
+  let PHASE_PRODUCTION_SERVER
+  let PHASE_DEVELOPMENT_SERVER
+  try {
+    const constants = require("next/constants")
+    PHASE_PRODUCTION_SERVER = constants.PHASE_PRODUCTION_SERVER
+    PHASE_DEVELOPMENT_SERVER = constants.PHASE_DEVELOPMENT_SERVER
+  } catch (error) {
+    if (!process.env.BLITZ_TEST_ENVIRONMENT) throw error
+  }
 
   let blitzConfig = {}
   const projectRoot = pkgDir.sync() || process.cwd()

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -34,6 +34,7 @@
     "url": "git+https://github.com/blitz-js/blitz.git"
   },
   "dependencies": {
+    "@blitzjs/config": "0.27.0-canary.1",
     "chalk": "4.0.0",
     "ora": "4.0.4",
     "tslog": "2.9.1"

--- a/packages/display/src/index.ts
+++ b/packages/display/src/index.ts
@@ -1,4 +1,3 @@
-import {getConfig} from "@blitzjs/config"
 import c from "chalk"
 import ora from "ora"
 import readline from "readline"
@@ -13,6 +12,7 @@ const defaultConfig: LogConfig = {
 }
 
 const getLogConfig = (): LogConfig => {
+  const {getConfig} = require("@blitzjs/config")
   const config = getConfig()
 
   // TODO - validate log config and print helpfull error if invalid

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@babel/core": "7.9.0",
     "@babel/plugin-transform-typescript": "7.9.4",
-    "@blitzjs/config": "0.27.0-canary.1",
     "@blitzjs/display": "0.27.0-canary.1",
     "@blitzjs/generator": "0.27.0-canary.1",
     "@types/jscodeshift": "0.7.1",

--- a/packages/server/jest.setup.js
+++ b/packages/server/jest.setup.js
@@ -1,0 +1,1 @@
+process.env.BLITZ_TEST_ENVIRONMENT = true


### PR DESCRIPTION
Closes: #1566 

### What are the changes and their implications?

This should fix blitz install by lazy requiring peer dependencies

