### PR TITLE
Add missing type exports like `GetStaticPropsContext` (patch)

### DIFF
--- a/examples/auth/blitz.config.js
+++ b/examples/auth/blitz.config.js
@@ -11,7 +11,7 @@ module.exports = withBundleAnalyzer({
     }),
   ],
   log: {
-    level: "trace",
+    // level: "trace",
   },
   experimental: {
     isomorphicResolverImports: true,

--- a/examples/store/blitz.config.js
+++ b/examples/store/blitz.config.js
@@ -6,7 +6,7 @@ module.exports = {
     },
   ],
   log: {
-    level: "trace",
+    // level: "trace",
   },
   experimental: {
     isomorphicResolverImports: true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,6 +55,8 @@
     "superjson": "1.5.0",
     "npm-run": "^5.0.1"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "next": "10.0.5"
+  },
   "gitHead": "d3b9fce0bdd251c2b1890793b0aa1cd77c1c0922"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,8 +55,6 @@
     "superjson": "1.5.0",
     "npm-run": "^5.0.1"
   },
-  "devDependencies": {
-    "next": "10.0.5"
-  },
+  "devDependencies": {},
   "gitHead": "d3b9fce0bdd251c2b1890793b0aa1cd77c1c0922"
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,16 +37,6 @@ export {SecurePassword, hash256, generateToken} from "./auth-utils"
 // --------------------
 // Exports from Next.js
 // --------------------
-export {
-  GetStaticProps,
-  GetStaticPaths,
-  GetServerSideProps,
-  InferGetStaticPropsType,
-  InferGetServerSidePropsType,
-  NextApiRequest as BlitzApiRequest,
-  NextApiResponse as BlitzApiResponse,
-} from "next"
-
 export {default as Head} from "next/head"
 
 export {default as Link, LinkProps} from "next/link"

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,7 +7,20 @@ import {BlitzRuntimeData} from "./blitz-data"
 import {useParams} from "./use-params"
 import {useRouterQuery} from "./use-router-query"
 
-export * from "next/types"
+export {
+  GetServerSideProps,
+  GetServerSidePropsResult,
+  GetStaticPaths,
+  GetStaticPathsContext,
+  GetStaticPathsResult,
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+  InferGetServerSidePropsType,
+  InferGetStaticPropsType,
+  PageConfig,
+  Redirect,
+} from "next"
 export type BlitzApiRequest = NextApiRequest
 export type BlitzApiResponse = NextApiResponse
 export type BlitzComponentType = NextComponentType

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,11 +1,17 @@
 import {IncomingMessage, ServerResponse} from "http"
 import {NextRouter} from "next/router"
+import {NextApiRequest, NextApiResponse, NextComponentType, NextPageContext} from "next/types"
 import {AuthenticateOptions, Strategy} from "passport"
 import {MutateOptions, MutationResult} from "react-query"
-import {BlitzApiRequest, BlitzApiResponse} from "."
 import {BlitzRuntimeData} from "./blitz-data"
 import {useParams} from "./use-params"
 import {useRouterQuery} from "./use-router-query"
+
+export * from "next/types"
+export type BlitzApiRequest = NextApiRequest
+export type BlitzApiResponse = NextApiResponse
+export type BlitzComponentType = NextComponentType
+export type BlitzPageContext = NextPageContext
 
 export interface BlitzRouter extends NextRouter {
   query: ReturnType<typeof useRouterQuery>

--- a/packages/core/test/rpc.test.ts
+++ b/packages/core/test/rpc.test.ts
@@ -1,7 +1,6 @@
-import {getIsomorphicEnhancedResolver} from "@blitzjs/core"
 import {serialize} from "superjson"
 import {getBlitzRuntimeData} from "../src/blitz-data"
-import {executeRpcCall} from "../src/rpc"
+import {executeRpcCall, getIsomorphicEnhancedResolver} from "../src/rpc"
 
 declare global {
   namespace NodeJS {


### PR DESCRIPTION


### What are the changes and their implications?

Add missing type exports like `InferGetServerSidePropsType` 


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
