### PR TITLE
(newapp) Change prisma version to be pinned to a minor version

### DIFF
--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -31,8 +31,8 @@
     ]
   },
   "dependencies": {
-    "@prisma/cli": "2.x",
-    "@prisma/client": "2.x",
+    "@prisma/cli": "~2.12",
+    "@prisma/client": "~2.12",
     "blitz": "canary",
     "react": "0.0.0-experimental-4ead6b530",
     "react-dom": "0.0.0-experimental-4ead6b530",


### PR DESCRIPTION
Related: #1586

### What are the changes and their implications?

Change prisma version to be pinned to a minor version because they make breaking changes in minor versions.

Prisma 2.13 compatibility will taken up separately 


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
