### PR TITLE
Fix bug where cancelling `blitz install` still outputs success message

### DIFF
--- a/packages/installer/src/recipe-executor.tsx
+++ b/packages/installer/src/recipe-executor.tsx
@@ -29,13 +29,12 @@ export class RecipeExecutor<Options extends RecipeMeta> {
         <RecipeRenderer cliArgs={cliArgs} steps={this.steps} recipeMeta={this.options} />,
       )
       await waitUntilExit()
-    } catch (e) {
+      log.info(
+        `\n🎉 The recipe for ${this.options.name} completed successfully! Its functionality is now fully configured in your Blitz app.\n`,
+      )
+     } catch (e) {
       log.error(e)
       return
     }
-
-    log.info(
-      `\n🎉 The recipe for ${this.options.name} completed successfully! Its functionality is now fully configured in your Blitz app.\n`,
-    )
   }
 }


### PR DESCRIPTION
Closes: #904 
This pull request resolves the success message error on cancelling the installer.
### What are the changes and their implications?
- added log message just after waitUntil function
- If the install gets complete the success message will run else the error message will be logged

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
