### PR TITLE
Fix: allow numbers and underscore in names for `blitz generate model`

### DIFF
--- a/packages/generator/src/prisma/field.ts
+++ b/packages/generator/src/prisma/field.ts
@@ -96,7 +96,7 @@ export class Field {
           break
       }
     }
-    if (!/^[A-Za-z]*$/.test(fieldName)) {
+    if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(fieldName)) {
       // modelName should be just alpha characters at this point, validate
       throw new Error(
         `[Field.parse]: received unknown special character in field name: ${fieldName}`,

--- a/packages/generator/test/prisma/field.test.ts
+++ b/packages/generator/test/prisma/field.test.ts
@@ -46,6 +46,22 @@ describe("Field model", () => {
     expect(Field.parse("name").toString()).toMatchInlineSnapshot(`"name  String"`)
   })
 
+  it("allow number characters in model name", () => {
+    expect(Field.parse("name2").toString()).toMatchInlineSnapshot(`"name2  String"`)
+  })
+
+  it("allow underscore characters in model name", () => {
+    expect(Field.parse("first_name").toString()).toMatchInlineSnapshot(`"first_name  String"`)
+  })
+
+  it("disallows number as a first character in model name", () => {
+    expect(() => Field.parse("2first").toString()).toThrow()
+  })
+
+  it("disallows underscore as a first character in model name", () => {
+    expect(() => Field.parse("_first").toString()).toThrow()
+  })
+
   it("disallows special characters in model name", () => {
     expect(() => Field.parse("app-user:int")).toThrow()
   })


### PR DESCRIPTION
Closes: #1610

### What are the changes and their implications?
changed the regex validating the field name

### Checklist

- [x] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
