### PR TITLE
Add `makeServerOnlyPrisma()` utility, allow `db` in client bundle, and update new app template

### DIFF
--- a/examples/auth/db/index.ts
+++ b/examples/auth/db/index.ts
@@ -1,15 +1,7 @@
+import {makeServerOnlyPrisma} from "blitz"
 import {PrismaClient} from "@prisma/client"
+
+const ServerOnlyPrisma = makeServerOnlyPrisma(PrismaClient)
+
 export * from "@prisma/client"
-
-let prisma: PrismaClient
-
-if (process.env.NODE_ENV === "production") {
-  prisma = new PrismaClient()
-} else {
-  // Ensure the prisma instance is re-used during hot-reloading
-  // Otherwise, a new client will be created on every reload
-  globalThis["prisma"] = globalThis["prisma"] || new PrismaClient()
-  prisma = globalThis["prisma"]
-}
-
-export default prisma
+export default new ServerOnlyPrisma()

--- a/examples/custom-server/db/index.ts
+++ b/examples/custom-server/db/index.ts
@@ -1,15 +1,7 @@
-import { PrismaClient } from "@prisma/client"
+import {makeServerOnlyPrisma} from "blitz"
+import {PrismaClient} from "@prisma/client"
+
+const ServerOnlyPrisma = makeServerOnlyPrisma(PrismaClient)
+
 export * from "@prisma/client"
-
-let prisma: PrismaClient
-
-if (process.env.NODE_ENV === "production") {
-  prisma = new PrismaClient()
-} else {
-  // Ensure the prisma instance is re-used during hot-reloading
-  // Otherwise, a new client will be created on every reload
-  globalThis["prisma"] = globalThis["prisma"] || new PrismaClient()
-  prisma = globalThis["prisma"]
-}
-
-export default prisma
+export default new ServerOnlyPrisma()

--- a/examples/store/db/index.ts
+++ b/examples/store/db/index.ts
@@ -1,15 +1,7 @@
+import {makeServerOnlyPrisma} from "blitz"
 import {PrismaClient} from "@prisma/client"
+
+const ServerOnlyPrisma = makeServerOnlyPrisma(PrismaClient)
+
 export * from "@prisma/client"
-
-let prisma: PrismaClient
-
-if (process.env.NODE_ENV === "production") {
-  prisma = new PrismaClient()
-} else {
-  // Ensure the prisma instance is re-used during hot-reloading
-  // Otherwise, a new client will be created on every reload
-  globalThis["prisma"] = globalThis["prisma"] || new PrismaClient()
-  prisma = globalThis["prisma"]
-}
-
-export default prisma
+export default new ServerOnlyPrisma()

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,5 +52,6 @@
     "secure-password": "4.0.0",
     "superjson": "1.4.1"
   },
+  "devDependencies": {},
   "gitHead": "d3b9fce0bdd251c2b1890793b0aa1cd77c1c0922"
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -81,3 +81,5 @@ export type BlitzPage<P = {}, IP = P> = NextPage<P, IP> & {
 }
 export {isLocalhost} from "./utils/index"
 export {prettyMs} from "./utils/pretty-ms"
+
+export {makeServerOnlyPrisma} from "./prisma-utils"

--- a/packages/core/src/prisma-utils.ts
+++ b/packages/core/src/prisma-utils.ts
@@ -1,0 +1,10 @@
+export const makeServerOnlyPrisma = <T>(PrismaClient: T): T => {
+  return new Proxy(PrismaClient as any, {
+    construct(target, args) {
+      if (typeof window !== "undefined") return {}
+      ;(globalThis as any)._blitz_prismaClient =
+        (globalThis as any)._blitz_prismaClient || new target(...args)
+      return (globalThis as any)._blitz_prismaClient
+    },
+  })
+}

--- a/packages/generator/templates/app/db/index.ts
+++ b/packages/generator/templates/app/db/index.ts
@@ -1,15 +1,7 @@
+import { makeServerOnlyPrisma } from "blitz"
 import { PrismaClient } from "@prisma/client"
+
+const ServerOnlyPrisma = makeServerOnlyPrisma(PrismaClient)
+
 export * from "@prisma/client"
-
-let prisma: PrismaClient
-
-if (process.env.NODE_ENV === "production") {
-    prisma = new PrismaClient()
-} else {
-    // Ensure the prisma instance is re-used during hot-reloading
-    // Otherwise, a new client will be created on every reload
-    globalThis["prisma"] = globalThis["prisma"] || new PrismaClient()
-    prisma = globalThis["prisma"]
-}
-
-export default prisma
+export default new ServerOnlyPrisma()

--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -25,7 +25,6 @@ export function withBlitz(nextConfig: any) {
           config.module = config.module || {}
           config.module.rules = config.module.rules || []
           const excluded = [
-            path.resolve("./db"),
             /node_modules[\\/]@blitzjs[\\/]display/,
             /node_modules[\\/]@blitzjs[\\/]config/,
             /node_modules[\\/]passport/,


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/937

### What are the changes and their implications?

- This enables importing prisma enums from `'db'`. 
- This simplifies the Prisma client instantiation code in `db/index.ts`
- This allows `db` to be in the client bundle (for enums to come through from Prisma)
- This **requires** using the new `makeServerOnlyPrisma()` utility unless you manually adjust your webpack config to block `db/index.ts` in the client bundle.

### Checklist

- [ ] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes: https://github.com/blitz-js/blitzjs.com/pull/326

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
