### PR TITLE
Fix a false duplicate error with `.coverage` directory in your project (patch)

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -71,6 +71,7 @@ const defaults = {
     "**/.now/**/*",
     "**/*.pnp.js",
     "coverage/**/*",
+    ".coverage/**/*",
     "dist/**/*",
     "**/node_modules/**/*",
     "cypress/**/*",


### PR DESCRIPTION
Closes: #1625

### What are the changes and their implications?

Fix a false duplicate error with `.coverage` directory in your project
