### PR TITLE
fix `db.$reset()` error "cached plan must not change result type" (patch)

### DIFF
--- a/packages/core/src/prisma-utils.ts
+++ b/packages/core/src/prisma-utils.ts
@@ -27,13 +27,13 @@ export const enhancePrisma = <TPrismaClientCtor extends Constructor>(
       if (!global._blitz_prismaClient) {
         const client = new target(...args)
 
-        client.$reset = function reset() {
+        client.$reset = async function reset() {
           if (process.env.NODE_ENV === "production") {
             throw new Error(
               "You are calling db.$reset() in a production environment. We think you probably didn't mean to do that, so we are throwing this error instead of destroying your life's work.",
             )
           }
-          return new Promise<void>((res, rej) =>
+          await new Promise<void>((res, rej) =>
             exec("prisma migrate reset --force --skip-generate --preview-feature", function (err) {
               if (err) {
                 rej(err)
@@ -42,6 +42,7 @@ export const enhancePrisma = <TPrismaClientCtor extends Constructor>(
               }
             }),
           )
+          global._blitz_prismaClient.$disconnect()
         }
 
         global._blitz_prismaClient = client


### PR DESCRIPTION
### What are the changes and their implications?

Fixes the following issue when using `db.$reset()` in tests.

```ts
PASS app/auth/mutations/resetPassword.test.ts (5.103 s)
19:24:32.052 DEBUG forgotPassword.ts No user found, no email sent 
FAIL app/auth/mutations/forgotPassword.test.ts
  ● forgotPassword mutation › works correctly


    Invalid `prisma.user.findFirst()` invocation:


      Error occurred during query execution:
    ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Error { kind: Db, cause: Some(DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState("0A000"), message: "cached plan must not change result type", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("plancache.c"), line: Some(718), routine: Some("RevalidateCachedQuery") }) }) })

      at PrismaClientFetcher.request (node_modules/@prisma/client/runtime/index.js:78459:15)
```

### Checklist

- [x] Changes covered by tests (tests added if needed)
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
