### PR TITLE
Fix type of resolver.pipe when one of the pipe functions returns a promise

### DIFF
--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -1,8 +1,9 @@
 import {infer as zInfer, ZodSchema} from "zod"
 import {Ctx} from "./middleware"
 import {SessionContext, SessionContextBase} from "./supertokens"
+import {Await} from "./types"
 
-type PipeFn<Prev, Next> = (i: Prev, c: Ctx) => Next
+type PipeFn<Prev, Next> = (i: Await<Prev>, c: Ctx) => Next
 
 function pipe<A, Z>(ab: (i: A, c: Ctx) => Z): (input: A, ctx: Ctx) => Z
 function pipe<A, B, C>(ab: PipeFn<A, B>, bc: PipeFn<B, C>): (input: A, ctx: Ctx) => C

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -75,14 +75,14 @@ export type Middleware = (
 export type FirstParam<F extends QueryFn> = Parameters<F>[0]
 
 /**
- * Get the type of the value, that the Promise holds.
+ * If type has a Promise, unwrap it. Otherwise return the original type
  */
-export type PromiseType<T extends PromiseLike<any>> = T extends PromiseLike<infer U> ? U : T
+export type Await<T> = T extends PromiseLike<infer U> ? U : T
 
 /**
  * Get the return type of a function which returns a Promise.
  */
-export type PromiseReturnType<T extends (...args: any) => Promise<any>> = PromiseType<ReturnType<T>>
+export type PromiseReturnType<T extends (...args: any) => Promise<any>> = Await<ReturnType<T>>
 
 export interface CancellablePromise<T> extends Promise<T> {
   cancel?: Function


### PR DESCRIPTION
Closes: https://discord.com/channels/802917734999523368/802989361401430036/804752811132190802

### What are the changes and their implications?

Fix type of resolver.pipe when one of the pipe functions returns a promise
