### PR TITLE
Update jest config  for a deprecated option

### DIFF
--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
 
   globals: {
     "ts-jest": {
-      tsConfig: "test/tsconfig.json",
+      tsconfig: "test/tsconfig.json",
       isolatedModules: true,
     },
   },

--- a/packages/generator/jest.config.js
+++ b/packages/generator/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
 
   globals: {
     "ts-jest": {
-      tsConfig: "test/tsconfig.json",
+      tsconfig: "test/tsconfig.json",
     },
   },
 }

--- a/packages/installer/jest.config.js
+++ b/packages/installer/jest.config.js
@@ -18,7 +18,7 @@ module.exports = {
 
   globals: {
     "ts-jest": {
-      tsConfig: "test/tsconfig.json",
+      tsconfig: "test/tsconfig.json",
       isolatedModules: true,
     },
   },

--- a/packages/repl/jest.config.js
+++ b/packages/repl/jest.config.js
@@ -18,7 +18,7 @@ module.exports = {
 
   globals: {
     "ts-jest": {
-      tsConfig: "test/tsconfig.json",
+      tsconfig: "test/tsconfig.json",
     },
   },
 }


### PR DESCRIPTION
Closes: #1683

### What are the changes and their implications?

Update ts-jest option name from `tsConfig` to `tsconfig` in jest.config.js.

target packages

- cli
- generator
- installer
- repl

#### WHY

Refs: https://github.com/kulshekhar/ts-jest/blob/master/CHANGELOG.md#2642-2020-10-23
`tsConfig` gets deprecated at ts-jest@26.4.2

#### Reproduction deprecated warnings

1. go to cli package
1. run `yarn test:watch --watchAll`

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the “Allow edits from maintainers” box below this window -->