### PR TITLE
Remove console.log from reflexjs recipe

### DIFF
--- a/recipes/reflexjs/index.ts
+++ b/recipes/reflexjs/index.ts
@@ -145,7 +145,6 @@ export default RecipeBuilder()
     singleFileSearch: paths.babelConfig(),
 
     transform(program: Collection<j.Program>) {
-      console.log("here")
       return addBabelPreset(program, "reflexjs/babel")
     },
   })


### PR DESCRIPTION
Closes: n/a

### What are the changes and their implications?

Removing console.log from the reflexjs recipe which was round after review of all recipes.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
