### PR TITLE
Automatically disable `useQuery` suspense when not using concurrent mode

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -8,6 +8,7 @@ export interface BlitzConfig extends Record<string, unknown> {
   target?: string
   experimental?: {
     isomorphicResolverImports?: boolean
+    reactMode?: string
   }
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,10 +41,12 @@
   },
   "dependencies": {
     "@blitzjs/display": "0.29.2",
+    "@types/htmlescape": "^1.1.1",
     "@types/secure-password": "3.1.0",
     "b64-lite": "^1.4.0",
     "bad-behavior": "^1.0.1",
     "cookie-session": "^1.4.0",
+    "htmlescape": "^1.1.1",
     "lodash": "^4.17.20",
     "lodash-es": "^4.17.20",
     "passport": "0.4.1",

--- a/packages/core/src/blitz-data.tsx
+++ b/packages/core/src/blitz-data.tsx
@@ -1,16 +1,28 @@
 import {getConfig} from "@blitzjs/config"
 import htmlescape from "htmlescape"
 import React from "react"
+import {isClient} from "./utils"
 
-// Automatically deserialize __BLITZ_DATA__ in a browser environment
-if (typeof window !== "undefined") {
-  if (document.getElementById("__BLITZ_DATA__")) {
-    deserializeAndSetBlitzDataOnWindow()
+export function _getBlitzRuntimeData() {
+  return {suspenseEnabled: getConfig().experimental?.reactMode !== "legacy"}
+}
+
+export function getBlitzRuntimeData() {
+  if (isClient) {
+    return window.__BLITZ_DATA__
+  } else {
+    if (!global.__BLITZ_DATA__) {
+      global.__BLITZ_DATA__ = _getBlitzRuntimeData()
+    }
+    return global.__BLITZ_DATA__
   }
 }
 
-export function getBlitzData() {
-  return {config: getConfig()}
+// Automatically deserialize __BLITZ_DATA__ in a browser environment
+if (isClient) {
+  if (document.getElementById("__BLITZ_DATA__")) {
+    deserializeAndSetBlitzDataOnWindow()
+  }
 }
 
 export function deserializeAndSetBlitzDataOnWindow() {
@@ -20,7 +32,7 @@ export function deserializeAndSetBlitzDataOnWindow() {
     )
     window.__BLITZ_DATA__ = data
   } catch (e) {
-    console.error(e)
+    console.error("Error deserializing __BLITZ__DATA__", e)
   }
 }
 
@@ -30,7 +42,7 @@ export function BlitzData() {
       id="__BLITZ_DATA__"
       type="application/json"
       dangerouslySetInnerHTML={{
-        __html: htmlescape(getBlitzData()),
+        __html: htmlescape(_getBlitzRuntimeData()),
       }}
     />
   )

--- a/packages/core/src/blitz-data.tsx
+++ b/packages/core/src/blitz-data.tsx
@@ -1,0 +1,37 @@
+import {getConfig} from "@blitzjs/config"
+import htmlescape from "htmlescape"
+import React from "react"
+
+// Automatically deserialize __BLITZ_DATA__ in a browser environment
+if (typeof window !== "undefined") {
+  if (document.getElementById("__BLITZ_DATA__")) {
+    deserializeAndSetBlitzDataOnWindow()
+  }
+}
+
+export function getBlitzData() {
+  return {config: getConfig()}
+}
+
+export function deserializeAndSetBlitzDataOnWindow() {
+  try {
+    const data: typeof window["__BLITZ_DATA__"] = JSON.parse(
+      document.getElementById("__BLITZ_DATA__")!.textContent!,
+    )
+    window.__BLITZ_DATA__ = data
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+export function BlitzData() {
+  return (
+    <script
+      id="__BLITZ_DATA__"
+      type="application/json"
+      dangerouslySetInnerHTML={{
+        __html: htmlescape(getBlitzData()),
+      }}
+    />
+  )
+}

--- a/packages/core/src/blitz-script.tsx
+++ b/packages/core/src/blitz-script.tsx
@@ -1,0 +1,12 @@
+import {NextScript} from "next/document"
+import React from "react"
+import {BlitzData} from "./blitz-data"
+
+export function BlitzScript() {
+  return (
+    <>
+      <BlitzData />
+      <NextScript />
+    </>
+  )
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,7 +1,0 @@
-export function getBlitzConfig() {
-  if (typeof window !== "undefined") {
-    return window.__BLITZ_DATA__?.config
-  } else {
-    return undefined
-  }
-}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,0 +1,7 @@
+export function getBlitzConfig() {
+  if (typeof window !== "undefined") {
+    return window.__BLITZ_DATA__?.config
+  } else {
+    return undefined
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ import {AppProps as NextAppProps} from "next/app"
 export * from "./types"
 export * from "./errors"
 export * from "./constants"
+export {BlitzScript} from "./blitz-script"
 export {useQuery, usePaginatedQuery, useInfiniteQuery} from "./use-query-hooks"
 export {getQueryKey, invalidateQuery, setQueryData} from "./utils/react-query-utils"
 export {useParam, useParams} from "./use-params"
@@ -58,7 +59,6 @@ export {
   Html,
   Head as DocumentHead,
   Main,
-  NextScript as BlitzScript,
   DocumentContext,
   DocumentInitialProps,
 } from "next/document"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,6 @@ export {passportAuth} from "./passport-adapter"
 export {getIsomorphicEnhancedResolver} from "./rpc"
 export {useMutation} from "./use-mutation"
 export {invoke, invokeWithMiddleware} from "./invoke"
-export {getBlitzConfig} from "./config"
 
 export {
   getAllMiddlewareForModule,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export {passportAuth} from "./passport-adapter"
 export {getIsomorphicEnhancedResolver} from "./rpc"
 export {useMutation} from "./use-mutation"
 export {invoke, invokeWithMiddleware} from "./invoke"
+export {getBlitzConfig} from "./config"
 
 export {
   getAllMiddlewareForModule,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,4 @@
+import {BlitzConfig} from "@blitzjs/config"
 import {IncomingMessage, ServerResponse} from "http"
 import {NextRouter} from "next/router"
 import {AuthenticateOptions, Strategy} from "passport"
@@ -156,6 +157,7 @@ type RequestIdleCallbackDeadline = {
 
 declare global {
   interface Window {
+    __BLITZ_DATA__?: {config?: BlitzConfig}
     requestIdleCallback: (
       callback: (deadline: RequestIdleCallbackDeadline) => void,
       opts?: RequestIdleCallbackOptions,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,3 @@
-import {BlitzConfig} from "@blitzjs/config"
 import {IncomingMessage, ServerResponse} from "http"
 import {NextRouter} from "next/router"
 import {AuthenticateOptions, Strategy} from "passport"
@@ -155,9 +154,18 @@ type RequestIdleCallbackDeadline = {
   timeRemaining: () => number
 }
 
+export type BlitzRuntimeData = {
+  suspenseEnabled: boolean
+}
+
 declare global {
+  namespace NodeJS {
+    interface Global {
+      __BLITZ_DATA__: BlitzRuntimeData
+    }
+  }
   interface Window {
-    __BLITZ_DATA__?: {config?: BlitzConfig}
+    __BLITZ_DATA__: BlitzRuntimeData
     requestIdleCallback: (
       callback: (deadline: RequestIdleCallbackDeadline) => void,
       opts?: RequestIdleCallbackOptions,

--- a/packages/core/src/use-query-hooks.ts
+++ b/packages/core/src/use-query-hooks.ts
@@ -12,8 +12,8 @@ import {useSession} from "./supertokens"
 import {FirstParam, PromiseReturnType, QueryFn} from "./types"
 import {useRouter} from "./use-router"
 import {
-  defaultQueryConfig,
   emptyQueryFn,
+  getDefaultQueryConfig,
   getQueryCacheFunctions,
   getQueryKey,
   QueryCacheFunctions,
@@ -49,7 +49,7 @@ export function useQuery<T extends QueryFn, TResult = PromiseReturnType<T>>(
           enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true})
       : (emptyQueryFn as any),
     config: {
-      ...defaultQueryConfig,
+      ...getDefaultQueryConfig(),
       ...options,
     },
   })
@@ -90,7 +90,7 @@ export function usePaginatedQuery<T extends QueryFn, TResult = PromiseReturnType
           enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true})
       : (emptyQueryFn as any),
     config: {
-      ...defaultQueryConfig,
+      ...getDefaultQueryConfig(),
       ...options,
     },
   })
@@ -148,7 +148,7 @@ export function useInfiniteQuery<
           enhancedResolverRpcClient(params(resultOfGetFetchMore), {fromQueryHook: true})
       : (emptyQueryFn as any),
     config: {
-      ...defaultQueryConfig,
+      ...getDefaultQueryConfig(),
       ...options,
     },
   })

--- a/packages/core/src/use-query-hooks.ts
+++ b/packages/core/src/use-query-hooks.ts
@@ -13,11 +13,11 @@ import {FirstParam, PromiseReturnType, QueryFn} from "./types"
 import {useRouter} from "./use-router"
 import {
   emptyQueryFn,
-  getDefaultQueryConfig,
   getQueryCacheFunctions,
   getQueryKey,
   QueryCacheFunctions,
   sanitize,
+  useDefaultQueryConfig,
 } from "./utils/react-query-utils"
 
 // -------------------------
@@ -49,7 +49,7 @@ export function useQuery<T extends QueryFn, TResult = PromiseReturnType<T>>(
           enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true})
       : (emptyQueryFn as any),
     config: {
-      ...getDefaultQueryConfig(),
+      ...useDefaultQueryConfig(),
       ...options,
     },
   })
@@ -90,7 +90,7 @@ export function usePaginatedQuery<T extends QueryFn, TResult = PromiseReturnType
           enhancedResolverRpcClient(params, {fromQueryHook: true, alreadySerialized: true})
       : (emptyQueryFn as any),
     config: {
-      ...getDefaultQueryConfig(),
+      ...useDefaultQueryConfig(),
       ...options,
     },
   })
@@ -148,7 +148,7 @@ export function useInfiniteQuery<
           enhancedResolverRpcClient(params(resultOfGetFetchMore), {fromQueryHook: true})
       : (emptyQueryFn as any),
     config: {
-      ...getDefaultQueryConfig(),
+      ...useDefaultQueryConfig(),
       ...options,
     },
   })

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -1,6 +1,6 @@
 import {queryCache, QueryKey} from "react-query"
 import {serialize} from "superjson"
-import {getBlitzConfig} from "../config"
+import {getBlitzRuntimeData} from "../blitz-data"
 import {EnhancedResolverRpcClient, QueryFn, Resolver} from "../types"
 import {isClient, isServer} from "."
 import {requestIdleCallback} from "./request-idle-callback"
@@ -147,9 +147,10 @@ export const retryFunction = (failureCount: number, error: any) => {
   return false
 }
 
-let suspense = getBlitzConfig()?.experimental?.reactMode !== "legacy"
-
-export const defaultQueryConfig = {
-  suspense,
-  retry: retryFunction,
+export function getDefaultQueryConfig() {
+  const {suspenseEnabled} = getBlitzRuntimeData()
+  return {
+    suspense: !!suspenseEnabled,
+    retry: retryFunction,
+  }
 }

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -1,3 +1,4 @@
+import {useMemo} from "react"
 import {queryCache, QueryKey} from "react-query"
 import {serialize} from "superjson"
 import {getBlitzRuntimeData} from "../blitz-data"
@@ -147,10 +148,12 @@ export const retryFunction = (failureCount: number, error: any) => {
   return false
 }
 
-export function getDefaultQueryConfig() {
-  const {suspenseEnabled} = getBlitzRuntimeData()
-  return {
-    suspense: !!suspenseEnabled,
-    retry: retryFunction,
-  }
+export function useDefaultQueryConfig() {
+  return useMemo(() => {
+    const {suspenseEnabled} = getBlitzRuntimeData()
+    return {
+      suspense: !!suspenseEnabled,
+      retry: retryFunction,
+    }
+  }, [])
 }

--- a/packages/core/src/utils/react-query-utils.ts
+++ b/packages/core/src/utils/react-query-utils.ts
@@ -1,5 +1,6 @@
 import {queryCache, QueryKey} from "react-query"
 import {serialize} from "superjson"
+import {getBlitzConfig} from "../config"
 import {EnhancedResolverRpcClient, QueryFn, Resolver} from "../types"
 import {isClient, isServer} from "."
 import {requestIdleCallback} from "./request-idle-callback"
@@ -146,7 +147,9 @@ export const retryFunction = (failureCount: number, error: any) => {
   return false
 }
 
+let suspense = getBlitzConfig()?.experimental?.reactMode !== "legacy"
+
 export const defaultQueryConfig = {
-  suspense: true,
+  suspense,
   retry: retryFunction,
 }

--- a/packages/core/test/blitz-data.test.ts
+++ b/packages/core/test/blitz-data.test.ts
@@ -1,4 +1,9 @@
-import {BlitzData, deserializeAndSetBlitzDataOnWindow, getBlitzData} from "../src/blitz-data"
+import {
+  _getBlitzRuntimeData,
+  BlitzData,
+  deserializeAndSetBlitzDataOnWindow,
+  getBlitzRuntimeData,
+} from "../src/blitz-data"
 import {render} from "./test-utils"
 
 describe("BlitzData", () => {
@@ -16,10 +21,19 @@ describe("BlitzData", () => {
     })
   })
 
-  describe("BlitzData sets __BLITZ_DATA__", () => {
+  describe("BlitzData sets __BLITZ_DATA__ on window", () => {
     deserializeAndSetBlitzDataOnWindow()
     it("should equal the original data", () => {
-      expect(window.__BLITZ_DATA__).toEqual(getBlitzData())
+      expect(window.__BLITZ_DATA__).toBeDefined()
+      expect(window.__BLITZ_DATA__).toEqual(_getBlitzRuntimeData())
+    })
+  })
+
+  describe("BlitzData sets __BLITZ_DATA__ on global", () => {
+    getBlitzRuntimeData()
+    it("should equal the original data", () => {
+      expect(global.__BLITZ_DATA__).toBeDefined()
+      expect(global.__BLITZ_DATA__).toEqual(_getBlitzRuntimeData())
     })
   })
 })

--- a/packages/core/test/blitz-data.test.ts
+++ b/packages/core/test/blitz-data.test.ts
@@ -1,0 +1,25 @@
+import {BlitzData, deserializeAndSetBlitzDataOnWindow, getBlitzData} from "../src/blitz-data"
+import {render} from "./test-utils"
+
+describe("BlitzData", () => {
+  const renderedComponent = render(BlitzData())
+
+  describe("BlitzData renders", () => {
+    const blitzData = renderedComponent.container.querySelector(
+      "#__BLITZ_DATA__",
+    ) as HTMLScriptElement
+    it("should be a script element", () => {
+      expect(blitzData.nodeName).toEqual("SCRIPT")
+    })
+    it("should have type text/json", () => {
+      expect(blitzData.type).toEqual("application/json")
+    })
+  })
+
+  describe("BlitzData sets __BLITZ_DATA__", () => {
+    deserializeAndSetBlitzDataOnWindow()
+    it("should equal the original data", () => {
+      expect(window.__BLITZ_DATA__).toEqual(getBlitzData())
+    })
+  })
+})

--- a/packages/core/test/use-query.test.tsx
+++ b/packages/core/test/use-query.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import {queryCache} from "react-query"
+import {_getBlitzRuntimeData} from "../src/blitz-data"
 import {useInfiniteQuery, useQuery} from "../src/use-query-hooks"
 import {
   act,
@@ -38,6 +39,7 @@ describe("useQuery", () => {
       </React.Suspense>
     )
 
+    window.__BLITZ_DATA__ = _getBlitzRuntimeData()
     const {rerender} = render(ui())
     return [res, () => rerender(ui())]
   }
@@ -102,6 +104,7 @@ describe("useInfiniteQuery", () => {
       </React.Suspense>
     )
 
+    window.__BLITZ_DATA__ = _getBlitzRuntimeData()
     const {rerender} = render(ui())
     return [res, () => rerender(ui())]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3304,6 +3304,11 @@
     "@types/node" "*"
     "@types/vinyl" "*"
 
+"@types/htmlescape@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/htmlescape/-/htmlescape-1.1.1.tgz#8aa7ac246f9a69999b84873f072f2e30e1334f03"
+  integrity sha1-iqesJG+aaZmbhIc/By8uMOEzTwM=
+
 "@types/http-cache-semantics@*":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
@@ -9684,6 +9689,11 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+htmlescape@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/htmlescape/-/htmlescape-1.1.1.tgz#3a03edc2214bca3b66424a3e7959349509cb0351"
+  integrity sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=
 
 htmlparser2@5.0.1:
   version "5.0.1"


### PR DESCRIPTION
Closes https://github.com/blitz-js/blitz/issues/1732

### What are the changes and their implications?

Currently the `defaultQueryConfig` for `useQuery` sets `{ suspense: true }`.  This is a good default for `suspense` because Blitz enables React `concurrent` mode by default, and the default app template uses `Suspense`.

However, if a user of Blitz changes the `reactMode` to `legacy` and removes `Suspense` from their app, the default no longer makes sense, and the user must manually override the config in each call to useQuery.

This change updates the `defaultQueryConfig` to depend on the `reactMode`.

Making this change required plumbing through the blitzConfig from the server through to the client by way of a new `__BLITZ_DATA__` mechanism modeled after `__NEXT_DATA__`.

Some implementation notes:

* Exporting `BlitzScript` from `core/src/index.ts` has the side-effect of setting the `window.__BLITZ_DATA__` attribute when running in a browser environment and must happen after the value has appeared in the HTML document but before using anything else depends on that value being set.
* The `BlitzScript` element embeds the serialized `__BLITZ_DATA__`  in the HTML document and must be rendered before the `NextScript` element. (When the `NextScript` element is rendered it loads the scripts for the app, including the code in `core/src/index.ts`, causing the side-effect described above.)

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
