### PR TITLE
Change `makeServerOnlyPrisma` to `enhancePrisma` which adds `db.$reset()` for use in tests

### DIFF
--- a/examples/auth/db/index.ts
+++ b/examples/auth/db/index.ts
@@ -1,10 +1,7 @@
 import {enhancePrisma} from "blitz"
 import {PrismaClient} from "@prisma/client"
 
-const BlitzPrisma = enhancePrisma(PrismaClient)
+const EnhancedPrisma = enhancePrisma(PrismaClient)
 
 export * from "@prisma/client"
-const db = new BlitzPrisma()
-
-// TODO fix type here
-db.$reset
+export default new EnhancedPrisma()

--- a/examples/auth/db/index.ts
+++ b/examples/auth/db/index.ts
@@ -1,7 +1,10 @@
-import {makeServerOnlyPrisma} from "blitz"
+import {enhancePrisma} from "blitz"
 import {PrismaClient} from "@prisma/client"
 
-const ServerOnlyPrisma = makeServerOnlyPrisma(PrismaClient)
+const BlitzPrisma = enhancePrisma(PrismaClient)
 
 export * from "@prisma/client"
-export default new ServerOnlyPrisma()
+const db = new BlitzPrisma()
+
+// TODO fix type here
+db.$reset

--- a/examples/custom-server/db/index.ts
+++ b/examples/custom-server/db/index.ts
@@ -1,7 +1,7 @@
-import {makeServerOnlyPrisma} from "blitz"
+import {enhancePrisma} from "blitz"
 import {PrismaClient} from "@prisma/client"
 
-const ServerOnlyPrisma = makeServerOnlyPrisma(PrismaClient)
+const EnhancedPrisma = enhancePrisma(PrismaClient)
 
 export * from "@prisma/client"
-export default new ServerOnlyPrisma()
+export default new EnhancedPrisma()

--- a/examples/store/db/index.ts
+++ b/examples/store/db/index.ts
@@ -1,7 +1,7 @@
-import {makeServerOnlyPrisma} from "blitz"
+import {enhancePrisma} from "blitz"
 import {PrismaClient} from "@prisma/client"
 
-const ServerOnlyPrisma = makeServerOnlyPrisma(PrismaClient)
+const EnhancedPrisma = enhancePrisma(PrismaClient)
 
 export * from "@prisma/client"
-export default new ServerOnlyPrisma()
+export default new EnhancedPrisma()

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@types/passport": "1.0.5",
     "@types/pluralize": "0.0.29",
     "@types/prettier": "2.1.6",
+    "@types/npm-run": "5.0.0",
     "@types/pump": "1.1.0",
     "@types/pumpify": "1.4.1",
     "@types/react": "17.0.0",

--- a/packages/blitz/jest-preset/setup-after-env.js
+++ b/packages/blitz/jest-preset/setup-after-env.js
@@ -2,8 +2,7 @@ require("@testing-library/jest-dom")
 
 afterAll(async () => {
   try {
-    // eslint-disable-next-line no-undef
-    await globalThis._blitz_prismaClient.$disconnect()
+    await global._blitz_prismaClient.$disconnect()
   } catch (error) {
     // ignore error
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,8 @@
     "passport": "0.4.1",
     "react-query": "2.5.12",
     "secure-password": "4.0.0",
-    "superjson": "1.4.1"
+    "superjson": "1.4.1",
+    "npm-run": "^5.0.1"
   },
   "devDependencies": {},
   "gitHead": "d3b9fce0bdd251c2b1890793b0aa1cd77c1c0922"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,4 +83,4 @@ export type BlitzPage<P = {}, IP = P> = NextPage<P, IP> & {
 export {isLocalhost} from "./utils/index"
 export {prettyMs} from "./utils/pretty-ms"
 
-export {makeServerOnlyPrisma} from "./prisma-utils"
+export {enhancePrisma} from "./prisma-utils"

--- a/packages/core/src/prisma-utils.ts
+++ b/packages/core/src/prisma-utils.ts
@@ -1,4 +1,10 @@
-export const makeServerOnlyPrisma = <T>(PrismaClient: T): T => {
+import {exec} from "npm-run"
+
+interface EnhancedPrisma {
+  $reset: () => Promise<void>
+}
+
+export const enhancePrisma = <T>(PrismaClient: T): T & EnhancedPrisma => {
   return new Proxy(PrismaClient as any, {
     construct(target, args) {
       if (typeof window !== "undefined" && process.env.JEST_WORKER_ID === undefined) {
@@ -6,9 +12,25 @@ export const makeServerOnlyPrisma = <T>(PrismaClient: T): T => {
         // Skip in Jest tests because window is defined in Jest tests
         return {}
       }
-      ;(globalThis as any)._blitz_prismaClient =
-        (globalThis as any)._blitz_prismaClient || new target(...args)
-      return (globalThis as any)._blitz_prismaClient
+      if ((globalThis as any)._blitz_prismaClient) {
+        return (globalThis as any)._blitz_prismaClient
+      }
+
+      const client = new target(...args)
+
+      client.$reset = function reset() {
+        return new Promise((res, rej) =>
+          exec("prisma migrate reset --force --skip-generate --preview-feature", function (err) {
+            if (err) {
+              rej(err)
+            } else {
+              res()
+            }
+          }),
+        )
+      }
+      ;(globalThis as any)._blitz_prismaClient = client
+      return client
     },
   })
 }

--- a/packages/core/src/prisma-utils.ts
+++ b/packages/core/src/prisma-utils.ts
@@ -1,10 +1,18 @@
 import {exec} from "npm-run"
 
-interface EnhancedPrisma {
+interface Constructor<T> {
+  new (...args: any): T
+}
+
+interface Base {}
+
+interface EnhancedPrismaClient {
   $reset: () => Promise<void>
 }
 
-export const enhancePrisma = <T>(PrismaClient: T): T & EnhancedPrisma => {
+export const enhancePrisma = <T extends Base>(
+  PrismaClient: Constructor<T>,
+): Constructor<EnhancedPrismaClient & T> => {
   return new Proxy(PrismaClient as any, {
     construct(target, args) {
       if (typeof window !== "undefined" && process.env.JEST_WORKER_ID === undefined) {
@@ -12,25 +20,26 @@ export const enhancePrisma = <T>(PrismaClient: T): T & EnhancedPrisma => {
         // Skip in Jest tests because window is defined in Jest tests
         return {}
       }
-      if ((globalThis as any)._blitz_prismaClient) {
-        return (globalThis as any)._blitz_prismaClient
+
+      if (!global._blitz_prismaClient) {
+        const client = new target(...args) as EnhancedPrismaClient
+
+        client.$reset = function reset() {
+          return new Promise<void>((res, rej) =>
+            exec("prisma migrate reset --force --skip-generate --preview-feature", function (err) {
+              if (err) {
+                rej(err)
+              } else {
+                res()
+              }
+            }),
+          )
+        }
+
+        global._blitz_prismaClient = client
       }
 
-      const client = new target(...args)
-
-      client.$reset = function reset() {
-        return new Promise((res, rej) =>
-          exec("prisma migrate reset --force --skip-generate --preview-feature", function (err) {
-            if (err) {
-              rej(err)
-            } else {
-              res()
-            }
-          }),
-        )
-      }
-      ;(globalThis as any)._blitz_prismaClient = client
-      return client
+      return global._blitz_prismaClient
     },
   })
 }

--- a/packages/core/src/prisma-utils.ts
+++ b/packages/core/src/prisma-utils.ts
@@ -25,6 +25,11 @@ export const enhancePrisma = <T extends Base>(
         const client = new target(...args) as EnhancedPrismaClient
 
         client.$reset = function reset() {
+          if (process.env.NODE_ENV === "production") {
+            throw new Error(
+              "You are calling db.$reset() in a production environment. We think you probably didn't mean to do that, so we are throwing this error instead of destroying your life's work.",
+            )
+          }
           return new Promise<void>((res, rej) =>
             exec("prisma migrate reset --force --skip-generate --preview-feature", function (err) {
               if (err) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -159,6 +159,7 @@ declare global {
   namespace NodeJS {
     interface Global {
       __BLITZ_DATA__: BlitzRuntimeData
+      _blitz_prismaClient: any
     }
   }
   interface Window {

--- a/packages/generator/templates/app/db/index.ts
+++ b/packages/generator/templates/app/db/index.ts
@@ -1,7 +1,7 @@
-import { makeServerOnlyPrisma } from "blitz"
+import { enhancePrisma } from "blitz"
 import { PrismaClient } from "@prisma/client"
 
-const ServerOnlyPrisma = makeServerOnlyPrisma(PrismaClient)
+const EnhancedPrisma = enhancePrisma(PrismaClient)
 
 export * from "@prisma/client"
-export default new ServerOnlyPrisma()
+export default new EnhancedPrisma()

--- a/packages/server/src/with-blitz.ts
+++ b/packages/server/src/with-blitz.ts
@@ -30,6 +30,7 @@ export function withBlitz(nextConfig: any) {
             /node_modules[\\/]passport/,
             /node_modules[\\/]cookie-session/,
             /node_modules[\\/]secure-password/,
+            /node_modules[\\/]npm-run/,
             /blitz[\\/]packages[\\/]config/,
             /blitz[\\/]packages[\\/]display/,
             /node-libs-browser/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3451,6 +3451,13 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/npm-run@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/npm-run/-/npm-run-5.0.0.tgz#e2cf7bb4f5215c65ca14d286ccf0f176e951cb45"
+  integrity sha512-SbRnR2S0/CL9GW5mKng/V9T3uEPFSkGC5a71AcyCnT1ltK/kSv1A0nSO8AYI3FjuE4ep04HPi6eCuXWpnwD5HQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/oauth@*":
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/@types/oauth/-/oauth-0.9.1.tgz#e17221e7f7936b0459ae7d006255dff61adca305"
@@ -6132,7 +6139,7 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.19.0, commander@^2.20.0:
+commander@^2.19.0, commander@^2.20.0, commander@^2.9.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -7880,49 +7887,6 @@ eslint-visitor-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
-
-eslint@7.17.0, eslint@^7.3.0:
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.17.0.tgz#4ccda5bf12572ad3bf760e6f195886f50569adb0"
-  integrity sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@eslint/eslintrc" "^0.2.2"
-    ajv "^6.10.0"
-    chalk "^4.0.0"
-    cross-spawn "^7.0.2"
-    debug "^4.0.1"
-    doctrine "^3.0.0"
-    enquirer "^2.3.5"
-    eslint-scope "^5.1.1"
-    eslint-utils "^2.1.0"
-    eslint-visitor-keys "^2.0.0"
-    espree "^7.3.1"
-    esquery "^1.2.0"
-    esutils "^2.0.2"
-    file-entry-cache "^6.0.0"
-    functional-red-black-tree "^1.0.1"
-    glob-parent "^5.0.0"
-    globals "^12.1.0"
-    ignore "^4.0.6"
-    import-fresh "^3.0.0"
-    imurmurhash "^0.1.4"
-    is-glob "^4.0.0"
-    js-yaml "^3.13.1"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.4.1"
-    lodash "^4.17.19"
-    minimatch "^3.0.4"
-    natural-compare "^1.4.0"
-    optionator "^0.9.1"
-    progress "^2.0.0"
-    regexpp "^3.1.0"
-    semver "^7.2.1"
-    strip-ansi "^6.0.0"
-    strip-json-comments "^3.1.0"
-    table "^6.0.4"
-    text-table "^0.2.0"
-    v8-compile-cache "^2.0.3"
 
 eslint@7.17.0, eslint@^7.3.0:
   version "7.17.0"
@@ -13547,6 +13511,13 @@ npm-packlist@^1.1.6, npm-packlist@^1.4.1, npm-packlist@^1.4.4:
     npm-bundled "^1.0.1"
     npm-normalize-package-bin "^1.0.1"
 
+npm-path@^2.0.2, npm-path@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64"
+  integrity sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==
+  dependencies:
+    which "^1.2.10"
+
 npm-pick-manifest@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz#f4d9e5fd4be2153e5f4e5f9b7be8dc419a99abb7"
@@ -13584,6 +13555,25 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+npm-run@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run/-/npm-run-5.0.1.tgz#1baea93389b50ae25a32382c8ca322398e50cd16"
+  integrity sha512-s7FyRpHUgaJfzkRgOnevX8rAWWsv1dofY1XS7hliWCF6LSQh+HtDfBvpigPS1krLvXw+Fi17CYMY8mUtblnyWw==
+  dependencies:
+    minimist "^1.2.0"
+    npm-path "^2.0.4"
+    npm-which "^3.0.1"
+    serializerr "^1.0.3"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  integrity sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 "npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.1, npmlog@^4.0.2, npmlog@^4.1.2:
   version "4.1.2"
@@ -14876,6 +14866,11 @@ proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
+
+protochain@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/protochain/-/protochain-1.0.5.tgz#991c407e99de264aadf8f81504b5e7faf7bfa260"
+  integrity sha1-mRxAfpneJkqt+PgVBLXn+ve/omA=
 
 protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.8"
@@ -16317,6 +16312,13 @@ serialize-javascript@^4.0.0:
   integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
   dependencies:
     randombytes "^2.1.0"
+
+serializerr@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/serializerr/-/serializerr-1.0.3.tgz#12d4c5aa1c3ffb8f6d1dc5f395aa9455569c3f91"
+  integrity sha1-EtTFqhw/+49tHcXzlaqUVVacP5E=
+  dependencies:
+    protochain "^1.0.5"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -18672,7 +18674,7 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@1, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.1:
+which@1, which@^1.2.10, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
### What are the changes and their implications?

This adds a `db.$reset()` function to prisma client when using `new enhancePrisma(PrismaClient)()` for use in tests like this:

```ts
beforeEach(() => {
  return db.$reset()
})
```

### Checklist

- [x] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes: https://github.com/blitz-js/blitzjs.com/pull/334

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
