### PR TITLE
Improvements to `isAuthorized`: (1) Ability to strongly type, (2) Change first arg to have `ctx`, (3) Allow multiple params, (4) add conditional `$authorize()`

### DIFF
--- a/examples/auth/app/users/queries/getUser.ts
+++ b/examples/auth/app/users/queries/getUser.ts
@@ -7,6 +7,7 @@ type GetUserInput = {
 
 export default async function getUser({where}: GetUserInput, ctx: Ctx) {
   ctx.session.$authorize()
+  ctx.session.$isAuthorized()
 
   const user = await db.user.findFirst({where})
 

--- a/examples/auth/app/users/queries/getUser.ts
+++ b/examples/auth/app/users/queries/getUser.ts
@@ -7,7 +7,6 @@ type GetUserInput = {
 
 export default async function getUser({where}: GetUserInput, ctx: Ctx) {
   ctx.session.$authorize()
-  ctx.session.$isAuthorized()
 
   const user = await db.user.findFirst({where})
 

--- a/examples/auth/types.ts
+++ b/examples/auth/types.ts
@@ -11,7 +11,7 @@ declare module "blitz" {
     userId: User["id"]
     views?: number
   }
-  export interface Authorization {
+  export interface Session {
     isAuthorized: typeof simpleRolesIsAuthorized
   }
 }

--- a/examples/auth/types.ts
+++ b/examples/auth/types.ts
@@ -1,5 +1,6 @@
-import {DefaultCtx, SessionContext, DefaultPublicData, DefaultAuthorize} from "blitz"
-// import {simpleRolesIsAuthorized} from "@blitzjs/server"
+import {DefaultCtx, SessionContext, DefaultPublicData} from "blitz"
+
+import {simpleRolesIsAuthorized} from "@blitzjs/server"
 import {User} from "db"
 
 declare module "blitz" {
@@ -10,8 +11,7 @@ declare module "blitz" {
     userId: User["id"]
     views?: number
   }
-  // export type IsAuthorized = typeof simpleRolesIsAuthorized
-  export interface Authorize extends DefaultAuthorize {
-    (roleOrRoles?: string | string[], options?: {if?: boolean}): boolean
+  export interface Authorization {
+    isAuthorized: typeof simpleRolesIsAuthorized
   }
 }

--- a/examples/auth/types.ts
+++ b/examples/auth/types.ts
@@ -1,5 +1,4 @@
 import {DefaultCtx, SessionContext, DefaultPublicData} from "blitz"
-
 import {simpleRolesIsAuthorized} from "@blitzjs/server"
 import {User} from "db"
 

--- a/examples/auth/types.ts
+++ b/examples/auth/types.ts
@@ -1,4 +1,5 @@
-import {DefaultCtx, SessionContext, DefaultPublicData} from "blitz"
+import {DefaultCtx, SessionContext, DefaultPublicData, DefaultAuthorize} from "blitz"
+// import {simpleRolesIsAuthorized} from "@blitzjs/server"
 import {User} from "db"
 
 declare module "blitz" {
@@ -8,5 +9,9 @@ declare module "blitz" {
   export interface PublicData extends DefaultPublicData {
     userId: User["id"]
     views?: number
+  }
+  // export type IsAuthorized = typeof simpleRolesIsAuthorized
+  export interface Authorize extends DefaultAuthorize {
+    (roleOrRoles?: string | string[], options?: {if?: boolean}): boolean
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "publish-danger": "lerna publish --canary --pre-dist-tag danger --preid danger.$(git rev-parse --short HEAD) --allow-branch * --force-publish",
     "danger:push-all": "git push --no-verify && git push --no-verify --tags"
   },
-  "resolutions": {},
+  "resolutions": {
+    "typescript": "4.1.3"
+  },
   "devDependencies": {
     "@rollup/pluginutils": "4.1.0",
     "@testing-library/jest-dom": "5.11.8",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export {
   SessionConfig, // new
   SessionContext,
   AuthenticatedSessionContext,
+  IsAuthorizedArgs,
 } from "./supertokens"
 
 export {SecurePassword, hash256, generateToken} from "./auth-utils"

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -1,5 +1,6 @@
 import {useState} from "react"
 import {COOKIE_CSRF_TOKEN} from "./constants"
+import {Ctx} from "./middleware"
 import {publicDataStore} from "./public-data-store"
 import {PublicData} from "./types"
 import {readCookie} from "./utils/cookie"
@@ -25,7 +26,7 @@ export type SessionConfig = {
   createSession: (session: SessionModel) => Promise<SessionModel>
   updateSession: (handle: string, session: Partial<SessionModel>) => Promise<SessionModel>
   deleteSession: (handle: string) => Promise<SessionModel>
-  isAuthorized: (userRoles: string[], input?: any) => boolean
+  isAuthorized: (ctx: Ctx, input?: any) => boolean
 }
 
 export interface SessionContextBase extends PublicData {
@@ -33,8 +34,6 @@ export interface SessionContextBase extends PublicData {
   $publicData: unknown
   $authorize(input?: any): asserts this is AuthenticatedSessionContext
   $isAuthorized(input?: any): boolean
-  // authorize: (roleOrRoles?: string | string[]) => void
-  // isAuthorized: (roleOrRoles?: string | string[]) => boolean
   $create: (publicData: PublicData, privateData?: Record<any, any>) => Promise<void>
   $revoke: () => Promise<void>
   $revokeAll: () => Promise<void>
@@ -74,46 +73,3 @@ export const useSession: () => PublicDataWithLoading = () => {
 
   return {...publicData, isLoading}
 }
-
-/*
- * This will ensure a user is logged in before using the query/mutation.
- * Optionally, as the second argument you can pass an array of roles
- * which will also be enforce.
- * Not logged in -> throw AuthenticationError
- * Role not matched -> throw AuthorizationError
- */
-// TODO - returned type should accept the ctx argument with `session`
-/*
- * DISABLING THIS FOR NOW - I think ctx.session.authorize is probably the best way
- */
-// export const authorize = <T extends (input: any, ctx?: any) => any>(
-//   resolverOrRoles: T | string[],
-//   maybeResolver?: T,
-// ) => {
-//   let resolver: T
-//   let roles: string[]
-//   if (Array.isArray(resolverOrRoles)) {
-//     roles = resolverOrRoles
-//     resolver = maybeResolver as T
-//   } else {
-//     roles = []
-//     resolver = resolverOrRoles
-//   }
-//
-//   assert(resolver, "You must pass a query or mutation resolver function to authorize()")
-//
-//   return ((input: any, ctx?: {session?: SessionContext}) => {
-//     if (!ctx?.session?.userId) throw new AuthenticationError()
-//
-//     // If user doesn't supply roles, then authorization is not checked
-//     if (roles.length) {
-//       let isAuthorized = false
-//       for (const role of roles) {
-//         if (ctx?.session?.roles.includes(role)) isAuthorized = true
-//       }
-//       if (!isAuthorized) throw new AuthorizationError()
-//     }
-//
-//     return resolver(input, ctx)
-//   }) as T
-// }

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -26,14 +26,16 @@ export type SessionConfig = {
   createSession: (session: SessionModel) => Promise<SessionModel>
   updateSession: (handle: string, session: Partial<SessionModel>) => Promise<SessionModel>
   deleteSession: (handle: string) => Promise<SessionModel>
-  isAuthorized: (data: {ctx: Ctx}, ...args: any[]) => boolean
+  isAuthorized: (data: {ctx: Ctx; args: any[]}) => boolean
 }
 
 export type IsAuthorizedArgs = "isAuthorized" extends keyof Session
-  ? Tail<Parameters<Session["isAuthorized"]>>
+  ? "args" extends keyof Parameters<Session["isAuthorized"]>[0]
+    ? Parameters<Session["isAuthorized"]>[0]["args"]
+    : unknown[]
   : unknown[]
 
-type Tail<L extends any[]> = L extends readonly [any, ...infer LTail] ? LTail : L
+// type Tail<L extends any[]> = L extends readonly [any, ...infer LTail] ? LTail : L
 
 export interface SessionContextBase extends PublicData {
   $handle: string | null

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -2,7 +2,7 @@ import {useState} from "react"
 import {COOKIE_CSRF_TOKEN} from "./constants"
 import {Ctx} from "./middleware"
 import {publicDataStore} from "./public-data-store"
-import {Authorization, PublicData} from "./types"
+import {PublicData, Session} from "./types"
 import {readCookie} from "./utils/cookie"
 import {useIsomorphicLayoutEffect} from "./utils/hooks"
 
@@ -29,8 +29,8 @@ export type SessionConfig = {
   isAuthorized: (data: {ctx: Ctx}, ...args: any[]) => boolean
 }
 
-export type IsAuthorizedArgs = "isAuthorized" extends keyof Authorization
-  ? Tail<Parameters<Authorization["isAuthorized"]>>
+export type IsAuthorizedArgs = "isAuthorized" extends keyof Session
+  ? Tail<Parameters<Session["isAuthorized"]>>
   : unknown[]
 
 type Tail<L extends any[]> = L extends readonly [any, ...infer LTail] ? LTail : L

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -35,8 +35,6 @@ export type IsAuthorizedArgs = "isAuthorized" extends keyof Session
     : unknown[]
   : unknown[]
 
-// type Tail<L extends any[]> = L extends readonly [any, ...infer LTail] ? LTail : L
-
 export interface SessionContextBase extends PublicData {
   $handle: string | null
   $publicData: unknown

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -2,7 +2,7 @@ import {useState} from "react"
 import {COOKIE_CSRF_TOKEN} from "./constants"
 import {Ctx} from "./middleware"
 import {publicDataStore} from "./public-data-store"
-import {PublicData} from "./types"
+import {Authorize, PublicData} from "./types"
 import {readCookie} from "./utils/cookie"
 import {useIsomorphicLayoutEffect} from "./utils/hooks"
 
@@ -26,14 +26,14 @@ export type SessionConfig = {
   createSession: (session: SessionModel) => Promise<SessionModel>
   updateSession: (handle: string, session: Partial<SessionModel>) => Promise<SessionModel>
   deleteSession: (handle: string) => Promise<SessionModel>
-  isAuthorized: (ctx: Ctx, input?: any) => boolean
+  isAuthorized: (data: {ctx: Ctx}, ...args: any[]) => boolean
 }
 
 export interface SessionContextBase extends PublicData {
   $handle: string | null
   $publicData: unknown
-  $authorize(input?: any): asserts this is AuthenticatedSessionContext
-  $isAuthorized(input?: any): boolean
+  $authorize(...args: Parameters<Authorize>): asserts this is AuthenticatedSessionContext
+  $isAuthorized: Authorize
   $create: (publicData: PublicData, privateData?: Record<any, any>) => Promise<void>
   $revoke: () => Promise<void>
   $revokeAll: () => Promise<void>

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -2,7 +2,7 @@ import {useState} from "react"
 import {COOKIE_CSRF_TOKEN} from "./constants"
 import {Ctx} from "./middleware"
 import {publicDataStore} from "./public-data-store"
-import {Authorize, PublicData} from "./types"
+import {Authorization, PublicData} from "./types"
 import {readCookie} from "./utils/cookie"
 import {useIsomorphicLayoutEffect} from "./utils/hooks"
 
@@ -29,11 +29,17 @@ export type SessionConfig = {
   isAuthorized: (data: {ctx: Ctx}, ...args: any[]) => boolean
 }
 
+export type IsAuthorizedArgs = "isAuthorized" extends keyof Authorization
+  ? Tail<Parameters<Authorization["isAuthorized"]>>
+  : unknown[]
+
+type Tail<L extends any[]> = L extends readonly [any, ...infer LTail] ? LTail : L
+
 export interface SessionContextBase extends PublicData {
   $handle: string | null
   $publicData: unknown
-  $authorize(...args: Parameters<Authorize>): asserts this is AuthenticatedSessionContext
-  $isAuthorized: Authorize
+  $authorize(...args: IsAuthorizedArgs): asserts this is AuthenticatedSessionContext
+  $isAuthorized: (...args: IsAuthorizedArgs) => this is AuthenticatedSessionContext
   $create: (publicData: PublicData, privateData?: Record<any, any>) => Promise<void>
   $revoke: () => Promise<void>
   $revokeAll: () => Promise<void>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,7 +37,7 @@ export interface DefaultPublicData {
 }
 export interface PublicData extends DefaultPublicData {}
 
-export interface Authorization {
+export interface Session {
   // isAuthorize can be injected here
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,10 +37,9 @@ export interface DefaultPublicData {
 }
 export interface PublicData extends DefaultPublicData {}
 
-export interface DefaultAuthorize {
-  (...args: any[]): any
+export interface Authorization {
+  // isAuthorize can be injected here
 }
-export interface Authorize extends DefaultAuthorize {}
 
 export interface MiddlewareRequest extends BlitzApiRequest {
   protocol?: string

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,8 +35,12 @@ export interface DefaultPublicData {
   userId: any
   roles: string[]
 }
-
 export interface PublicData extends DefaultPublicData {}
+
+export interface DefaultAuthorize {
+  (...args: any[]): any
+}
+export interface Authorize extends DefaultAuthorize {}
 
 export interface MiddlewareRequest extends BlitzApiRequest {
   protocol?: string

--- a/packages/generator/templates/app/types.ts
+++ b/packages/generator/templates/app/types.ts
@@ -1,4 +1,5 @@
 import { DefaultCtx, SessionContext, DefaultPublicData } from "blitz"
+import { simpleRolesIsAuthorized } from "@blitzjs/server"
 import { User } from "db"
 
 declare module "blitz" {
@@ -7,5 +8,8 @@ declare module "blitz" {
   }
   export interface PublicData extends DefaultPublicData {
     userId: User["id"]
+  }
+  export interface Session {
+    isAuthorized: typeof simpleRolesIsAuthorized
   }
 }

--- a/packages/server/src/supertokens.test.ts
+++ b/packages/server/src/supertokens.test.ts
@@ -165,7 +165,7 @@ async function mockServer<TInput, TResult>(
   const handler = rpcApiHandler(
     resolverModule,
     [
-      sessionMiddleware({isAuthorized: simpleRolesIsAuthorized, domain: "test"}),
+      sessionMiddleware({isAuthorized: simpleRolesIsAuthorized as any, domain: "test"}),
       ...(resolverModule.middleware || []),
     ],
     dbConnectorFn,

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -91,11 +91,15 @@ const defaultConfig: SessionConfig = {
   },
 }
 
-export function simpleRolesIsAuthorized(
-  {ctx}: any,
-  roleOrRoles?: string | string[],
-  {if: condition = true}: {if?: boolean} = {},
-) {
+type SimpleRolesIsAuthorizedArgs = {
+  ctx: any
+  args: [roleOrRoles?: string | string[], options?: {if?: boolean}]
+}
+
+export function simpleRolesIsAuthorized({ctx, args}: SimpleRolesIsAuthorizedArgs) {
+  const [roleOrRoles, options = {}] = args
+  const condition = options.if ?? true
+
   // No roles required, so all roles allowed
   if (!roleOrRoles) return true
   // Don't enforce the roles if condition is false
@@ -258,7 +262,7 @@ export class SessionContextClass implements SessionContext {
   $isAuthorized(...args: IsAuthorizedArgs) {
     if (!this.userId) return false
 
-    return config.isAuthorized({ctx: this._res.blitzCtx}, ...args)
+    return config.isAuthorized({ctx: this._res.blitzCtx, args})
   }
 
   async $create(publicData: PublicData, privateData?: Record<any, any>) {

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -18,6 +18,7 @@ import {
   HEADER_PUBLIC_DATA_TOKEN,
   HEADER_SESSION_CREATED,
   HEADER_SESSION_REVOKED,
+  IsAuthorizedArgs,
   isLocalhost,
   Middleware,
   MiddlewareResponse,
@@ -29,10 +30,9 @@ import {
   SessionContext,
   TOKEN_SEPARATOR,
 } from "@blitzjs/core"
+// Must import this type from 'blitz'
 import {log} from "@blitzjs/display"
 import {fromBase64, toBase64} from "b64-lite"
-// Must import this type from 'blitz'
-import {Authorize} from "blitz"
 import cookie from "cookie"
 import {addMinutes, addYears, differenceInMinutes, isPast} from "date-fns"
 import {IncomingMessage, ServerResponse} from "http"
@@ -243,7 +243,7 @@ export class SessionContextClass implements SessionContext {
     return this._kernel.publicData
   }
 
-  $authorize(...args: Parameters<Authorize>) {
+  $authorize(...args: IsAuthorizedArgs) {
     const e = new AuthenticationError()
     Error.captureStackTrace(e, this.$authorize)
     if (!this.userId) throw e
@@ -255,7 +255,7 @@ export class SessionContextClass implements SessionContext {
     }
   }
 
-  $isAuthorized(...args: Parameters<Authorize>) {
+  $isAuthorized(...args: IsAuthorizedArgs) {
     if (!this.userId) return false
 
     return config.isAuthorized({ctx: this._res.blitzCtx}, ...args)

--- a/yarn.lock
+++ b/yarn.lock
@@ -19118,15 +19118,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.1.3:
+typescript@4.1.3, typescript@^3.7.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
-
-typescript@^3.7.3:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 ua-parser-js@^0.7.22:
   version "0.7.23"


### PR DESCRIPTION
### What are the changes and their implications?

This

1. Adds ability to strongly type the input of `ctx.session.$authorize()` and `ctx.session.$isAuthorized()`
2. Changes `isAuthorized` signature to take a single object with `{ctx, args: []}`
3. Allows `isAuthorized` to accept multiple params like `ctx.session.$authorize('read', 'project')`
4. Add optional second `{if: boolean}` argument to the default `simpleRolesIsAuthorized` implementation.
   5. Enables this: `ctx.session.$authorize('admin', {if: id !== ctx.session.userId})`

### Checklist

- [ ] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
