### PR TITLE
[RFC] Change `db/index.ts` to be side-effect free and all uses of `db.something` to `db().something`

### DIFF
--- a/examples/auth/app/auth/auth-utils.ts
+++ b/examples/auth/app/auth/auth-utils.ts
@@ -18,7 +18,7 @@ export const verifyPassword = async (hashedPassword: string, password: string) =
 }
 
 export const authenticateUser = async (email: string, password: string) => {
-  const user = await db.user.findFirst({where: {email}})
+  const user = await db().user.findFirst({where: {email}})
 
   if (!user || !user.hashedPassword) throw new AuthenticationError()
 
@@ -28,7 +28,7 @@ export const authenticateUser = async (email: string, password: string) => {
     case SecurePassword.VALID_NEEDS_REHASH:
       // Upgrade hashed password with a more secure hash
       const improvedHash = await hashPassword(password)
-      await db.user.update({where: {id: user.id}, data: {hashedPassword: improvedHash}})
+      await db().user.update({where: {id: user.id}, data: {hashedPassword: improvedHash}})
       break
     default:
       throw new AuthenticationError()

--- a/examples/auth/app/auth/mutations/signup.ts
+++ b/examples/auth/app/auth/mutations/signup.ts
@@ -14,7 +14,7 @@ export default async function signup(input: SignupInputType, {session}: Ctx) {
   const {email, password} = SignupInput.parse(input)
 
   const hashedPassword = await hashPassword(password)
-  const user = await db.user.create({
+  const user = await db().user.create({
     data: {email, hashedPassword, role: "user"},
     select: {id: true, name: true, email: true, role: true},
   })

--- a/examples/auth/app/users/queries/getCurrentUser.ts
+++ b/examples/auth/app/users/queries/getCurrentUser.ts
@@ -4,7 +4,7 @@ import db from "db"
 export default async function getCurrentUser(_ = null, ctx: Ctx) {
   if (!ctx.session.userId) return null
 
-  const user = await db.user.findFirst({
+  const user = await db().user.findFirst({
     where: {id: ctx.session.userId},
     select: {id: true, name: true, email: true, role: true},
   })

--- a/examples/auth/app/users/queries/getUser.ts
+++ b/examples/auth/app/users/queries/getUser.ts
@@ -8,7 +8,7 @@ type GetUserInput = {
 export default async function getUser({where}: GetUserInput, ctx: Ctx) {
   ctx.session.authorize()
 
-  const user = await db.user.findFirst({where})
+  const user = await db().user.findFirst({where})
 
   if (!user) throw new NotFoundError(`User with id ${where.id} does not exist`)
 

--- a/examples/auth/app/users/queries/getUsers.ts
+++ b/examples/auth/app/users/queries/getUsers.ts
@@ -6,14 +6,14 @@ type GetUsersInput = Pick<FindManyUserArgs, "where" | "orderBy" | "skip" | "take
 export default async function getUsers({where, orderBy, skip = 0, take}: GetUsersInput, ctx: Ctx) {
   ctx.session.authorize()
 
-  const users = await db.user.findMany({
+  const users = await db().user.findMany({
     where,
     orderBy,
     take,
     skip,
   })
 
-  const count = await db.user.count()
+  const count = await db().user.count()
   const hasMore = typeof take === "number" ? skip + take < count : false
   const nextPage = hasMore ? {take, skip: skip + take!} : null
 

--- a/examples/auth/db/index.ts
+++ b/examples/auth/db/index.ts
@@ -1,15 +1,7 @@
 import {PrismaClient} from "@prisma/client"
 export * from "@prisma/client"
 
-let prisma: PrismaClient
-
-if (process.env.NODE_ENV === "production") {
-  prisma = new PrismaClient()
-} else {
-  // Ensure the prisma instance is re-used during hot-reloading
-  // Otherwise, a new client will be created on every reload
-  globalThis["prisma"] = globalThis["prisma"] || new PrismaClient()
-  prisma = globalThis["prisma"]
+export default function db(): PrismaClient {
+  globalThis.prisma = globalThis.prisma || new PrismaClient()
+  return globalThis.prisma
 }
-
-export default prisma


### PR DESCRIPTION
### What are the changes and their implications?

**This is a proposal for a semi-breaking change to the `db/index.ts` file.**

Until now, the `db/index.ts` file has instantiated PrismaClient at the top level as a side effect. We started with this because it's quite elegant to just call `db.user.findMany()` instead of `db().user.findMany()`.

The primary motivation to change this to be side-effect free is so that we can import Prisma enums from `db`. Once we finish [Prisma 2.13](https://github.com/blitz-js/blitz/pull/1661) support, you will be able to do `import {RoleEnum} from '@prisma/client'` but you can't do `import {RoleEnum} from 'db'` because it's not side effect free.

The other motivation is that last year I learned that side effects in your JS files are very bad. You almost always run into something at some point that breaks because of it.

**What the change would entail:**

- New apps would have `db/index.ts` as side effect free
- `blitz generate` would generate code that has `db()`
- Existing apps would continue to work because in Blitz we can support both `db` being PrismaClient and it being a function that returns PrismaClient.
- We could create a little codemod that would update usage of `db` to `db()` throughout your app

What do you all think?

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

