### PR TITLE
Update jest preset to runInBand and auto disconnect Prisma client after tests (minor)

### DIFF
--- a/packages/blitz/jest-preset.js
+++ b/packages/blitz/jest-preset.js
@@ -5,6 +5,7 @@ const projectRoot = pkgDir.sync() || process.cwd()
 const {compilerOptions} = require(path.join(projectRoot, "tsconfig"))
 
 module.exports = {
+  maxWorkers: 1,
   globalSetup: path.resolve(__dirname, "./jest-preset/global-setup.js"),
   setupFilesAfterEnv: [
     path.resolve(__dirname, "./jest-preset/setup-after-env.js"),

--- a/packages/blitz/jest-preset/setup-after-env.js
+++ b/packages/blitz/jest-preset/setup-after-env.js
@@ -1,1 +1,10 @@
 require("@testing-library/jest-dom")
+
+afterAll(async () => {
+  try {
+    // eslint-disable-next-line no-undef
+    await globalThis._blitz_prismaClient.$disconnect()
+  } catch (error) {
+    // ignore error
+  }
+})


### PR DESCRIPTION


### What are the changes and their implications?

Update jest preset to runInBand (required when running tests that reset/connect to DB) and auto disconnect Prisma client after tests


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
