### PR TITLE
Fix to properly handle http errors (no more `Failed to parse json from request to /api/users/queries/getCurrentUser`) (patch)

### DIFF
--- a/packages/core/src/rpc.ts
+++ b/packages/core/src/rpc.ts
@@ -100,7 +100,7 @@ export const executeRpcCall = <TInput, TResult>(
         }
       }
 
-      if (response.status < 200 || response.status >= 300) {
+      if (!response.ok) {
         const error = new Error(response.statusText)
         ;(error as any).statusCode = response.status
         ;(error as any).path = apiUrl

--- a/packages/core/src/rpc.ts
+++ b/packages/core/src/rpc.ts
@@ -130,7 +130,7 @@ export const executeRpcCall = <TInput, TResult>(
 
           throw error
         } else {
-          const data = deserialize({json: payload.response, meta: payload.meta?.response})
+          const data = deserialize({json: payload.result, meta: payload.meta?.result})
 
           if (!opts.fromQueryHook) {
             const queryKey = getQueryKeyFromUrlAndParams(apiUrl, params)

--- a/packages/core/test/rpc.test.ts
+++ b/packages/core/test/rpc.test.ts
@@ -10,7 +10,7 @@ declare global {
   }
 }
 
-global.fetch = jest.fn(() => Promise.resolve({json: () => ({result: null, error: null})}))
+global.fetch = jest.fn(() => Promise.resolve({ok: true, json: () => ({result: null, error: null})}))
 window.__BLITZ_DATA__ = getBlitzRuntimeData()
 
 describe("RPC", () => {
@@ -28,7 +28,7 @@ describe("RPC", () => {
       const fetchMock = jest
         .spyOn(global, "fetch")
         .mockImplementationOnce(() =>
-          Promise.resolve({json: () => ({result: "result", error: null})}),
+          Promise.resolve({ok: true, json: () => ({result: "result", error: null})}),
         )
 
       const resolverModule = {
@@ -57,6 +57,7 @@ describe("RPC", () => {
       const serializedError = serialize(error)
       const fetchMock = jest.spyOn(global, "fetch").mockImplementation(() =>
         Promise.resolve({
+          ok: true,
           json: () => ({
             result: null,
             error: serializedError.json,


### PR DESCRIPTION
### What are the changes and their implications?

I'm sure anyone running Blitz in production has seen a lot of errors like `Failed to parse json from request to /api/users/queries/getCurrentUser` that come from bad server responses when in fact the issue is not json parsing but an error from the server.

This fixes that and properly passes on the network error code to your react app.


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
