### PR TITLE
Fix `session.$isAuthorized` to not have assertion return type (patch)

### DIFF
--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -33,7 +33,9 @@ export interface SessionContextBase extends PublicData {
   $handle: string | null
   $publicData: unknown
   $authorize(...args: IsAuthorizedArgs): asserts this is AuthenticatedSessionContext
-  $isAuthorized: (...args: IsAuthorizedArgs) => this is AuthenticatedSessionContext
+  // $isAuthorized cannot have assertion return type because it breaks advanced use cases
+  // with multiple isAuthorized calls
+  $isAuthorized: (...args: IsAuthorizedArgs) => boolean
   $create: (publicData: PublicData, privateData?: Record<any, any>) => Promise<void>
   $revoke: () => Promise<void>
   $revokeAll: () => Promise<void>


### PR DESCRIPTION
### What are the changes and their implications?

Fix `session.$isAuthorized` to not have assertion return type which breaks advanced uses

