### PR TITLE
Rename `chakra` recipe to `chakra-ui`

### DIFF
--- a/recipes/chakra-ui/index.ts
+++ b/recipes/chakra-ui/index.ts
@@ -35,7 +35,7 @@ export default RecipeBuilder()
   .addAddDependenciesStep({
     stepId: "addDeps",
     stepName: "Add npm dependencies",
-    explanation: `Chakra requires some other dependencies like emotion to work`,
+    explanation: `Chakra UI requires some other dependencies like emotion to work`,
     packages: [
       {name: "@chakra-ui/react", version: "1.1.2"},
       {name: "@emotion/react", version: "11.1.4"},
@@ -46,7 +46,7 @@ export default RecipeBuilder()
   .addTransformFilesStep({
     stepId: "importProviderAndReset",
     stepName: "Import ChakraProvider component",
-    explanation: `We can import the chakra provider into _app, so it is accessible in the whole app`,
+    explanation: `We can import the chakra-ui provider into _app, so it is accessible in the whole app`,
     singleFileSearch: paths.app(),
     transform(program: Collection<j.Program>) {
       const stylesImport = j.importDeclaration(

--- a/recipes/chakra-ui/package.json
+++ b/recipes/chakra-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@blitzjs/recipe-chakra",
+  "name": "@blitzjs/recipe-chakra-ui",
   "private": true,
   "version": "0.29.2",
   "description": "The Blitz Recipe for installing Chakra UI",
@@ -14,7 +14,8 @@
   "keywords": [
     "blitz",
     "blitzjs",
-    "chakra"
+    "chakra",
+    "chakra-ui"
   ],
   "author": "zeko369 <zekan.fran369@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
The Chakra UI package is named `@chakra-ui/react`.
This commit updates the recipe name to more closely match the package.

Closes: #1774

### Checklist

- [ ] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
