### PR TITLE
Fix module not found issues by moving isomorphic resolver imports behind experimental flag

### DIFF
--- a/examples/auth/blitz.config.js
+++ b/examples/auth/blitz.config.js
@@ -13,6 +13,9 @@ module.exports = withBundleAnalyzer({
   log: {
     level: "trace",
   },
+  experimental: {
+    isomorphicResolverImports: true,
+  },
   /*
   webpack: (config, {buildId, dev, isServer, defaultLoaders, webpack}) => {
     // Note: we provide webpack above so you should not `require` it

--- a/examples/store/blitz.config.js
+++ b/examples/store/blitz.config.js
@@ -5,6 +5,9 @@ module.exports = {
       return next()
     },
   ],
+  experimental: {
+    isomorphicResolverImports: true,
+  },
   // webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
   //   // Note: we provide webpack above so you should not `require` it
   //   // Perform customizations to webpack config

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -3,10 +3,18 @@ import {join} from "path"
 import pkgDir from "pkg-dir"
 
 const configFiles = ["blitz.config.js", "next.config.js"]
+
+export interface BlitzConfig extends Record<string, unknown> {
+  target?: string
+  experimental?: {
+    isomorphicResolverImports?: boolean
+  }
+}
+
 /**
  * @param {boolean | undefined} reload - reimport config files to reset global cache
  */
-export const getConfig = (reload?: boolean): Record<string, unknown> => {
+export const getConfig = (reload?: boolean): BlitzConfig => {
   if (global.blitzConfig && Object.keys(global.blitzConfig).length > 0 && !reload) {
     return global.blitzConfig
   }

--- a/packages/file-pipeline/src/helpers/agnostic-source/agnostic-source.test.ts
+++ b/packages/file-pipeline/src/helpers/agnostic-source/agnostic-source.test.ts
@@ -13,13 +13,9 @@ function logItem(fileOrString: {path: string} | string) {
 }
 
 describe("agnosticSource", () => {
-  afterEach(() => {
-    try {
-      if (fs.existsSync(resolve(cwd, "three"))) {
-        fs.unlinkSync(resolve(cwd, "three"))
-      }
-    } catch {
-      // Ignore any errors like ENOENT: no such file or directory
+  beforeEach(() => {
+    if (fs.existsSync(resolve(cwd, "three"))) {
+      fs.unlinkSync(resolve(cwd, "three"))
     }
   })
 

--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -39,28 +39,36 @@ export function withBlitz(nextConfig: any) {
             config.module.rules.push({test: excluded, use: {loader: "null-loader"}})
           })
 
-          config.plugins.push(
-            new options.webpack.NormalModuleReplacementPlugin(
-              /[/\\]?(mutations|queries)[/\\]/,
-              (resource: any) => {
-                const request = resource.request as string
-                if (request.includes("_resolvers")) {
-                  return
-                }
+          if (normalizedConfig.experimental?.isomorphicResolverImports) {
+            config.plugins.push(
+              new options.webpack.NormalModuleReplacementPlugin(
+                /[/\\]?(mutations|queries)[/\\]/,
+                (resource: any) => {
+                  const request = resource.request as string
+                  if (request.includes("_resolvers")) {
+                    return
+                  }
 
-                if (
-                  request.endsWith(".js") ||
-                  request.endsWith(".ts") ||
-                  request.endsWith(".jsx") ||
-                  request.endsWith(".tsx")
-                ) {
-                  return
-                }
+                  if (
+                    request.endsWith(".js") ||
+                    request.endsWith(".ts") ||
+                    request.endsWith(".jsx") ||
+                    request.endsWith(".tsx")
+                  ) {
+                    return
+                  }
 
-                resource.request = resource.request + ".client"
-              },
-            ),
-          )
+                  resource.request = resource.request + ".client"
+                },
+              ),
+            )
+          } else {
+            config.module.rules.push({
+              issuer: /(mutations|queries)(?!.*\.client)/,
+              resource: /_resolvers/,
+              use: {loader: "null-loader"},
+            })
+          }
         }
 
         if (typeof normalizedConfig.webpack === "function") {


### PR DESCRIPTION
Closes: #1558 

### What are the changes and their implications?

This reverts the recent change that enables isomorphic code imports from resolver files (for example exporting a zod schema from a mutation and being able to import that in client code).

Enabling that for everyone was pre-mature, sorry about that!! So moving that behind an experimental flag until we get everything working smooth.

To enable, add this to blitz.config.js

```
  experimental: {
    isomorphicResolverImports: true,
  },
```

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
