### PR TITLE
Change session cookies to have a unique prefixed based on package.json name field (major)

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -10,6 +10,17 @@ export interface BlitzConfig extends Record<string, unknown> {
     isomorphicResolverImports?: boolean
     reactMode?: string
   }
+  _meta: {
+    packageName: string
+  }
+}
+
+declare global {
+  namespace NodeJS {
+    interface Global {
+      blitzConfig: BlitzConfig
+    }
+  }
 }
 
 /**
@@ -22,8 +33,14 @@ export const getConfig = (reload?: boolean): BlitzConfig => {
 
   const {PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_SERVER} = require("next/constants")
 
-  let blitzConfig = {}
   const projectRoot = pkgDir.sync() || process.cwd()
+  const pkgJson = require(join(projectRoot, "package.json"))
+
+  let blitzConfig = {
+    _meta: {
+      packageName: pkgJson.name,
+    },
+  }
 
   for (const configFile of configFiles) {
     if (existsSync(join(projectRoot, configFile))) {

--- a/packages/config/src/node.d.ts
+++ b/packages/config/src/node.d.ts
@@ -1,5 +1,0 @@
-declare namespace NodeJS {
-  interface Global {
-    blitzConfig: Record<string, unknown>
-  }
-}

--- a/packages/core/src/blitz-data.tsx
+++ b/packages/core/src/blitz-data.tsx
@@ -3,8 +3,17 @@ import htmlescape from "htmlescape"
 import React from "react"
 import {isClient} from "./utils"
 
-export function _getBlitzRuntimeData() {
-  return {suspenseEnabled: getConfig().experimental?.reactMode !== "legacy"}
+export type BlitzRuntimeData = {
+  suspenseEnabled: boolean
+  sessionCookiePrefix: string
+}
+
+export function _getBlitzRuntimeData(): BlitzRuntimeData {
+  const config = getConfig()
+  return {
+    sessionCookiePrefix: config._meta.packageName.replace(/[^a-zA-Z0-9-_]/g, "_"),
+    suspenseEnabled: config.experimental?.reactMode !== "legacy",
+  }
 }
 
 export function getBlitzRuntimeData() {

--- a/packages/core/src/blitz-data.tsx
+++ b/packages/core/src/blitz-data.tsx
@@ -17,7 +17,7 @@ export function _getBlitzRuntimeData(): BlitzRuntimeData {
 }
 
 export function getBlitzRuntimeData() {
-  if (isClient) {
+  if (isClient && process.env.JEST_WORKER_ID === "undefined") {
     return window.__BLITZ_DATA__
   } else {
     if (!global.__BLITZ_DATA__) {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,3 +1,5 @@
+import {getBlitzRuntimeData} from "./blitz-data"
+
 // regarding tokens
 export const TOKEN_SEPARATOR = ";"
 export const HANDLE_SEPARATOR = ":"
@@ -5,11 +7,15 @@ export const SESSION_TYPE_OPAQUE_TOKEN_SIMPLE = "ots"
 export const SESSION_TYPE_ANONYMOUS_JWT = "ajwt"
 export const SESSION_TOKEN_VERSION_0 = "v0"
 
-export const COOKIE_ANONYMOUS_SESSION_TOKEN = "sAnonymousSessionToken"
-export const COOKIE_SESSION_TOKEN = "sSessionToken"
-export const COOKIE_REFRESH_TOKEN = "sIdRefreshToken"
-export const COOKIE_CSRF_TOKEN = "sAntiCrfToken"
-export const COOKIE_PUBLIC_DATA_TOKEN = "sPublicDataToken"
+export const COOKIE_ANONYMOUS_SESSION_TOKEN = () =>
+  `${getBlitzRuntimeData().sessionCookiePrefix}_sAnonymousSessionToken`
+export const COOKIE_SESSION_TOKEN = () =>
+  `${getBlitzRuntimeData().sessionCookiePrefix}_sSessionToken`
+export const COOKIE_REFRESH_TOKEN = () =>
+  `${getBlitzRuntimeData().sessionCookiePrefix}_sIdRefreshToken`
+export const COOKIE_CSRF_TOKEN = () => `${getBlitzRuntimeData().sessionCookiePrefix}_sAntiCrfToken`
+export const COOKIE_PUBLIC_DATA_TOKEN = () =>
+  `${getBlitzRuntimeData().sessionCookiePrefix}_sPublicDataToken`
 
 // Headers always all lower case
 export const HEADER_CSRF = "anti-csrf"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export {passportAuth} from "./passport-adapter"
 export {getIsomorphicEnhancedResolver} from "./rpc"
 export {useMutation} from "./use-mutation"
 export {invoke, invokeWithMiddleware} from "./invoke"
+export {getBlitzRuntimeData} from "./blitz-data"
 
 export {
   getAllMiddlewareForModule,

--- a/packages/core/src/public-data-store.test.ts
+++ b/packages/core/src/public-data-store.test.ts
@@ -17,7 +17,7 @@ describe("publicDataStore", () => {
   })
   it("calls readCookie token on init", () => {
     // note: As public-data-store has side effects, this test might be fickle
-    expect(readCookie).toHaveBeenCalledWith(COOKIE_PUBLIC_DATA_TOKEN)
+    expect(readCookie).toHaveBeenCalledWith(COOKIE_PUBLIC_DATA_TOKEN())
   })
 
   describe("updateState", () => {
@@ -48,7 +48,7 @@ describe("publicDataStore", () => {
   describe("clear", () => {
     it("clears the cookie", () => {
       publicDataStore.clear()
-      expect(deleteCookie).toHaveBeenCalledWith(COOKIE_PUBLIC_DATA_TOKEN)
+      expect(deleteCookie).toHaveBeenCalledWith(COOKIE_PUBLIC_DATA_TOKEN())
     })
     it("clears the cache", () => {
       publicDataStore.clear()

--- a/packages/core/src/public-data-store.ts
+++ b/packages/core/src/public-data-store.ts
@@ -33,7 +33,7 @@ class PublicDataStore {
   }
 
   clear() {
-    deleteCookie(COOKIE_PUBLIC_DATA_TOKEN)
+    deleteCookie(COOKIE_PUBLIC_DATA_TOKEN())
     this.updateState(this.emptyPublicData)
   }
 
@@ -48,7 +48,7 @@ class PublicDataStore {
   }
 
   private getToken() {
-    return readCookie(COOKIE_PUBLIC_DATA_TOKEN)
+    return readCookie(COOKIE_PUBLIC_DATA_TOKEN())
   }
 }
 export const publicDataStore = new PublicDataStore()

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -56,7 +56,7 @@ export interface AuthenticatedSessionContext extends SessionContextBase {
   publicData: PublicData
 }
 
-export const getAntiCSRFToken = () => readCookie(COOKIE_CSRF_TOKEN)
+export const getAntiCSRFToken = () => readCookie(COOKIE_CSRF_TOKEN())
 
 export interface PublicDataWithLoading extends PublicData {
   isLoading: boolean

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,6 +3,7 @@ import {NextRouter} from "next/router"
 import {AuthenticateOptions, Strategy} from "passport"
 import {MutateOptions, MutationResult} from "react-query"
 import {BlitzApiRequest, BlitzApiResponse} from "."
+import {BlitzRuntimeData} from "./blitz-data"
 import {useParams} from "./use-params"
 import {useRouterQuery} from "./use-router-query"
 
@@ -152,10 +153,6 @@ type RequestIdleCallbackOptions = {
 type RequestIdleCallbackDeadline = {
   readonly didTimeout: boolean
   timeRemaining: () => number
-}
-
-export type BlitzRuntimeData = {
-  suspenseEnabled: boolean
 }
 
 declare global {

--- a/packages/core/test/rpc.test.ts
+++ b/packages/core/test/rpc.test.ts
@@ -1,5 +1,6 @@
 import {getIsomorphicEnhancedResolver} from "@blitzjs/core"
 import {serialize} from "superjson"
+import {getBlitzRuntimeData} from "../src/blitz-data"
 import {executeRpcCall} from "../src/rpc"
 
 declare global {
@@ -11,6 +12,7 @@ declare global {
 }
 
 global.fetch = jest.fn(() => Promise.resolve({json: () => ({result: null, error: null})}))
+window.__BLITZ_DATA__ = getBlitzRuntimeData()
 
 describe("RPC", () => {
   describe("HEAD", () => {

--- a/packages/core/test/use-query.test.tsx
+++ b/packages/core/test/use-query.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import {queryCache} from "react-query"
-import {_getBlitzRuntimeData} from "../src/blitz-data"
+import {getBlitzRuntimeData} from "../src/blitz-data"
 import {useInfiniteQuery, useQuery} from "../src/use-query-hooks"
 import {
   act,
@@ -15,6 +15,8 @@ import {enhanceQueryFn} from "./test-utils"
 beforeEach(() => {
   queryCache.clear()
 })
+
+window.__BLITZ_DATA__ = getBlitzRuntimeData()
 
 describe("useQuery", () => {
   const setupHook = (
@@ -39,7 +41,6 @@ describe("useQuery", () => {
       </React.Suspense>
     )
 
-    window.__BLITZ_DATA__ = _getBlitzRuntimeData()
     const {rerender} = render(ui())
     return [res, () => rerender(ui())]
   }
@@ -104,7 +105,6 @@ describe("useInfiniteQuery", () => {
       </React.Suspense>
     )
 
-    window.__BLITZ_DATA__ = _getBlitzRuntimeData()
     const {rerender} = render(ui())
     return [res, () => rerender(ui())]
   }

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -18,7 +18,7 @@ export async function routes(config: ServerConfig) {
     writeManifestFile,
   } = await normalize({...config, env: "dev"})
 
-  const {sitemap = defaultSitemapFunction} = getConfig() as Record<string, unknown> & {
+  const {sitemap = defaultSitemapFunction} = getConfig() as ReturnType<typeof getConfig> & {
     sitemap: typeof defaultSitemapFunction
   }
 

--- a/packages/server/src/supertokens.test.ts
+++ b/packages/server/src/supertokens.test.ts
@@ -65,14 +65,14 @@ describe("supertokens", () => {
 
       expect(res.status).toBe(200)
       expect(res.headers.get(HEADER_CSRF)).not.toBe(undefined)
-      expect(cookie(COOKIE_ANONYMOUS_SESSION_TOKEN)).not.toBeUndefined()
-      expect(cookie(COOKIE_SESSION_TOKEN)).toBe("")
-      expect(cookie(COOKIE_REFRESH_TOKEN)).toBeUndefined()
+      expect(cookie(COOKIE_ANONYMOUS_SESSION_TOKEN())).not.toBeUndefined()
+      expect(cookie(COOKIE_SESSION_TOKEN())).toBe("")
+      expect(cookie(COOKIE_REFRESH_TOKEN())).toBeUndefined()
 
       expect(res.headers.get(HEADER_PUBLIC_DATA_TOKEN)).toBe("updated")
-      expect(cookie(COOKIE_PUBLIC_DATA_TOKEN)).not.toBe(undefined)
+      expect(cookie(COOKIE_PUBLIC_DATA_TOKEN())).not.toBe(undefined)
 
-      const [publicDataStr, expireAtStr] = fromBase64(cookie(COOKIE_PUBLIC_DATA_TOKEN)).split(
+      const [publicDataStr, expireAtStr] = fromBase64(cookie(COOKIE_PUBLIC_DATA_TOKEN())).split(
         TOKEN_SEPARATOR,
       )
 
@@ -144,7 +144,7 @@ describe("supertokens", () => {
       expect(publicData.roles[0]).toBe("admin")
 
       const cookieHeader = res.headers.get("Set-Cookie") as string
-      expect(readCookie(cookieHeader, COOKIE_SESSION_TOKEN)).not.toBe(undefined)
+      expect(readCookie(cookieHeader, COOKIE_SESSION_TOKEN())).not.toBe(undefined)
     })
   })
 })

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -398,7 +398,7 @@ export const setSessionCookie = (
 ) => {
   setCookie(
     res,
-    cookie.serialize(COOKIE_SESSION_TOKEN, sessionToken, {
+    cookie.serialize(COOKIE_SESSION_TOKEN(), sessionToken, {
       path: "/",
       httpOnly: true,
       secure:
@@ -420,7 +420,7 @@ export const setAnonymousSessionCookie = (
 ) => {
   setCookie(
     res,
-    cookie.serialize(COOKIE_ANONYMOUS_SESSION_TOKEN, token, {
+    cookie.serialize(COOKIE_ANONYMOUS_SESSION_TOKEN(), token, {
       path: "/",
       httpOnly: true,
       secure:
@@ -443,7 +443,7 @@ export const setCSRFCookie = (
   debug("setCSRFCookie", antiCSRFToken)
   setCookie(
     res,
-    cookie.serialize(COOKIE_CSRF_TOKEN, antiCSRFToken, {
+    cookie.serialize(COOKIE_CSRF_TOKEN(), antiCSRFToken, {
       path: "/",
       secure:
         !process.env.DISABLE_SECURE_COOKIES &&
@@ -465,7 +465,7 @@ export const setPublicDataCookie = (
   setHeader(res, HEADER_PUBLIC_DATA_TOKEN, "updated")
   setCookie(
     res,
-    cookie.serialize(COOKIE_PUBLIC_DATA_TOKEN, publicDataToken, {
+    cookie.serialize(COOKIE_PUBLIC_DATA_TOKEN(), publicDataToken, {
       path: "/",
       secure:
         !process.env.DISABLE_SECURE_COOKIES &&
@@ -485,9 +485,9 @@ export async function getSession(
   req: BlitzApiRequest,
   res: ServerResponse,
 ): Promise<SessionKernel | null> {
-  const anonymousSessionToken = req.cookies[COOKIE_ANONYMOUS_SESSION_TOKEN]
-  const sessionToken = req.cookies[COOKIE_SESSION_TOKEN] // for essential method
-  const idRefreshToken = req.cookies[COOKIE_REFRESH_TOKEN] // for advanced method
+  const anonymousSessionToken = req.cookies[COOKIE_ANONYMOUS_SESSION_TOKEN()]
+  const sessionToken = req.cookies[COOKIE_SESSION_TOKEN()] // for essential method
+  const idRefreshToken = req.cookies[COOKIE_REFRESH_TOKEN()] // for advanced method
   const enableCsrfProtection =
     req.method !== "GET" && req.method !== "OPTIONS" && !process.env.DISABLE_CSRF_PROTECTION
   const antiCSRFToken = req.headers[HEADER_CSRF] as string


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1153

### What are the changes and their implications?

This changes session cookies to have a unique prefix taken from your package.json name field. This allows different apps to remain logged in on the same origin (like localhost:3000).

This will cause all users of your app to be logged out, so they will simply need to log back in.


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
