### PR TITLE
(newapp) Change Final Form `<LabeledTextField/>` to properly parse numbers

### DIFF
--- a/packages/generator/templates/app/_forms/finalform/LabeledTextField.tsx
+++ b/packages/generator/templates/app/_forms/finalform/LabeledTextField.tsx
@@ -16,7 +16,9 @@ export const LabeledTextField = React.forwardRef<HTMLInputElement, LabeledTextFi
     const {
       input,
       meta: {touched, error, submitError, submitting},
-    } = useField(name)
+    } = useField(name, {
+      parse: props.type === "number" ? Number : undefined
+    })
 
     const normalizedError = Array.isArray(error) ? error.join(", ") : error || submitError
 


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1636

### What are the changes and their implications?

As mentioned in the linked issue, when using Final-Form, the `LabeledTextField` doesn't correctly parse value inputs as one would assume considering the `number` type is allowed on the component.

Thanks to @hasparus for coming up with the solution!

__For Blitz maintainers:__
:zap: I couldn't find any tests for this component in the repo so I didn't add any but please let me know if you want one added.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
