### PR TITLE
Fix `--help` flag for `blitz prisma` command not being sent to prisma

### DIFF
--- a/packages/cli/src/commands/prisma.ts
+++ b/packages/cli/src/commands/prisma.ts
@@ -1,4 +1,4 @@
-import {Command, flags} from "@oclif/command"
+import {Command} from "@oclif/command"
 
 const getPrismaBin = () => require("@blitzjs/server").resolveBinAsync("@prisma/cli", "prisma")
 let prismaBin: string
@@ -32,10 +32,6 @@ export const runPrismaExitOnError = async (...args: Parameters<typeof runPrisma>
 export class PrismaCommand extends Command {
   static description = "Loads env variables then proxies all args to Prisma CLI"
   static aliases = ["p"]
-
-  static flags = {
-    help: flags.help({char: "h"}),
-  }
 
   static strict = false
 


### PR DESCRIPTION


### What are the changes and their implications?

Fix `--help` flag for `blitz prisma` command not being sent to prisma