### PR TITLE
Update .eslintrc.js on examples/custom-server to add @typescript-eslint parser/plugin config

### DIFF
--- a/examples/custom-server/.eslintrc.js
+++ b/examples/custom-server/.eslintrc.js
@@ -1,9 +1,10 @@
 module.exports = {
+  parser: "@typescript-eslint/parser",
   env: {
     es2020: true,
   },
   extends: ["react-app", "plugin:jsx-a11y/recommended"],
-  plugins: ["jsx-a11y"],
+  plugins: ["@typescript-eslint", "jsx-a11y"],
   rules: {
     "import/no-anonymous-default-export": "error",
     "import/no-webpack-loader-syntax": "off",

--- a/packages/installer/test/executors/executor.test.tsx
+++ b/packages/installer/test/executors/executor.test.tsx
@@ -1,5 +1,5 @@
-import React from "react"
 import {render} from "ink-testing-library"
+import React from "react"
 import {Frontmatter} from "../../src/executors/executor"
 describe("Executor", () => {
   const executorConfig = {

--- a/recipes/reflexjs/templates/theme/theme/index.ts
+++ b/recipes/reflexjs/templates/theme/theme/index.ts
@@ -1,4 +1,4 @@
-export default {
+const theme = {
   breakpoints: ["640px", "768px", "1024px", "1280px"],
   colors: {
     text: "#111",
@@ -492,3 +492,5 @@ export default {
     chart: `<svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>`,
   },
 }
+
+export default theme


### PR DESCRIPTION
Closes: #1696

### What are the changes and their implications?

Solve ESLint warnings (not errors)

- import orders are wrong. `packages/installer/test/executors/executor.test.tsx`
- needs to name default export object. `recipes/reflexjs/templates/theme/theme/index.ts`
- (Everything else) needs to configure .eslintrc.js about `@typescript-eslint` config 

<img width="421" alt="スクリーンショット 2021-01-12 19 25 11" src="https://user-images.githubusercontent.com/3866581/104302325-fb0f0980-550b-11eb-9be8-2507e6ea00d3.png">


### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
