### PR TITLE
Add missing exports for `LinkProps`, `ImageProps`, and `ErrorProps`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,8 +63,7 @@ export {
 
 export {default as dynamic} from "next/dynamic"
 
-export {default as ErrorComponent} from "next/error"
-export {ErrorProps} from "next/error"
+export {default as ErrorComponent, ErrorProps} from "next/error"
 
 export {default as getConfig} from "next/config"
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,8 +44,7 @@ export {
 
 export {default as Head} from "next/head"
 
-export {default as Link} from "next/link"
-export {LinkProps} from "next/link"
+export {default as Link, LinkProps} from "next/link"
 
 export {default as Router} from "next/router"
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,8 +48,7 @@ export {default as Link, LinkProps} from "next/link"
 
 export {default as Router} from "next/router"
 
-export {default as Image} from "next/image"
-export {ImageProps} from "next/image"
+export {default as Image, ImageProps} from "next/image"
 
 export {
   default as Document,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,10 +45,12 @@ export {
 export {default as Head} from "next/head"
 
 export {default as Link} from "next/link"
+export {LinkProps} from "next/link"
 
 export {default as Router} from "next/router"
 
 export {default as Image} from "next/image"
+export {ImageProps} from "next/image"
 
 export {
   default as Document,
@@ -63,6 +65,7 @@ export {
 export {default as dynamic} from "next/dynamic"
 
 export {default as ErrorComponent} from "next/error"
+export {ErrorProps} from "next/error"
 
 export {default as getConfig} from "next/config"
 


### PR DESCRIPTION
### What are the changes and their implications?

In most of my projects I find myself needing to use `LinkProps` from `next/link`, but doing two imports for this feels weird to me.

I've also added `ImageProps` and `ErrorProps`.

```tsx
import { Link, Image } from "blitz"
import { LinkProps, ImageProps } from "next/link"
```

as compared to:
```tsx
import { Link, LinkProps, Image, ImageProps } from "blitz"
```

### Checklist
Not really sure if either are applicable here. Let me know and I'll update the PR accordingly.

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
