### PR TITLE
Add config option for cookie `domain` to sessionMiddleware

### DIFF
--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -19,6 +19,7 @@ export type SessionConfig = {
   sessionExpiryMinutes?: number
   method?: "essential" | "advanced"
   sameSite?: "none" | "lax" | "strict"
+  domain?: string
   getSession: (handle: string) => Promise<SessionModel | null>
   getSessions: (userId: PublicData["userId"]) => Promise<SessionModel[]>
   createSession: (session: SessionModel) => Promise<SessionModel>

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -408,6 +408,7 @@ export const setSessionCookie = (
         process.env.NODE_ENV === "production" &&
         !isLocalhost(req),
       sameSite: config.sameSite,
+      domain: config.domain,
       expires: expiresAt,
     }),
   )
@@ -429,6 +430,7 @@ export const setAnonymousSessionCookie = (
         process.env.NODE_ENV === "production" &&
         !isLocalhost(req),
       sameSite: config.sameSite,
+      domain: config.domain,
       expires: expiresAt,
     }),
   )
@@ -450,6 +452,7 @@ export const setCSRFCookie = (
         process.env.NODE_ENV === "production" &&
         !isLocalhost(req),
       sameSite: config.sameSite,
+      domain: config.domain,
       expires: expiresAt,
     }),
   )
@@ -471,6 +474,7 @@ export const setPublicDataCookie = (
         process.env.NODE_ENV === "production" &&
         !isLocalhost(req),
       sameSite: config.sameSite,
+      domain: config.domain,
       expires: expiresAt,
     }),
   )

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -44,7 +44,7 @@ function assert(condition: any, message: string): asserts condition {
 }
 
 // ----------------------------------------------------------------------------------------
-// IMPORTANT: blitz.config.js must be loaded for session managment config to be initialized
+// IMPORTANT: blitz.config.js must be loaded for session management config to be initialized
 // This line ensures that blitz.config.js is loaded
 // ----------------------------------------------------------------------------------------
 process.nextTick(getConfig)


### PR DESCRIPTION
Closes: #1664 

### What are the changes and their implications?
Changed the `SessionConfig` to allow users to add a [domain](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) attribute to their config. From MDN "The Domain attribute specifies which hosts are allowed to receive the cookie."

### Checklist

- [x] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
