### PR TITLE
Add Quirrel recipe AND add Plain-Text Transformer to recipe APIs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,7 +51,12 @@ module.exports = {
       },
     ],
   },
-  ignorePatterns: ["packages/cli/", "packages/generator/templates", ".eslintrc.js"],
+  ignorePatterns: [
+    "packages/cli/",
+    "packages/generator/templates",
+    ".eslintrc.js",
+    "recipes/*/templates",
+  ],
   overrides: [
     {
       files: ["examples/**", "packages/gui/**", "recipes/**"],

--- a/packages/installer/src/executors/file-transform-executor.tsx
+++ b/packages/installer/src/executors/file-transform-executor.tsx
@@ -93,8 +93,6 @@ export const Propose: Executor["Propose"] = ({cliArgs, onProposalAccepted, step}
   )
 }
 export const Commit: Executor["Commit"] = ({onChangeCommitted, proposalData: filePath, step}) => {
-  const transformFn = (step as Config).transform
-
   const [loading, setLoading] = React.useState(true)
 
   const handleChangeCommitted = React.useCallback(() => {
@@ -115,7 +113,7 @@ export const Commit: Executor["Commit"] = ({onChangeCommitted, proposalData: fil
       console.error(results)
     }
     setLoading(false)
-  }, [filePath, transformFn])
+  }, [filePath, step])
 
   if (loading) {
     return (

--- a/packages/installer/src/utils/paths.ts
+++ b/packages/installer/src/utils/paths.ts
@@ -21,4 +21,7 @@ export const paths = {
   blitzConfig() {
     return "blitz.config.js"
   },
+  packageJson() {
+    return "package.json"
+  },
 }

--- a/packages/installer/src/utils/transform.ts
+++ b/packages/installer/src/utils/transform.ts
@@ -22,7 +22,13 @@ export interface TransformResult {
   filename: string
   error?: Error
 }
+
+export type StringTransformer = (program: string) => string
 export type Transformer = (program: Collection<j.Program>) => Collection<j.Program>
+
+export function stringProcessFile(original: string, transformerFn: StringTransformer): string {
+  return transformerFn(original)
+}
 
 export function processFile(original: string, transformerFn: Transformer): string {
   const program = j(original, {parser: customTsParser})
@@ -30,7 +36,7 @@ export function processFile(original: string, transformerFn: Transformer): strin
 }
 
 export function transform(
-  transformerFn: Transformer,
+  processFile: (original: string) => string,
   targetFilePaths: string[],
 ): TransformResult[] {
   const results: TransformResult[] = []
@@ -45,7 +51,7 @@ export function transform(
     try {
       const fileBuffer = fs.readFileSync(filePath)
       const fileSource = fileBuffer.toString("utf-8")
-      const transformedCode = processFile(fileSource, transformerFn)
+      const transformedCode = processFile(fileSource)
       fs.writeFileSync(filePath, transformedCode)
       results.push({
         status: TransformStatus.Success,

--- a/recipes/quirrel/index.ts
+++ b/recipes/quirrel/index.ts
@@ -1,4 +1,5 @@
 import {paths, RecipeBuilder} from "@blitzjs/installer"
+import path from "path"
 
 export default RecipeBuilder()
   .setName("Quirrel")
@@ -38,5 +39,13 @@ export default RecipeBuilder()
         return [start, command, end].join("")
       })
     },
+  })
+  .addNewFilesStep({
+    stepId: "addExamples",
+    stepName: "Add example files",
+    explanation: "Create one example Queue and CronJob that illustrate Quirrel usage.",
+    targetDirectory: "app",
+    templatePath: path.join(__dirname, "templates", "app"),
+    templateValues: {},
   })
   .build()

--- a/recipes/quirrel/index.ts
+++ b/recipes/quirrel/index.ts
@@ -1,0 +1,42 @@
+import {paths, RecipeBuilder} from "@blitzjs/installer"
+
+export default RecipeBuilder()
+  .setName("Quirrel")
+  .setDescription("Configure Quirrel locally and set it up for immediate use.")
+  .setOwner("Simon Knott <info@quirrel.dev>")
+  .setRepoLink("https://quirrel.dev")
+  .addAddDependenciesStep({
+    stepId: "addQuirrelDep",
+    stepName: "Install Quirrel",
+    explanation:
+      "Installs the Quirrel NPM package and concurrently (useful for starting Quirrel together with Blitz).",
+    packages: [
+      {
+        name: "quirrel",
+        version: "latest",
+      },
+      {
+        name: "concurrently",
+        version: "latest",
+        isDevDep: true,
+      },
+    ],
+  })
+  .addTransformFilesStep({
+    stepId: "startWithBlitz",
+    stepName: 'Start Quirrel with "blitz start"',
+    explanation: "Make sure that your local Quirrel server runs when you need it.",
+    singleFileSearch: paths.packageJson(),
+    transformPlain(program) {
+      return program.replace(/("start":\s*")(.*)(")/, (_fullMatch, start, command: string, end) => {
+        if (command.includes("concurrently")) {
+          command += ` 'quirrel'`
+        } else {
+          command = `concurrently --raw '${command}' 'quirrel'`
+        }
+
+        return [start, command, end].join("")
+      })
+    },
+  })
+  .build()

--- a/recipes/quirrel/package.json
+++ b/recipes/quirrel/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@blitzjs/recipe-quirrel",
+  "private": true,
+  "version": "0.29.2",
+  "description": "The Blitz Recipe for adding Quirrel",
+  "main": "index.ts",
+  "scripts": {
+    "test": "echo \"No tests yet\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/blitz-js/blitz.git"
+  },
+  "keywords": [
+    "blitz",
+    "blitzjs"
+  ],
+  "author": "Simon Knott <info@quirrel.dev>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/blitz-js/blitz/issues"
+  },
+  "homepage": "https://github.com/blitz-js/blitz#readme",
+  "dependencies": {
+    "@blitzjs/installer": "0.29.2"
+  }
+}

--- a/recipes/quirrel/templates/app/api/greetingsQueue.ts
+++ b/recipes/quirrel/templates/app/api/greetingsQueue.ts
@@ -1,0 +1,13 @@
+import { Queue } from "quirrel/blitz"
+
+export interface Greetings {
+  to: string;
+  message: string;
+}
+
+export default Queue(
+  "api/greetingsQueue", // the path of this API route
+  async ({ to, message }: Greetings) => {
+    console.log(`Greetings, ${to}! Thy ears shall hear: "${message}"`)
+  }
+)

--- a/recipes/quirrel/templates/app/api/hourlyCron.ts
+++ b/recipes/quirrel/templates/app/api/hourlyCron.ts
@@ -1,0 +1,9 @@
+import { CronJob } from "quirrel/blitz"
+
+export default CronJob(
+  "api/hourlyCron", // the path of this API route
+  "@hourly", // cron schedule (see https://crontab.guru)
+  async () => {
+    console.log("A new hour has begun!")
+  }
+)

--- a/recipes/quirrel/templates/app/mutations/enqueueGreeting.ts
+++ b/recipes/quirrel/templates/app/mutations/enqueueGreeting.ts
@@ -1,0 +1,8 @@
+import greetingsQueue from "app/api/greetingsQueue"
+
+export default async function enqueueGreeting() {
+  await greetingsQueue.enqueue({
+    to: "Sandy Cheeks",
+    message: "Howdy!"
+  })
+}


### PR DESCRIPTION
### What are the changes and their implications?

- Adds support for plain-text transformers
- Adds a recipe for setting up Quirrel with your Blitz project

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
