### PR TITLE
Fix `makeServerOnlyPrisma()` not working in Jest tests (patch)

### DIFF
--- a/packages/core/src/prisma-utils.ts
+++ b/packages/core/src/prisma-utils.ts
@@ -1,7 +1,11 @@
 export const makeServerOnlyPrisma = <T>(PrismaClient: T): T => {
   return new Proxy(PrismaClient as any, {
     construct(target, args) {
-      if (typeof window !== "undefined") return {}
+      if (typeof window !== "undefined" && process.env.JEST_WORKER_ID === undefined) {
+        // Return empty object if in the browser
+        // Skip in Jest tests because window is defined in Jest tests
+        return {}
+      }
       ;(globalThis as any)._blitz_prismaClient =
         (globalThis as any)._blitz_prismaClient || new target(...args)
       return (globalThis as any)._blitz_prismaClient


### PR DESCRIPTION


### What are the changes and their implications?

Fix `makeServerOnlyPrisma()` not working in Jest tests
