### PR TITLE
Fix broken API routes because of babel-plugin-superjson-next bug (patch)

### DIFF
--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -36,6 +36,6 @@
     }
   ],
   "dependencies": {
-    "babel-plugin-superjson-next": "0.1.11"
+    "babel-plugin-superjson-next": "0.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5030,10 +5030,10 @@ babel-plugin-polyfill-regenerator@^0.0.4:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.0.3"
 
-babel-plugin-superjson-next@0.1.11:
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/babel-plugin-superjson-next/-/babel-plugin-superjson-next-0.1.11.tgz#03ee814a6cbf70af6e2cc26b0ff58c875963879b"
-  integrity sha512-FSjhm4eHnygleUjBwGpCzIWDodmFsMKHDlWBTimSMgMmyOw+6xKIUrQCjE3Ly4Qi0FdE2IUyypMt7UsUiemkXA==
+babel-plugin-superjson-next@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-superjson-next/-/babel-plugin-superjson-next-0.2.1.tgz#7a5834c78807e36820a326f4f5d8d02f5a06ee8a"
+  integrity sha512-6vBq2p2mFSa8Kq0AXtJ+3un+lkEymxHjpshk0J3Rx7klYBPiIUbfSw8ekwtinFcHOe+KnLpckOzrYEssD7XT1w==
   dependencies:
     "@babel/helper-module-imports" "^7.12.5"
     hoist-non-react-statics "^3.3.2"


### PR DESCRIPTION


### What are the changes and their implications?

Fix broken API routes because of babel-plugin-superjson-next bug: https://github.com/blitz-js/babel-plugin-superjson-next/pull/37

Related: https://github.com/blitz-js/blitz/issues/1819

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
