### PR TITLE
Fix `blitz generate` folder names to be kebab-case

### DIFF
--- a/packages/generator/src/generators/form-generator.ts
+++ b/packages/generator/src/generators/form-generator.ts
@@ -47,6 +47,7 @@ export class FormGenerator extends Generator<FormGeneratorOptions> {
 
   getTargetDirectory() {
     const context = this.options.context ? `${camelCaseToKebabCase(this.options.context)}/` : ""
-    return `app/${context}${this.options.modelNames}/components`
+    const kebabCaseModelName = camelCaseToKebabCase(this.options.modelNames)
+    return `app/${context}${kebabCaseModelName}/components`
   }
 }

--- a/packages/generator/src/generators/mutation-generator.ts
+++ b/packages/generator/src/generators/mutation-generator.ts
@@ -47,6 +47,7 @@ export class MutationGenerator extends Generator<MutationGeneratorOptions> {
 
   getTargetDirectory() {
     const context = this.options.context ? `${camelCaseToKebabCase(this.options.context)}/` : ""
-    return `app/${context}${this.options.modelNames}/mutations`
+    const kebabCaseModelName = camelCaseToKebabCase(this.options.modelNames)
+    return `app/${context}${kebabCaseModelName}/mutations`
   }
 }

--- a/packages/generator/src/generators/queries-generator.ts
+++ b/packages/generator/src/generators/queries-generator.ts
@@ -47,6 +47,7 @@ export class QueriesGenerator extends Generator<QueriesGeneratorOptions> {
 
   getTargetDirectory() {
     const context = this.options.context ? `${camelCaseToKebabCase(this.options.context)}/` : ""
-    return `app/${context}${this.options.modelNames}/queries`
+    const kebabCaseModelName = camelCaseToKebabCase(this.options.modelNames)
+    return `app/${context}${kebabCaseModelName}/queries`
   }
 }


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1784

### What are the changes and their implications?

"blitz generate" creates inconsistent folder names. Both camelCase and kebab-case folders are generated.
This migrate the rest of the generation to use kabeb-case

#### before:

`$ blitz g all fooBar`

```
CREATE    app/pages/foo-bars/[fooBarId]/edit.tsx
CREATE    app/pages/foo-bars/[fooBarId].tsx
CREATE    app/pages/foo-bars/index.tsx
CREATE    app/pages/foo-bars/new.tsx
CREATE    app/fooBars/components/FooBarForm.tsx
CREATE    app/fooBars/queries/getFooBar.ts
CREATE    app/fooBars/queries/getFooBars.ts
CREATE    app/fooBars/mutations/createFooBar.ts
CREATE    app/fooBars/mutations/deleteFooBar.ts
CREATE    app/fooBars/mutations/updateFooBar.ts
```

#### after:

`$ blitz g all fooBar`

```
CREATE    app/pages/foo-bars/[fooBarId].tsx
CREATE    app/pages/foo-bars/[fooBarId]/edit.tsx
CREATE    app/pages/foo-bars/index.tsx
CREATE    app/pages/foo-bars/new.tsx
CREATE    app/foo-bars/components/FooBarForm.tsx
CREATE    app/foo-bars/queries/getFooBar.ts
CREATE    app/foo-bars/queries/getFooBars.ts
CREATE    app/foo-bars/mutations/createFooBar.ts
CREATE    app/foo-bars/mutations/deleteFooBar.ts
CREATE    app/foo-bars/mutations/updateFooBar.ts
```

### Checklist

- [x] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
