### PR TITLE
Simplify type definition for `PublicData` (breaking change)

### DIFF
--- a/examples/auth/types.ts
+++ b/examples/auth/types.ts
@@ -8,7 +8,7 @@ declare module "blitz" {
   }
   export interface Session {
     isAuthorized: typeof simpleRolesIsAuthorized
-    publicData: {
+    PublicData: {
       userId: User["id"]
       roles: string[]
       views?: number

--- a/examples/auth/types.ts
+++ b/examples/auth/types.ts
@@ -1,4 +1,4 @@
-import {DefaultCtx, SessionContext, DefaultPublicData} from "blitz"
+import {DefaultCtx, SessionContext} from "blitz"
 import {simpleRolesIsAuthorized} from "@blitzjs/server"
 import {User} from "db"
 
@@ -6,11 +6,12 @@ declare module "blitz" {
   export interface Ctx extends DefaultCtx {
     session: SessionContext
   }
-  export interface PublicData extends DefaultPublicData {
-    userId: User["id"]
-    views?: number
-  }
   export interface Session {
     isAuthorized: typeof simpleRolesIsAuthorized
+    publicData: {
+      userId: User["id"]
+      roles: string[]
+      views?: number
+    }
   }
 }

--- a/examples/custom-server/types.ts
+++ b/examples/custom-server/types.ts
@@ -1,20 +1,16 @@
-import {DefaultCtx, SessionContext, DefaultPublicData} from "blitz"
+import {DefaultCtx, SessionContext} from "blitz"
+import {simpleRolesIsAuthorized} from "@blitzjs/server"
 import {User} from "db"
-import React from "react"
 
 declare module "blitz" {
   export interface Ctx extends DefaultCtx {
     session: SessionContext
   }
-  export interface PublicData extends DefaultPublicData {
-    userId: User["id"]
-  }
-}
-
-// This should not be needed. Usually it isn't but for some reason in this example it is
-declare module "react" {
-  interface StyleHTMLAttributes<T> extends React.HTMLAttributes<T> {
-    jsx?: boolean
-    global?: boolean
+  export interface Session {
+    isAuthorized: typeof simpleRolesIsAuthorized
+    publicData: {
+      userId: User["id"]
+      roles: string[]
+    }
   }
 }

--- a/examples/custom-server/types.ts
+++ b/examples/custom-server/types.ts
@@ -8,7 +8,7 @@ declare module "blitz" {
   }
   export interface Session {
     isAuthorized: typeof simpleRolesIsAuthorized
-    publicData: {
+    PublicData: {
       userId: User["id"]
       roles: string[]
     }

--- a/examples/custom-server/types.ts
+++ b/examples/custom-server/types.ts
@@ -1,6 +1,6 @@
 import {DefaultCtx, SessionContext} from "blitz"
 import {simpleRolesIsAuthorized} from "@blitzjs/server"
-import {User} from "db"
+import React from "react"
 
 declare module "blitz" {
   export interface Ctx extends DefaultCtx {
@@ -9,8 +9,16 @@ declare module "blitz" {
   export interface Session {
     isAuthorized: typeof simpleRolesIsAuthorized
     PublicData: {
-      userId: User["id"]
+      userId: number
       roles: string[]
     }
+  }
+}
+
+// This should not be needed. Usually it isn't but for some reason in this example it is
+declare module "react" {
+  interface StyleHTMLAttributes<T> extends React.HTMLAttributes<T> {
+    jsx?: boolean
+    global?: boolean
   }
 }

--- a/examples/fauna/types.ts
+++ b/examples/fauna/types.ts
@@ -1,11 +1,15 @@
-import { DefaultCtx, SessionContext, DefaultPublicData } from "blitz"
-import { User } from "db"
+import { DefaultCtx, SessionContext } from "blitz"
+import { simpleRolesIsAuthorized } from "@blitzjs/server"
 
 declare module "blitz" {
   export interface Ctx extends DefaultCtx {
     session: SessionContext
   }
-  export interface PublicData extends DefaultPublicData {
-    userId: User["id"]
+  export interface Session {
+    isAuthorized: typeof simpleRolesIsAuthorized
+    publicData: {
+      userId: string
+      roles: string[]
+    }
   }
 }

--- a/examples/fauna/types.ts
+++ b/examples/fauna/types.ts
@@ -7,7 +7,7 @@ declare module "blitz" {
   }
   export interface Session {
     isAuthorized: typeof simpleRolesIsAuthorized
-    publicData: {
+    PublicData: {
       userId: string
       roles: string[]
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,7 +31,6 @@ export {
   SessionConfig, // new
   SessionContext,
   AuthenticatedSessionContext,
-  IsAuthorizedArgs,
 } from "./supertokens"
 
 export {SecurePassword, hash256, generateToken} from "./auth-utils"

--- a/packages/core/src/public-data-store.ts
+++ b/packages/core/src/public-data-store.ts
@@ -6,7 +6,8 @@ import {parsePublicDataToken} from "./utils/tokens"
 
 class PublicDataStore {
   private eventKey = `${LOCALSTORAGE_PREFIX}publicDataUpdated`
-  readonly emptyPublicData: PublicData = {userId: null, roles: []}
+  // TODO remove `as any` after https://github.com/blitz-js/blitz/pull/1788 merged
+  readonly emptyPublicData: PublicData = {userId: null, roles: []} as any
   readonly observable = BadBehavior<PublicData>()
 
   constructor() {

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -2,7 +2,7 @@ import {useState} from "react"
 import {COOKIE_CSRF_TOKEN} from "./constants"
 import {Ctx} from "./middleware"
 import {publicDataStore} from "./public-data-store"
-import {PublicData, Session} from "./types"
+import {IsAuthorizedArgs, PublicData} from "./types"
 import {readCookie} from "./utils/cookie"
 import {useIsomorphicLayoutEffect} from "./utils/hooks"
 
@@ -28,12 +28,6 @@ export type SessionConfig = {
   deleteSession: (handle: string) => Promise<SessionModel>
   isAuthorized: (data: {ctx: Ctx; args: any[]}) => boolean
 }
-
-export type IsAuthorizedArgs = "isAuthorized" extends keyof Session
-  ? "args" extends keyof Parameters<Session["isAuthorized"]>[0]
-    ? Parameters<Session["isAuthorized"]>[0]["args"]
-    : unknown[]
-  : unknown[]
 
 export interface SessionContextBase extends PublicData {
   $handle: string | null

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,15 +31,18 @@ export interface BlitzRouter extends NextRouter {
   params: ReturnType<typeof useParams>
 }
 
-export interface DefaultPublicData {
-  userId: any
-  roles: string[]
-}
-export interface PublicData extends DefaultPublicData {}
-
 export interface Session {
-  // isAuthorize can be injected here
+  // isAuthorize can be injected here (see supertokens.ts)
+  // publicData can be injected here (see supertokens.ts)
 }
+
+export type PublicData = "publicData" extends keyof Session ? Session["publicData"] : {userId: any}
+
+export type IsAuthorizedArgs = "isAuthorized" extends keyof Session
+  ? "args" extends keyof Parameters<Session["isAuthorized"]>[0]
+    ? Parameters<Session["isAuthorized"]>[0]["args"]
+    : unknown[]
+  : unknown[]
 
 export interface MiddlewareRequest extends BlitzApiRequest {
   protocol?: string

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -33,10 +33,10 @@ export interface BlitzRouter extends NextRouter {
 
 export interface Session {
   // isAuthorize can be injected here (see supertokens.ts)
-  // publicData can be injected here (see supertokens.ts)
+  // PublicData can be injected here (see supertokens.ts)
 }
 
-export type PublicData = "publicData" extends keyof Session ? Session["publicData"] : {userId: any}
+export type PublicData = "PublicData" extends keyof Session ? Session["PublicData"] : {userId: any}
 
 export type IsAuthorizedArgs = "isAuthorized" extends keyof Session
   ? "args" extends keyof Parameters<Session["isAuthorized"]>[0]

--- a/packages/core/src/utils/tokens.test.ts
+++ b/packages/core/src/utils/tokens.test.ts
@@ -49,7 +49,7 @@ describe("supertokens", () => {
       const {result} = renderHook(() => useSession())
 
       act(() => {
-        publicDataStore.updateState({roles: ["foo"], userId: "bar"})
+        publicDataStore.updateState({roles: ["foo"], userId: "bar"} as any)
       })
 
       expect(result.current).toEqual({
@@ -59,7 +59,7 @@ describe("supertokens", () => {
       })
 
       act(() => {
-        publicDataStore.updateState({roles: ["baz"], userId: "boo"})
+        publicDataStore.updateState({roles: ["baz"], userId: "boo"} as any)
       })
 
       expect(result.current).toEqual({
@@ -73,7 +73,7 @@ describe("supertokens", () => {
       const {result, unmount} = renderHook(() => useSession())
 
       act(() => {
-        publicDataStore.updateState({roles: ["foo"], userId: "bar"})
+        publicDataStore.updateState({roles: ["foo"], userId: "bar"} as any)
       })
 
       act(() => {
@@ -81,7 +81,7 @@ describe("supertokens", () => {
       })
 
       act(() => {
-        publicDataStore.updateState({roles: ["baz"], userId: "boo"})
+        publicDataStore.updateState({roles: ["baz"], userId: "boo"} as any)
       })
 
       expect(result.current).toEqual({

--- a/packages/generator/templates/app/types.ts
+++ b/packages/generator/templates/app/types.ts
@@ -1,4 +1,4 @@
-import { DefaultCtx, SessionContext, DefaultPublicData } from "blitz"
+import { DefaultCtx, SessionContext } from "blitz"
 import { simpleRolesIsAuthorized } from "@blitzjs/server"
 import { User } from "db"
 
@@ -6,10 +6,11 @@ declare module "blitz" {
   export interface Ctx extends DefaultCtx {
     session: SessionContext
   }
-  export interface PublicData extends DefaultPublicData {
-    userId: User["id"]
-  }
   export interface Session {
+    publicData: {
+      userId: User["id"]
+      roles: string[]
+    }
     isAuthorized: typeof simpleRolesIsAuthorized
   }
 }

--- a/packages/generator/templates/app/types.ts
+++ b/packages/generator/templates/app/types.ts
@@ -7,10 +7,10 @@ declare module "blitz" {
     session: SessionContext
   }
   export interface Session {
+    isAuthorized: typeof simpleRolesIsAuthorized
     publicData: {
       userId: User["id"]
       roles: string[]
     }
-    isAuthorized: typeof simpleRolesIsAuthorized
   }
 }

--- a/packages/server/src/supertokens.test.ts
+++ b/packages/server/src/supertokens.test.ts
@@ -115,7 +115,7 @@ describe("supertokens", () => {
   it.skip("login works", async () => {
     // TODO - fix this test with a mock DB by passing custom config to sessionMiddleware
     const resolverModule = (async (_input: any, ctx: CtxWithSession) => {
-      await ctx.session.$create({userId: 1, roles: ["admin"]})
+      await ctx.session.$create({userId: 1, roles: ["admin"]} as any)
       return
     }) as EnhancedResolver<unknown, unknown>
 


### PR DESCRIPTION
### What are the changes and their implications?

This refactors and simplifies the type definition for `PublicData`. Here's the change you need to make in your app:

Notice 

```diff
-import { DefaultCtx, SessionContext, DefaultPublicData } from "blitz"
+import { DefaultCtx, SessionContext } from "blitz"
import { simpleRolesIsAuthorized } from "@blitzjs/server"
import { User } from "db"

declare module "blitz" {
  export interface Ctx extends DefaultCtx {
    session: SessionContext
  }
-  export interface PublicData extends DefaultPublicData {
-    userId: User["id"]
-  }
  export interface Session {
    isAuthorized: typeof simpleRolesIsAuthorized
+    PublicData: {
+      userId: User["id"]
+      roles: string[]  // NOTE: you now need to explicitly specify this field
+    }
  }
}
```

### Checklist

- [x] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
