### PR TITLE
[RFC] Prefix all `ctx.session` methods with `$` and move `publicData` fields to top level of `ctx.session`

### DIFF
--- a/examples/auth/app/auth/mutations/login.ts
+++ b/examples/auth/app/auth/mutations/login.ts
@@ -31,7 +31,7 @@ export default async function login(input: LoginInputType, {session}: Ctx) {
   // This throws an error if credentials are invalid
   const user = await authenticateUser(email, password)
 
-  await session.create({userId: user.id, roles: [user.role]})
+  await session.$create({userId: user.id, roles: [user.role]})
 
   return user
 }

--- a/examples/auth/app/auth/mutations/logout.ts
+++ b/examples/auth/app/auth/mutations/logout.ts
@@ -1,5 +1,5 @@
 import {Ctx} from "blitz"
 
 export default async function logout(_: any, {session}: Ctx) {
-  return await session.revoke()
+  return await session.$revoke()
 }

--- a/examples/auth/app/auth/mutations/signup.ts
+++ b/examples/auth/app/auth/mutations/signup.ts
@@ -18,7 +18,7 @@ export default async function signup(input: SignupInputType, {session}: Ctx) {
     select: {id: true, name: true, email: true, role: true},
   })
 
-  await session.create({userId: user.id, roles: [user.role]})
+  await session.$create({userId: user.id, roles: [user.role]})
 
   return user
 }

--- a/examples/auth/app/users/mutations/trackView.ts
+++ b/examples/auth/app/users/mutations/trackView.ts
@@ -1,9 +1,9 @@
 import {Ctx} from "blitz"
 
 export default async function trackView(_ = null, {session}: Ctx) {
-  const currentViews = session.publicData.views || 0
-  await session.setPublicData({views: currentViews + 1})
-  await session.setPrivateData({views: currentViews + 1})
+  const currentViews = session.views || 0
+  await session.$setPublicData({views: currentViews + 1})
+  await session.$setPrivateData({views: currentViews + 1})
 
   return
 }

--- a/examples/auth/app/users/queries/getUser.ts
+++ b/examples/auth/app/users/queries/getUser.ts
@@ -6,7 +6,7 @@ type GetUserInput = {
 }
 
 export default async function getUser({where}: GetUserInput, ctx: Ctx) {
-  ctx.session.authorize()
+  ctx.session.$authorize()
 
   const user = await db.user.findFirst({where})
 

--- a/examples/auth/app/users/queries/getUsers.ts
+++ b/examples/auth/app/users/queries/getUsers.ts
@@ -4,7 +4,7 @@ import db, {Prisma} from "db"
 type GetUsersInput = Pick<Prisma.UserFindManyArgs, "where" | "orderBy" | "skip" | "take">
 
 export default async function getUsers({where, orderBy, skip = 0, take}: GetUsersInput, ctx: Ctx) {
-  ctx.session.authorize()
+  ctx.session.$authorize()
 
   const users = await db.user.findMany({
     where,

--- a/examples/custom-server/app/auth/mutations/login.ts
+++ b/examples/custom-server/app/auth/mutations/login.ts
@@ -9,7 +9,7 @@ export default async function login(input: LoginInputType, {session}: Ctx) {
   // This throws an error if credentials are invalid
   const user = await authenticateUser(email, password)
 
-  await session.create({userId: user.id, roles: [user.role]})
+  await session.$create({userId: user.id, roles: [user.role]})
 
   return user
 }

--- a/examples/custom-server/app/auth/mutations/logout.ts
+++ b/examples/custom-server/app/auth/mutations/logout.ts
@@ -1,5 +1,5 @@
 import {Ctx} from "blitz"
 
 export default async function logout(_: any, {session}: Ctx) {
-  return await session.revoke()
+  return await session.$revoke()
 }

--- a/examples/custom-server/app/auth/mutations/signup.ts
+++ b/examples/custom-server/app/auth/mutations/signup.ts
@@ -13,7 +13,7 @@ export default async function signup(input: SignupInputType, {session}: Ctx) {
     select: {id: true, name: true, email: true, role: true},
   })
 
-  await session.create({userId: user.id, roles: [user.role]})
+  await session.$create({userId: user.id, roles: [user.role]})
 
   return user
 }

--- a/examples/fauna/app/auth/mutations/login.ts
+++ b/examples/fauna/app/auth/mutations/login.ts
@@ -9,7 +9,7 @@ export default async function login(input: LoginInputType, { session }: Ctx) {
   // This throws an error if credentials are invalid
   const user = await authenticateUser(email, password)
 
-  await session.create({ userId: user.id, roles: [user.role] })
+  await session.$create({ userId: user.id, roles: [user.role] })
 
   return user
 }

--- a/examples/fauna/app/auth/mutations/logout.ts
+++ b/examples/fauna/app/auth/mutations/logout.ts
@@ -1,5 +1,5 @@
 import { Ctx } from "blitz"
 
 export default async function logout(_: any, { session }: Ctx) {
-  return await session.revoke()
+  return await session.$revoke()
 }

--- a/examples/fauna/app/auth/mutations/signup.ts
+++ b/examples/fauna/app/auth/mutations/signup.ts
@@ -23,7 +23,7 @@ export default async function signup(input: SignupInputType, { session }: Ctx) {
   )
   console.log("Create user result:", user)
 
-  await session.create({ userId: user.id, roles: [user.role] })
+  await session.$create({ userId: user.id, roles: [user.role] })
 
   return user
 }

--- a/packages/core/src/passport-adapter.ts
+++ b/packages/core/src/passport-adapter.ts
@@ -67,7 +67,7 @@ export function passportAuth(config: BlitzPassportConfig) {
         middleware.push(async (req, res, next) => {
           const session = res.blitzCtx.session as SessionContext
           assert(session, "Missing Blitz sessionMiddleware!")
-          await session.setPublicData({[INTERNAL_REDIRECT_URL_KEY]: req.query.redirectUrl} as any)
+          await session.$setPublicData({[INTERNAL_REDIRECT_URL_KEY]: req.query.redirectUrl} as any)
           return next()
         })
       }
@@ -106,7 +106,7 @@ export function passportAuth(config: BlitzPassportConfig) {
                 result && typeof result === "object" && (result as any).redirectUrl
               let redirectUrl: string =
                 redirectUrlFromVerifyResult ||
-                (session.publicData as any)[INTERNAL_REDIRECT_URL_KEY] ||
+                (session.$publicData as any)[INTERNAL_REDIRECT_URL_KEY] ||
                 (error ? config.errorRedirectUrl : config.successRedirectUrl) ||
                 "/"
 
@@ -122,7 +122,7 @@ export function passportAuth(config: BlitzPassportConfig) {
 
               delete (result.publicData as any)[INTERNAL_REDIRECT_URL_KEY]
 
-              await session.create(result.publicData, result.privateData)
+              await session.$create(result.publicData, result.privateData)
 
               res.setHeader("Location", redirectUrl)
               res.statusCode = 302

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -28,32 +28,30 @@ export type SessionConfig = {
   isAuthorized: (userRoles: string[], input?: any) => boolean
 }
 
-export interface SessionContextBase {
-  userId: unknown
-  roles: string[]
-  handle: string | null
-  publicData: unknown
-  authorize(input?: any): asserts this is AuthenticatedSessionContext
-  isAuthorized(input?: any): boolean
+export interface SessionContextBase extends PublicData {
+  $handle: string | null
+  $publicData: unknown
+  $authorize(input?: any): asserts this is AuthenticatedSessionContext
+  $isAuthorized(input?: any): boolean
   // authorize: (roleOrRoles?: string | string[]) => void
   // isAuthorized: (roleOrRoles?: string | string[]) => boolean
-  create: (publicData: PublicData, privateData?: Record<any, any>) => Promise<void>
-  revoke: () => Promise<void>
-  revokeAll: () => Promise<void>
-  getPrivateData: () => Promise<Record<any, any>>
-  setPrivateData: (data: Record<any, any>) => Promise<void>
-  setPublicData: (data: Partial<Omit<PublicData, "userId">>) => Promise<void>
+  $create: (publicData: PublicData, privateData?: Record<any, any>) => Promise<void>
+  $revoke: () => Promise<void>
+  $revokeAll: () => Promise<void>
+  $getPrivateData: () => Promise<Record<any, any>>
+  $setPrivateData: (data: Record<any, any>) => Promise<void>
+  $setPublicData: (data: Partial<Omit<PublicData, "userId">>) => Promise<void>
 }
 
 // Could be anonymous
 export interface SessionContext extends SessionContextBase {
   userId: PublicData["userId"] | null
-  publicData: Partial<PublicData>
+  $publicData: Partial<PublicData>
 }
 
 export interface AuthenticatedSessionContext extends SessionContextBase {
   userId: PublicData["userId"]
-  publicData: PublicData
+  $publicData: PublicData
 }
 
 export const getAntiCSRFToken = () => readCookie(COOKIE_CSRF_TOKEN())

--- a/packages/server/src/supertokens.test.ts
+++ b/packages/server/src/supertokens.test.ts
@@ -45,7 +45,7 @@ describe("supertokens", () => {
     }) as unknown) as EnhancedResolver<unknown, unknown>
     resolverModule.middleware = [
       (_req, res, next) => {
-        expect(typeof (res.blitzCtx.session as SessionContext).create).toBe("function")
+        expect(typeof (res.blitzCtx.session as SessionContext).$create).toBe("function")
         return next()
       },
     ]
@@ -90,7 +90,7 @@ describe("supertokens", () => {
     }) as unknown) as EnhancedResolver<unknown, unknown>
     resolverModule.middleware = [
       (_req, res, next) => {
-        expect(typeof (res.blitzCtx.session as SessionContext).create).toBe("function")
+        expect(typeof (res.blitzCtx.session as SessionContext).$create).toBe("function")
         return next()
       },
     ]
@@ -115,7 +115,7 @@ describe("supertokens", () => {
   it.skip("login works", async () => {
     // TODO - fix this test with a mock DB by passing custom config to sessionMiddleware
     const resolverModule = (async (_input: any, ctx: CtxWithSession) => {
-      await ctx.session.create({userId: 1, roles: ["admin"]})
+      await ctx.session.$create({userId: 1, roles: ["admin"]})
       return
     }) as EnhancedResolver<unknown, unknown>
 

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -177,12 +177,25 @@ export async function getSessionContext(
     sessionKernel = await createAnonymousSession(req, res)
   }
 
-  const sessionContext = new SessionContextClass(req, res, sessionKernel)
+  const sessionContext = makeProxyToPublicData(new SessionContextClass(req, res, sessionKernel))
+
   if (!("blitzCtx" in res)) {
     ;(res as MiddlewareResponse).blitzCtx = {}
   }
   ;(res as MiddlewareResponse).blitzCtx.session = sessionContext
   return sessionContext
+}
+
+const makeProxyToPublicData = <T extends SessionContextClass>(ctxClass: T): T => {
+  return new Proxy(ctxClass, {
+    get(target, prop, receiver) {
+      if (prop in target || prop === "then") {
+        return Reflect.get(target, prop, receiver)
+      } else {
+        return Reflect.get(target.$publicData, prop, receiver)
+      }
+    },
+  })
 }
 
 export class SessionContextClass implements SessionContext {
@@ -196,7 +209,7 @@ export class SessionContextClass implements SessionContext {
     this._kernel = kernel
   }
 
-  get handle() {
+  get $handle() {
     return this._kernel.handle
   }
   get userId() {
@@ -205,57 +218,57 @@ export class SessionContextClass implements SessionContext {
   get roles() {
     return this._kernel.publicData.roles
   }
-  get publicData() {
+  get $publicData() {
     return this._kernel.publicData
   }
 
-  authorize(input?: any) {
+  $authorize(input?: any) {
     const e = new AuthenticationError()
-    Error.captureStackTrace(e, this.authorize)
+    Error.captureStackTrace(e, this.$authorize)
     if (!this.userId) throw e
 
-    if (!this.isAuthorized(input)) {
+    if (!this.$isAuthorized(input)) {
       const e = new AuthorizationError()
-      Error.captureStackTrace(e, this.authorize)
+      Error.captureStackTrace(e, this.$authorize)
       throw e
     }
   }
 
-  isAuthorized(input?: any) {
+  $isAuthorized(input?: any) {
     if (!this.userId) return false
 
     return config.isAuthorized(this.roles, input)
   }
 
-  async create(publicData: PublicData, privateData?: Record<any, any>) {
+  async $create(publicData: PublicData, privateData?: Record<any, any>) {
     this._kernel = await createNewSession(this._req, this._res, publicData, privateData, {
       jwtPayload: this._kernel.jwtPayload,
     })
   }
 
-  revoke() {
-    return revokeSession(this._req, this._res, this.handle)
+  $revoke() {
+    return revokeSession(this._req, this._res, this.$handle)
   }
 
-  async revokeAll() {
-    if (!this.publicData.userId) {
+  async $revokeAll() {
+    if (!this.$publicData.userId) {
       throw new Error("session.revokeAll() cannot be used with anonymous sessions")
     }
-    await revokeAllSessionsForUser(this._req, this._res, this.publicData.userId)
+    await revokeAllSessionsForUser(this._req, this._res, this.$publicData.userId)
     return
   }
 
-  async setPublicData(data: Record<any, any>) {
+  async $setPublicData(data: Record<any, any>) {
     if (this.userId && data.roles) {
       await updateAllPublicDataRolesForUser(this.userId, data.roles)
     }
     this._kernel.publicData = await setPublicData(this._req, this._res, this._kernel, data)
   }
 
-  async getPrivateData() {
-    return (await getPrivateData(this.handle)) || {}
+  async $getPrivateData() {
+    return (await getPrivateData(this.$handle)) || {}
   }
-  setPrivateData(data: Record<any, any>) {
+  $setPrivateData(data: Record<any, any>) {
     return setPrivateData(this._kernel, data)
   }
 }


### PR DESCRIPTION
### What are the changes and their implications?

Our `useSession` hook returns an object with all of the `publicData` properties on it like `session.customProp`. But on the server to access that you have to do `ctx.session.publicData.customProp` which is quite cumbersome and not consistent with the frontend.

So why not change this to be like Prisma client where custom things like `authorize()` are prefixed with `$` and then all publicData properties can be accessed at the top level.


```diff
-await ctx.session.authorize()
+await ctx.session.$authorize()

const userId = ctx.session.userId

-const orgId = ctx.session.publicData.orgId
+const orgId = ctx.session.orgId
```

What do you all think?

### Checklist

- [x] Tests added for changes
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
