### PR TITLE
Removed `unstable_` prefix from session middleware

### DIFF
--- a/examples/auth/blitz.config.js
+++ b/examples/auth/blitz.config.js
@@ -1,4 +1,4 @@
-const {sessionMiddleware, unstable_simpleRolesIsAuthorized} = require("@blitzjs/server")
+const {sessionMiddleware, simpleRolesIsAuthorized} = require("@blitzjs/server")
 const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true",
 })
@@ -6,7 +6,7 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
 module.exports = withBundleAnalyzer({
   middleware: [
     sessionMiddleware({
-      unstable_isAuthorized: unstable_simpleRolesIsAuthorized,
+      isAuthorized: simpleRolesIsAuthorized,
       sessionExpiryMinutes: 4,
     }),
   ],

--- a/examples/fauna/blitz.config.js
+++ b/examples/fauna/blitz.config.js
@@ -1,4 +1,4 @@
-const { sessionMiddleware, unstable_simpleRolesIsAuthorized } = require("@blitzjs/server")
+const { sessionMiddleware, simpleRolesIsAuthorized } = require("@blitzjs/server")
 const { GraphQLClient, gql } = require("graphql-request")
 
 const graphQLClient = new GraphQLClient("https://graphql.fauna.com/graphql", {
@@ -20,7 +20,7 @@ const normalizeSession = (faunaSession) => {
 module.exports = {
   middleware: [
     sessionMiddleware({
-      unstable_isAuthorized: unstable_simpleRolesIsAuthorized,
+      isAuthorized: simpleRolesIsAuthorized,
       getSession: async (handle) => {
         const { findSessionByHandle: session } = await graphQLClient.request(
           gql`

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -24,7 +24,7 @@ export type SessionConfig = {
   createSession: (session: SessionModel) => Promise<SessionModel>
   updateSession: (handle: string, session: Partial<SessionModel>) => Promise<SessionModel>
   deleteSession: (handle: string) => Promise<SessionModel>
-  unstable_isAuthorized: (userRoles: string[], input?: any) => boolean
+  isAuthorized: (userRoles: string[], input?: any) => boolean
 }
 
 export interface SessionContextBase {

--- a/packages/generator/templates/app/blitz.config.js
+++ b/packages/generator/templates/app/blitz.config.js
@@ -1,9 +1,9 @@
-const { sessionMiddleware, unstable_simpleRolesIsAuthorized } = require("@blitzjs/server")
+const { sessionMiddleware, simpleRolesIsAuthorized } = require("@blitzjs/server")
 
 module.exports = {
   middleware: [
     sessionMiddleware({
-      unstable_isAuthorized: unstable_simpleRolesIsAuthorized,
+      isAuthorized: simpleRolesIsAuthorized,
     }),
   ],
   /* Uncomment this to customize the webpack config

--- a/packages/server/src/supertokens.test.ts
+++ b/packages/server/src/supertokens.test.ts
@@ -15,7 +15,7 @@ import fetch from "isomorphic-unfetch"
 import {apiResolver} from "next/dist/next-server/server/api-utils"
 import listen from "test-listen"
 import {rpcApiHandler} from "./rpc"
-import {sessionMiddleware, unstable_simpleRolesIsAuthorized} from "./supertokens"
+import {sessionMiddleware, simpleRolesIsAuthorized} from "./supertokens"
 
 const isIsoDate = (str: string) => {
   if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(str)) return false
@@ -137,7 +137,7 @@ async function mockServer<TInput, TResult>(
   const handler = rpcApiHandler(
     resolverModule,
     [
-      sessionMiddleware({unstable_isAuthorized: unstable_simpleRolesIsAuthorized}),
+      sessionMiddleware({isAuthorized: simpleRolesIsAuthorized}),
       ...(resolverModule.middleware || []),
     ],
     dbConnectorFn,

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -83,12 +83,12 @@ const defaultConfig: SessionConfig = {
     }
   },
   deleteSession: (handle) => getDb().session.delete({where: {handle}}),
-  unstable_isAuthorized: () => {
-    throw new Error("No unstable_isAuthorized implementation provided")
+  isAuthorized: () => {
+    throw new Error("No isAuthorized implementation provided")
   },
 }
 
-export function unstable_simpleRolesIsAuthorized(userRoles: string[], input?: any) {
+export function simpleRolesIsAuthorized(userRoles: string[], input?: any) {
   // No roles required, so all roles allowed
   if (!input) return true
 
@@ -111,8 +111,8 @@ let config: Required<SessionConfig>
 // --------------------------------
 export const sessionMiddleware = (sessionConfig: Partial<SessionConfig> = {}): Middleware => {
   assert(
-    sessionConfig.unstable_isAuthorized,
-    "You must provide an authorization implementation to sessionMiddleware as unstable_isAuthorized(userRoles, input)",
+    sessionConfig.isAuthorized,
+    "You must provide an authorization implementation to sessionMiddleware as isAuthorized(userRoles, input)",
   )
   config = {
     ...defaultConfig,
@@ -223,7 +223,7 @@ export class SessionContextClass implements SessionContext {
   isAuthorized(input?: any) {
     if (!this.userId) return false
 
-    return config.unstable_isAuthorized(this.roles, input)
+    return config.isAuthorized(this.roles, input)
   }
 
   async create(publicData: PublicData, privateData?: Record<any, any>) {

--- a/recipes/theme-ui/templates/config/blitz.config.js
+++ b/recipes/theme-ui/templates/config/blitz.config.js
@@ -1,4 +1,4 @@
-const {sessionMiddleware, unstable_simpleRolesIsAuthorized} = require("@blitzjs/server")
+const {sessionMiddleware, simpleRolesIsAuthorized} = require("@blitzjs/server")
 
 const withMDX = require("@next/mdx")({
   extension: /\.mdx?$/,
@@ -7,7 +7,7 @@ const withMDX = require("@next/mdx")({
 module.exports = withMDX({
   middleware: [
     sessionMiddleware({
-      unstable_isAuthorized: unstable_simpleRolesIsAuthorized,
+      isAuthorized: simpleRolesIsAuthorized,
     }),
   ],
   /* Uncomment this to customize the webpack config


### PR DESCRIPTION
Closes: ??

### What are the changes and their implications?

I've removed the unstable prefix from the supertokens code in core.

### Checklist

- [ x ] Tests added for changes
- [ x ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes. See https://github.com/blitz-js/blitzjs.com/pull/281

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
