### PR TITLE
Improve error message from `useQuery` for case of incorrect resolver location (patch)

### DIFF
--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -50,7 +50,7 @@ export const validateQueryFn = <TInput, TResult>(
 ) => {
   if (!isEnhancedResolverRpcClient(queryFn) && isNotInUserTestEnvironment()) {
     throw new Error(
-      `Either the file path to your query resolver is incorrect (must be in a "queries" folder that isn't nested inside "pages" or "api") or you are trying to use Blitz's useQuery to fetch from third-party APIs (to do that, import useQuery directly from "react-query")`,
+      `Either the file path to your resolver is incorrect (must be in a "queries" or "mutations" folder that isn't nested inside "pages" or "api") or you are trying to use Blitz's useQuery to fetch from third-party APIs (to do that, import useQuery directly from "react-query")`,
     )
   }
 }

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -50,7 +50,7 @@ export const validateQueryFn = <TInput, TResult>(
 ) => {
   if (!isEnhancedResolverRpcClient(queryFn) && isNotInUserTestEnvironment()) {
     throw new Error(
-      `It looks like you are trying to use Blitz's useQuery to fetch from third-party APIs. To do that, import useQuery directly from "react-query"`,
+      `Either the file path to your query resolver is incorrect (must be in a "queries" folder that isn't nested inside "pages" or "api") or you are trying to use Blitz's useQuery to fetch from third-party APIs (to do that, import useQuery directly from "react-query")`,
     )
   }
 }

--- a/packages/core/test/__snapshots__/use-mutation.test.tsx.snap
+++ b/packages/core/test/__snapshots__/use-mutation.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useMutation useMutation calls the resolver with the argument shouldn't work with regular functions 1`] = `"It looks like you are trying to use Blitz's useQuery to fetch from third-party APIs. To do that, import useQuery directly from \\"react-query\\""`;
+exports[`useMutation useMutation calls the resolver with the argument shouldn't work with regular functions 1`] = `"Either the file path to your resolver is incorrect (must be in a \\"queries\\" or \\"mutations\\" folder that isn't nested inside \\"pages\\" or \\"api\\") or you are trying to use Blitz's useQuery to fetch from third-party APIs (to do that, import useQuery directly from \\"react-query\\")"`;

--- a/packages/core/test/__snapshots__/use-query.test.tsx.snap
+++ b/packages/core/test/__snapshots__/use-query.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useQuery a "query" that converts the string parameter to uppercase shouldn't work with regular functions 1`] = `"It looks like you are trying to use Blitz's useQuery to fetch from third-party APIs. To do that, import useQuery directly from \\"react-query\\""`;
+exports[`useQuery a "query" that converts the string parameter to uppercase shouldn't work with regular functions 1`] = `"Either the file path to your resolver is incorrect (must be in a \\"queries\\" or \\"mutations\\" folder that isn't nested inside \\"pages\\" or \\"api\\") or you are trying to use Blitz's useQuery to fetch from third-party APIs (to do that, import useQuery directly from \\"react-query\\")"`;


### PR DESCRIPTION


### What are the changes and their implications?

Improve error message from `useQuery` for case of incorrect resolver location
