### PR TITLE
Fix: `blitz db seed` should not run prisma migrations

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -1,6 +1,5 @@
 import {Command, flags} from "@oclif/command"
 import {log} from "@blitzjs/display"
-import {runPrismaExitOnError} from "./prisma"
 
 export function getDbName(connectionString: string): string {
   const dbUrlParts: string[] = connectionString!.split("/")

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -30,9 +30,6 @@ async function runSeed() {
   }
   spinner.succeed()
 
-  log.info("Running database migrations...")
-  await runPrismaExitOnError(["migrate", "dev", "--preview-feature"])
-
   try {
     console.log("\n" + log.withCaret("Seeding..."))
     seeds && (await seeds())


### PR DESCRIPTION
### What are the changes and their implications?

This was causing problems with new prisma version

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
