### PR TITLE
change jest-preset to use `.server.test.ts` instead of `.test.server.ts` (ignore)

### DIFF
--- a/examples/auth/cypress/integration/index.test.ts
+++ b/examples/auth/cypress/integration/index.test.ts
@@ -29,6 +29,7 @@ describe("index page", () => {
 
     cy.signup(user)
 
+    cy.wait(500)
     cy.contains("button", "Logout").click()
     cy.contains("a", /login/i).click()
 
@@ -37,6 +38,7 @@ describe("index page", () => {
     cy.contains("button", /login/i).click()
 
     cy.location("pathname").should("equal", "/")
+    cy.wait(500)
     cy.contains("button", "Logout")
   })
 

--- a/packages/blitz/jest-preset.js
+++ b/packages/blitz/jest-preset.js
@@ -54,8 +54,7 @@ module.exports = {
         color: "cyan",
       },
       testEnvironment: "jest-environment-jsdom-fourteen",
-      // prettier-ignore
-      testRegex: ["^((?!queries|mutations|api|\.server\.).)*\.(test|spec)\.(j|t)sx?$"],
+      testRegex: ["^((?!queries|mutations|api|\\.server\\.).)*\\.(test|spec)\\.(j|t)sx?$"],
       setupFilesAfterEnv: [
         path.resolve(__dirname, "./jest-preset/client/setup-after-env.js"),
         "<rootDir>/test/setup.ts",
@@ -70,10 +69,8 @@ module.exports = {
       },
       testEnvironment: "node",
       testRegex: [
-        // prettier-ignore
-        "\.server\.(spec|test)\.(j|t)sx?$",
-        // prettier-ignore
-        "[\\/](queries|mutations|api)[\\/].*\.(test|spec)\.(j|t)sx?$",
+        "\\.server\\.(spec|test)\\.(j|t)sx?$",
+        "[\\/](queries|mutations|api)[\\/].*\\.(test|spec)\\.(j|t)sx?$",
       ],
       setupFilesAfterEnv: [
         path.resolve(__dirname, "./jest-preset/server/setup-after-env.js"),

--- a/packages/blitz/jest-preset.js
+++ b/packages/blitz/jest-preset.js
@@ -54,7 +54,8 @@ module.exports = {
         color: "cyan",
       },
       testEnvironment: "jest-environment-jsdom-fourteen",
-      testRegex: ["^((?!queries|mutations|api).)*/*(test|spec).(j|t)sx?$"],
+      // prettier-ignore
+      testRegex: ["^((?!queries|mutations|api|\.server\.).)*\.(test|spec)\.(j|t)sx?$"],
       setupFilesAfterEnv: [
         path.resolve(__dirname, "./jest-preset/client/setup-after-env.js"),
         "<rootDir>/test/setup.ts",
@@ -69,8 +70,10 @@ module.exports = {
       },
       testEnvironment: "node",
       testRegex: [
-        "(spec|test).server.(j|t)sx?$",
-        ".*/(queries|mutations|api)/.*(test|spec).(j|t)sx?$",
+        // prettier-ignore
+        "\.server\.(spec|test)\.(j|t)sx?$",
+        // prettier-ignore
+        "[\\/](queries|mutations|api)[\\/].*\.(test|spec)\.(j|t)sx?$",
       ],
       setupFilesAfterEnv: [
         path.resolve(__dirname, "./jest-preset/server/setup-after-env.js"),


### PR DESCRIPTION
### What are the changes and their implications?

change jest-preset to use `.server.test.ts` instead of `.test.server.ts`

This is because server components will add files like `app.server.tsx` and we want to test those by just adding test, so `app.server.test.tsx`

### Checklist

- [x] Changes covered by tests (tests added if needed)
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
