### PR TITLE
inject isAuthorized args type

### DIFF
--- a/examples/auth/types.ts
+++ b/examples/auth/types.ts
@@ -1,5 +1,6 @@
-import {DefaultCtx, SessionContext, DefaultPublicData, DefaultAuthorize} from "blitz"
-// import {simpleRolesIsAuthorized} from "@blitzjs/server"
+import {DefaultCtx, SessionContext, DefaultPublicData} from "blitz"
+
+import {simpleRolesIsAuthorized} from "@blitzjs/server"
 import {User} from "db"
 
 declare module "blitz" {
@@ -10,8 +11,7 @@ declare module "blitz" {
     userId: User["id"]
     views?: number
   }
-  // export type IsAuthorized = typeof simpleRolesIsAuthorized
-  export interface Authorize extends DefaultAuthorize {
-    (roleOrRoles?: string | string[], options?: {if?: boolean}): boolean
+  export interface Authorization {
+    isAuthorized: typeof simpleRolesIsAuthorized
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "publish-danger": "lerna publish --canary --pre-dist-tag danger --preid danger.$(git rev-parse --short HEAD) --allow-branch * --force-publish",
     "danger:push-all": "git push --no-verify && git push --no-verify --tags"
   },
-  "resolutions": {},
+  "resolutions": {
+    "typescript": "4.1.3"
+  },
   "devDependencies": {
     "@rollup/pluginutils": "4.1.0",
     "@testing-library/jest-dom": "5.11.8",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export {
   SessionConfig, // new
   SessionContext,
   AuthenticatedSessionContext,
+  IsAuthorizedArgs,
 } from "./supertokens"
 
 export {SecurePassword, hash256, generateToken} from "./auth-utils"

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -2,7 +2,7 @@ import {useState} from "react"
 import {COOKIE_CSRF_TOKEN} from "./constants"
 import {Ctx} from "./middleware"
 import {publicDataStore} from "./public-data-store"
-import {Authorize, PublicData} from "./types"
+import {Authorization, PublicData} from "./types"
 import {readCookie} from "./utils/cookie"
 import {useIsomorphicLayoutEffect} from "./utils/hooks"
 
@@ -29,11 +29,17 @@ export type SessionConfig = {
   isAuthorized: (data: {ctx: Ctx}, ...args: any[]) => boolean
 }
 
+export type IsAuthorizedArgs = "isAuthorized" extends keyof Authorization
+  ? Tail<Parameters<Authorization["isAuthorized"]>>
+  : unknown[]
+
+type Tail<L extends any[]> = L extends readonly [any, ...infer LTail] ? LTail : L
+
 export interface SessionContextBase extends PublicData {
   $handle: string | null
   $publicData: unknown
-  $authorize(...args: Parameters<Authorize>): asserts this is AuthenticatedSessionContext
-  $isAuthorized: Authorize
+  $authorize(...args: IsAuthorizedArgs): asserts this is AuthenticatedSessionContext
+  $isAuthorized: (...args: IsAuthorizedArgs) => this is AuthenticatedSessionContext
   $create: (publicData: PublicData, privateData?: Record<any, any>) => Promise<void>
   $revoke: () => Promise<void>
   $revokeAll: () => Promise<void>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,10 +37,9 @@ export interface DefaultPublicData {
 }
 export interface PublicData extends DefaultPublicData {}
 
-export interface DefaultAuthorize {
-  (...args: any[]): any
+export interface Authorization {
+  // isAuthorize can be injected here
 }
-export interface Authorize extends DefaultAuthorize {}
 
 export interface MiddlewareRequest extends BlitzApiRequest {
   protocol?: string

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -18,6 +18,7 @@ import {
   HEADER_PUBLIC_DATA_TOKEN,
   HEADER_SESSION_CREATED,
   HEADER_SESSION_REVOKED,
+  IsAuthorizedArgs,
   isLocalhost,
   Middleware,
   MiddlewareResponse,
@@ -29,10 +30,9 @@ import {
   SessionContext,
   TOKEN_SEPARATOR,
 } from "@blitzjs/core"
+// Must import this type from 'blitz'
 import {log} from "@blitzjs/display"
 import {fromBase64, toBase64} from "b64-lite"
-// Must import this type from 'blitz'
-import {Authorize} from "blitz"
 import cookie from "cookie"
 import {addMinutes, addYears, differenceInMinutes, isPast} from "date-fns"
 import {IncomingMessage, ServerResponse} from "http"
@@ -243,7 +243,7 @@ export class SessionContextClass implements SessionContext {
     return this._kernel.publicData
   }
 
-  $authorize(...args: Parameters<Authorize>) {
+  $authorize(...args: IsAuthorizedArgs) {
     const e = new AuthenticationError()
     Error.captureStackTrace(e, this.$authorize)
     if (!this.userId) throw e
@@ -255,7 +255,7 @@ export class SessionContextClass implements SessionContext {
     }
   }
 
-  $isAuthorized(...args: Parameters<Authorize>) {
+  $isAuthorized(...args: IsAuthorizedArgs) {
     if (!this.userId) return false
 
     return config.isAuthorized({ctx: this._res.blitzCtx}, ...args)

--- a/yarn.lock
+++ b/yarn.lock
@@ -19118,15 +19118,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.1.3:
+typescript@4.1.3, typescript@^3.7.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
-
-typescript@^3.7.3:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 ua-parser-js@^0.7.22:
   version "0.7.23"


### PR DESCRIPTION
Closes: a twitter thread

### What are the changes and their implications?

A user can inject a type of `isAuthorized`:

```ts
declare module "blitz" {
  export interface Authorization {
    isAuthorized: typeof simpleRolesIsAuthorized
  }
}
```
which then will be used for parameters of `$authorize` and `$isAuthorized` omitting the first argument (`ctx`).

I had to set TypeScript 4.1 in resolutions to make `Tail` (variadic tuple) work (though it's possible to make it work in older TS versions using some hacks).

Limitations: it seems we lost parameter names on module boundaries (they display nicely as a named tuple when the code is in the same file). 
