### PR TITLE
Change package.json engines version 12.20 to 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     ]
   },
   "engines": {
-    "node": ">=12.20.0"
+    "node": ">=12"
   },
   "scripts": {
     "postinstall": "npm rebuild husky && patch-package",


### PR DESCRIPTION
From: https://github.com/blitz-js/blitz/pull/1763

### What are the changes and their implications?

The README says node 12 or higher, but `yarn install` requires node 12.20 or higher, so you will get an error.

To align the behavior of the development environment, change the engines version.

👇 ex: call yarn install in node v12.17.0

```bash
 $ yarn
yarn install v1.22.4
[1/5] 🔍  Validating package.json...
error root@0.0.0: The engine "node" is incompatible with this module. Expected version ">=12.20.0". Got "12.17.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

### Checklist

~~- [ ] Tests added for changes~~
~~- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
