### PR TITLE
Remove unnecessary log message about git core.excludesFiles (patch)

### DIFF
--- a/packages/server/src/parse-chokidar-rules-from-gitignore.ts
+++ b/packages/server/src/parse-chokidar-rules-from-gitignore.ts
@@ -19,6 +19,7 @@ function globalGitIgnore() {
     stdio: "pipe",
   })
   if (!(configResult.status === 0)) {
+    // Git config core.excludesFile is unset. Inferring .gitignore file locations.
     return null
   }
 

--- a/packages/server/src/parse-chokidar-rules-from-gitignore.ts
+++ b/packages/server/src/parse-chokidar-rules-from-gitignore.ts
@@ -19,7 +19,6 @@ function globalGitIgnore() {
     stdio: "pipe",
   })
   if (!(configResult.status === 0)) {
-    log.warning("Git config core.excludesFile is unset. Inferring .gitignore file locations.")
     return null
   }
 


### PR DESCRIPTION
### What are the changes and their implications?

I've removed the console message `Git config core.excludesFile is unset. Inferring .gitignore file locations.` when building a blitz app.

### Checklist

- [ ] Tests added for changes - just checked test output and the log has disappeared

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
