### PR TITLE
fix: enable resolver.authorize to accept Ctx

### DIFF
--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -275,7 +275,7 @@ interface ResolverAuthorize {
   (...args: Parameters<SessionContextBase["$authorize"]>): <T, C>(
     input: T,
     ctx: C,
-  ) => ResultWithContext<T, AuthenticatedMiddlewareCtx>
+  ) => ResultWithContext<T, AuthenticatedMiddlewareCtx | Ctx>
 }
 
 const authorize: ResolverAuthorize = (...args) => {


### PR DESCRIPTION
resolver.authorize should accept a standard `Ctx` in addition to `AuthenticatedMiddlewareCtx`. This is useful for testing purposes.

Closes: N/A

### What are the changes and their implications?

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
