### PR TITLE
(newapp) Add legacy-peer-deps to `.npmrc` for npm v7 compatibility

### DIFF
--- a/packages/generator/templates/app/.npmrc
+++ b/packages/generator/templates/app/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+legacy-peer-deps=true


### PR DESCRIPTION
Closes: #1856

### What are the changes and their implications?
add legacy-peer-deps for npm v7 compatibility 


### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
