### PR TITLE
Fix blitz/babel preset not passing options through to next/babel

### DIFF
--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-default-export
-export default function preset() {
+export default function preset(_api: any, options = {}) {
   return {
-    presets: [require('next/babel')],
+    presets: [[require('next/babel'), options]],
     plugins: [require('babel-plugin-superjson-next')],
   };
 }


### PR DESCRIPTION


### What are the changes and their implications?

Fix blitz/babel preset not passing options through to next/babel
