### PR TITLE
fix: auth form error message

### DIFF
--- a/packages/generator/templates/app/app/auth/components/LoginForm.tsx
+++ b/packages/generator/templates/app/app/auth/components/LoginForm.tsx
@@ -30,7 +30,7 @@ export const LoginForm = (props: LoginFormProps) => {
             } else {
               return {
                 [FORM_ERROR]:
-                  "Sorry, we had an unexpected error. Please try again. - " + error.toString(),
+                  "Sorry, we had an unexpected error. Please try again. - " + error.message.toString(),
               }
             }
           }

--- a/packages/generator/templates/app/app/auth/components/SignupForm.tsx
+++ b/packages/generator/templates/app/app/auth/components/SignupForm.tsx
@@ -29,7 +29,7 @@ export const SignupForm = (props: SignupFormProps) => {
               // This error comes from Prisma
               return { email: "This email is already being used" }
             } else {
-              return { [FORM_ERROR]: error.toString() }
+              return { [FORM_ERROR]: error.message.toString() }
             }
           }
         }}


### PR DESCRIPTION
### What are the changes and their implications?

### Currently

The signup and login pages show error message `[object Object]` when there is e.g. no database connection present, as can seen in this before-screenshot:

![blitz-before](https://user-images.githubusercontent.com/230500/105194292-b867b580-5b39-11eb-8f41-d5b005d8b9d4.png)

### After this PR

The expected error message is shown on screen, as can be seen in this after-screenshot:

![blitz-after](https://user-images.githubusercontent.com/230500/105194467-e4833680-5b39-11eb-879f-036190a1dc40.png)

### Disclaimer

I'm no blitz/ts guru so feel free to close if this is unsuitable. I just felt the time to describe the issue would take more time than creating the PR.

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes
