### PR TITLE
Add `generateToken()` and `hash256()` utilities (#1721) (minor)

### DIFF
--- a/packages/core/src/auth-utils.ts
+++ b/packages/core/src/auth-utils.ts
@@ -1,5 +1,12 @@
+import * as crypto from "crypto"
+import {nanoid} from "nanoid"
 import SecurePasswordLib from "secure-password"
 import {AuthenticationError} from "./errors"
+
+export const hash256 = (input: string = "") =>
+  crypto.createHash("sha256").update(input).digest("hex")
+
+export const generateToken = (numberOfCharacters: number = 32) => nanoid(numberOfCharacters)
 
 const SP = () => new SecurePasswordLib()
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,7 +30,7 @@ export {
   AuthenticatedSessionContext,
 } from "./supertokens"
 
-export {SecurePassword} from "./auth-utils"
+export {SecurePassword, hash256, generateToken} from "./auth-utils"
 
 // --------------------
 // Exports from Next.js

--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -26,7 +26,6 @@ export function withBlitz(nextConfig: any) {
           config.module.rules = config.module.rules || []
           const excluded = [
             path.resolve("./db"),
-            path.resolve("crypto"),
             /node_modules[\\/]@blitzjs[\\/]display/,
             /node_modules[\\/]@blitzjs[\\/]config/,
             /node_modules[\\/]passport/,
@@ -34,6 +33,8 @@ export function withBlitz(nextConfig: any) {
             /node_modules[\\/]secure-password/,
             /blitz[\\/]packages[\\/]config/,
             /blitz[\\/]packages[\\/]display/,
+            /node-libs-browser/,
+            /crypto-browserify/,
           ]
           excluded.forEach((excluded) => {
             config.module.rules.push({test: excluded, use: {loader: "null-loader"}})

--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -26,6 +26,7 @@ export function withBlitz(nextConfig: any) {
           config.module.rules = config.module.rules || []
           const excluded = [
             path.resolve("./db"),
+            path.resolve("crypto"),
             /node_modules[\\/]@blitzjs[\\/]display/,
             /node_modules[\\/]@blitzjs[\\/]config/,
             /node_modules[\\/]passport/,


### PR DESCRIPTION
### What are the changes and their implications?

- Add `generateToken()`, a utility to generate crypto tokens for things like password resets
- Add `hash256()` a utility to hash tokens when storing them in your database with sha256

These will be used for forgot password in https://github.com/blitz-js/blitz/pull/1127

### Checklist

- [ ] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes: https://github.com/blitz-js/blitzjs.com/pull/327

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
