### PR TITLE
Add `blitz prisma` CLI command for Prisma 2.13+ support

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -1,35 +1,8 @@
 import {Command, flags} from "@oclif/command"
 import {log} from "@blitzjs/display"
+import {runPrisma, runPrismaExitOnError} from "./prisma"
 
-const getPrismaBin = () => require("@blitzjs/server").resolveBinAsync("@prisma/cli", "prisma")
-let prismaBin: string
 let schemaArg: string
-
-const runPrisma = async (args: string[], silent = false) => {
-  if (!prismaBin) {
-    try {
-      prismaBin = await getPrismaBin()
-    } catch (err) {
-      throw err
-    }
-  }
-
-  const cp = require("cross-spawn").spawn(prismaBin, args, {
-    stdio: silent ? "ignore" : "inherit",
-    env: process.env,
-  })
-  const code = await require("p-event")(cp, "exit", {rejectionEvents: []})
-
-  return code === 0
-}
-
-const runPrismaExitOnError = async (...args: Parameters<typeof runPrisma>) => {
-  const success = await runPrisma(...args)
-
-  if (!success) {
-    process.exit(1)
-  }
-}
 
 // Prisma client generation will fail if no model is defined in the schema.
 // So the silent option is here to ignore that failure

--- a/packages/cli/src/commands/prisma.ts
+++ b/packages/cli/src/commands/prisma.ts
@@ -1,0 +1,47 @@
+import {Command, flags} from "@oclif/command"
+
+const getPrismaBin = () => require("@blitzjs/server").resolveBinAsync("@prisma/cli", "prisma")
+let prismaBin: string
+
+export const runPrisma = async (args: string[], silent = false) => {
+  if (!prismaBin) {
+    try {
+      prismaBin = await getPrismaBin()
+    } catch (err) {
+      throw err
+    }
+  }
+
+  const cp = require("cross-spawn").spawn(prismaBin, args, {
+    stdio: silent ? "ignore" : "inherit",
+    env: process.env,
+  })
+  const code = await require("p-event")(cp, "exit", {rejectionEvents: []})
+
+  return code === 0
+}
+
+export const runPrismaExitOnError = async (...args: Parameters<typeof runPrisma>) => {
+  const success = await runPrisma(...args)
+
+  if (!success) {
+    process.exit(1)
+  }
+}
+
+export class PrismaCommand extends Command {
+  static description = "Loads env variables then proxies all args to Prisma CLi"
+  static aliases = ["p"]
+
+  static flags = {
+    help: flags.help({char: "h"}),
+  }
+
+  static strict = false
+
+  async run() {
+    const {argv} = this.parse(PrismaCommand)
+
+    await runPrismaExitOnError(argv)
+  }
+}

--- a/packages/cli/src/commands/prisma.ts
+++ b/packages/cli/src/commands/prisma.ts
@@ -30,7 +30,7 @@ export const runPrismaExitOnError = async (...args: Parameters<typeof runPrisma>
 }
 
 export class PrismaCommand extends Command {
-  static description = "Loads env variables then proxies all args to Prisma CLi"
+  static description = "Loads env variables then proxies all args to Prisma CLI"
   static aliases = ["p"]
 
   static flags = {


### PR DESCRIPTION
### What are the changes and their implications?

As discussed in https://github.com/blitz-js/blitz/discussions/1611, for Prisma 2.13+ support we are [removing `blitz db migrate`](https://github.com/blitz-js/blitz/pull/1661) in favor of using the prisma CLI directly.

However they currently don't support all the .env files that we do, so this adds a `blitz prisma` command that first loads the env vars and then proxies all commands straight to the Prisma CLI.


```
// Example
blitz prisma migrate dev
or
blitz p migrate dev
```

### Checklist

- [ ] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes: https://github.com/blitz-js/blitzjs.com/pull/308

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
