### PR TITLE
fix: typo? Prepped -> Prepared

### DIFF
--- a/packages/file-pipeline/src/display.ts
+++ b/packages/file-pipeline/src/display.ts
@@ -30,7 +30,7 @@ export function createDisplay() {
       }
 
       case READY: {
-        spinner.succeed(chalk.green.bold("Prepped for launch"))
+        spinner.succeed(chalk.green.bold("Prepared for launch"))
         break
       }
     }


### PR DESCRIPTION
This maybe trivial. I googled and found 'prepared' can also be written as 'prepped', but since the previous prompt says 'preparing', it might be better to use 'prepared' here.
