### PR TITLE
Fix extra `ms` in API log message

### DIFF
--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -47,7 +47,7 @@ const rpcMiddleware = <TInput, TResult>(
 
         const duration = Date.now() - startTime
         log.debug(chalk.dim("Result:"), result ? result : JSON.stringify(result))
-        log.info(chalk.dim(`Finished in ${prettyMs(duration)}ms`))
+        log.info(chalk.dim(`Finished in ${prettyMs(duration)}`))
         displayLog.newline()
 
         res.blitzResult = result


### PR DESCRIPTION
Closes: ??

### What are the changes and their implications?
Currently rpc log message incorrectly appends `ms` after the result of `prettyMs()`. This patch fixes that.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
