### PR TITLE
Remove `resolver.authorizeIf` AND remove second options arg to `session.$authorize()` (major)

### DIFF
--- a/examples/auth/app/projects/mutations/createProject.ts
+++ b/examples/auth/app/projects/mutations/createProject.ts
@@ -10,7 +10,6 @@ export const CreateProject = z.object({
 export default resolver.pipe(
   resolver.zod(CreateProject),
   resolver.authorize(),
-  resolver.authorizeIf((input, ctx) => input.name === ctx.session.roles[0], "admin"),
   // How to set a default input value
   (input, _ctx) => ({dueDate: new Date(), ...input}),
   async (input, _ctx) => {

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -192,16 +192,4 @@ export const resolver = {
       return input
     }
   },
-  authorizeIf<T>(
-    conditionCallback: (input: T, ctx: Ctx) => boolean,
-    ...args: Parameters<SessionContextBase["$authorize"]>
-  ) {
-    return function (input: T, ctx: any) {
-      const session: SessionContext = ctx.session
-      if (conditionCallback(input, ctx)) {
-        session.$authorize(...args)
-      }
-      return input
-    }
-  },
 }

--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -93,12 +93,11 @@ const defaultConfig: SessionConfig = {
 
 type SimpleRolesIsAuthorizedArgs = {
   ctx: any
-  args: [roleOrRoles?: string | string[], options?: {if?: boolean}]
+  args: [roleOrRoles?: string | string[]]
 }
 
 export function simpleRolesIsAuthorized({ctx, args}: SimpleRolesIsAuthorizedArgs) {
-  const [roleOrRoles, options = {}] = args
-  const condition = options.if ?? true
+  const [roleOrRoles] = args
   const $publicData = (ctx.session as SessionContext).$publicData
   const publicData = $publicData as typeof $publicData & {roles: unknown}
   if (!("roles" in publicData)) {
@@ -110,8 +109,6 @@ export function simpleRolesIsAuthorized({ctx, args}: SimpleRolesIsAuthorizedArgs
 
   // No roles required, so all roles allowed
   if (!roleOrRoles) return true
-  // Don't enforce the roles if condition is false
-  if (!condition) return true
 
   const rolesToAuthorize = []
   if (Array.isArray(roleOrRoles)) {


### PR DESCRIPTION
Closes https://discord.com/channels/802917734999523368/802993959164444693/804756866487812167

### What are the changes and their implications?

- Remove `resolver.authorizeIf` 
- Remove second options arg to `session.$authorize()` (`{if: boolean}`)


These were too confusing to folks. Additionally I found that in practice I wasn't even using `resolver.authorizeIf` because I wrapped it in a utility function instead.

Code from my app:

```ts
// Utility
export const enforceAdminIfNotCurrentOrganization = <T extends Record<any, any>>(
  input: T,
  ctx: Ctx
): T => {
  if (!ctx.session.orgId) throw new Error("missing session.orgId")
  if (!input.organizationId) throw new Error("missing input.organizationId")
  if (input.organizationId !== ctx.session.orgId) {
    ctx.session.$authorize("admin")
  }
  return input
}


export default resolver.pipe(
  resolver.zod(GetTestResult),
  resolver.authorize(),
  enforceAdminIfNotCurrentOrganization,
  async ({ id, organizationId }) => {
    const testResult = await db.testResult.findFirst({
      where: { id, organizationId },
    })
    if (!testResult) throw new NotFoundError()
    return testResult as TestResult
  }
)
```


### Checklist

- [x] Tests added for changes
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
