### PR TITLE
Fix new app and `blitz generate` templates to use new `session.$` prefix (patch)

### DIFF
--- a/packages/generator/templates/app/app/auth/mutations/changePassword.ts
+++ b/packages/generator/templates/app/app/auth/mutations/changePassword.ts
@@ -4,7 +4,7 @@ import { authenticateUser } from "./login"
 import { ChangePasswordInput, ChangePasswordInputType } from "../validations"
 
 export default async function changePassword(input: ChangePasswordInputType, ctx: Ctx) {
-  ctx.session.authorize()
+  ctx.session.$authorize()
   const { currentPassword, newPassword } = ChangePasswordInput.parse(input)
 
   const user = await db.user.findFirst({ where: { id: ctx.session.userId } })

--- a/packages/generator/templates/app/app/auth/mutations/login.ts
+++ b/packages/generator/templates/app/app/auth/mutations/login.ts
@@ -25,7 +25,7 @@ export default async function login(input: LoginInputType, ctx: Ctx) {
   // This throws an error if credentials are invalid
   const user = await authenticateUser(email, password)
 
-  await ctx.session.create({ userId: user.id, roles: [user.role] })
+  await ctx.session.$create({ userId: user.id, roles: [user.role] })
 
   return user
 }

--- a/packages/generator/templates/app/app/auth/mutations/logout.ts
+++ b/packages/generator/templates/app/app/auth/mutations/logout.ts
@@ -1,5 +1,5 @@
 import { Ctx } from "blitz"
 
 export default async function logout(_: any, ctx: Ctx) {
-  return await ctx.session.revoke()
+  return await ctx.session.$revoke()
 }

--- a/packages/generator/templates/app/app/auth/mutations/signup.ts
+++ b/packages/generator/templates/app/app/auth/mutations/signup.ts
@@ -12,7 +12,7 @@ export default async function signup(input: SignupInputType, ctx: Ctx) {
     select: { id: true, name: true, email: true, role: true },
   })
 
-  await ctx.session.create({ userId: user.id, roles: [user.role] })
+  await ctx.session.$create({ userId: user.id, roles: [user.role] })
 
   return user
 }

--- a/packages/generator/templates/app/test/setup.ts
+++ b/packages/generator/templates/app/test/setup.ts
@@ -1,2 +1,4 @@
 // This is the jest 'setupFilesAfterEnv' setup file
 // It's a good place to set globals, add global before/after hooks, etc
+
+export {} // so TS doesn't complain

--- a/packages/generator/templates/mutation/create__ModelName__.ts
+++ b/packages/generator/templates/mutation/create__ModelName__.ts
@@ -15,7 +15,7 @@ if (process.env.parentModel) {
     {data, __parentModelId__}: Create__ModelName__Input,
     ctx: Ctx,
   ) {
-    ctx.session.authorize()
+    ctx.session.$authorize()
 
     const __modelName__ = await db.__modelName__.create({
       data: {...data, __parentModel__: {connect: {id: __parentModelId__}}},
@@ -25,7 +25,7 @@ if (process.env.parentModel) {
   }
 } else {
   export default async function create__ModelName__({data}: Create__ModelName__Input, ctx: Ctx) {
-    ctx.session.authorize()
+    ctx.session.$authorize()
 
     const __modelName__ = await db.__modelName__.create({data})
 

--- a/packages/generator/templates/mutation/delete__ModelName__.ts
+++ b/packages/generator/templates/mutation/delete__ModelName__.ts
@@ -4,7 +4,7 @@ import db, {Prisma} from "db"
 type Delete__ModelName__Input = Pick<Prisma.__ModelName__DeleteArgs, "where">
 
 export default async function delete__ModelName__({where}: Delete__ModelName__Input, ctx: Ctx) {
-  ctx.session.authorize()
+  ctx.session.$authorize()
 
   const __modelName__ = await db.__modelName__.delete({where})
 

--- a/packages/generator/templates/mutation/update__ModelName__.ts
+++ b/packages/generator/templates/mutation/update__ModelName__.ts
@@ -15,7 +15,7 @@ export default async function update__ModelName__(
   {where, data}: Update__ModelName__Input,
   ctx: Ctx,
 ) {
-  ctx.session.authorize()
+  ctx.session.$authorize()
 
   if (process.env.parentModel) {
     // Don't allow updating

--- a/packages/generator/templates/queries/get__ModelName__.ts
+++ b/packages/generator/templates/queries/get__ModelName__.ts
@@ -4,7 +4,7 @@ import db, {Prisma} from "db"
 type Get__ModelName__Input = Pick<Prisma.__ModelName__FindFirstArgs, "where">
 
 export default async function get__ModelName__({where}: Get__ModelName__Input, ctx: Ctx) {
-  ctx.session.authorize()
+  ctx.session.$authorize()
 
   const __modelName__ = await db.__modelName__.findFirst({where})
 

--- a/packages/generator/templates/queries/get__ModelNames__.ts
+++ b/packages/generator/templates/queries/get__ModelNames__.ts
@@ -10,7 +10,7 @@ export default async function get__ModelNames__(
   {where, orderBy, skip = 0, take}: Get__ModelNames__Input,
   ctx: Ctx,
 ) {
-  ctx.session.authorize()
+  ctx.session.$authorize()
 
   const __modelNames__ = await db.__modelName__.findMany({
     where,

--- a/packages/generator/templates/query/__rawInput__.ts
+++ b/packages/generator/templates/query/__rawInput__.ts
@@ -2,7 +2,7 @@ import {Ctx} from "blitz"
 import db from "db"
 
 export default async function __rawInput__(input, ctx: Ctx) {
-  ctx.session.authorize()
+  ctx.session.$authorize()
 
   // Do your stuff :)
 


### PR DESCRIPTION


### What are the changes and their implications?

Fix `blitz generate` templates to use new `session.$authorize()` name 

