### PR TITLE
Automatically prompt to run `prisma migrate` after `blitz generate` (minor)

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -64,11 +64,11 @@ function ModelNames(input: string = "") {
 
 const generatorMap = {
   [ResourceType.All]: [
-    ModelGenerator,
     PageGenerator,
     FormGenerator,
     QueriesGenerator,
     MutationsGenerator,
+    ModelGenerator,
   ],
   [ResourceType.Crud]: [MutationsGenerator, QueriesGenerator],
   [ResourceType.Model]: [ModelGenerator],
@@ -77,7 +77,7 @@ const generatorMap = {
   [ResourceType.Query]: [QueryGenerator],
   [ResourceType.Mutations]: [MutationsGenerator],
   [ResourceType.Mutation]: [MutationGenerator],
-  [ResourceType.Resource]: [ModelGenerator, QueriesGenerator, MutationsGenerator],
+  [ResourceType.Resource]: [QueriesGenerator, MutationsGenerator, ModelGenerator],
 }
 
 export class Generate extends Command {

--- a/packages/display/src/index.ts
+++ b/packages/display/src/index.ts
@@ -54,7 +54,7 @@ const withX = (str: string) => {
 }
 
 const withProgress = (str: string) => {
-  return withCaret(c.bold(str))
+  return withCaret(str)
 }
 
 /**
@@ -110,7 +110,7 @@ const meta = (msg: string) => {
  * @param {string} msg
  */
 const progress = (msg: string) => {
-  console.log(withCaret(c.bold(msg)))
+  console.log(withProgress(msg))
 }
 
 const info = (msg: string) => {

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -44,6 +44,7 @@
     "enquirer": "2.3.6",
     "fs-extra": "^9.1.0",
     "fs-readdir-recursive": "1.1.0",
+    "npm-run": "^5.0.1",
     "got": "^11.8.1",
     "jscodeshift": "0.11.0",
     "mem-fs": "1.2.0",

--- a/packages/generator/templates/app/app/pages/index.tsx
+++ b/packages/generator/templates/app/app/pages/index.tsx
@@ -73,9 +73,7 @@ const Home: BlitzPage = () => {
         <pre>
           <code>blitz generate all project name:string</code>
         </pre>
-        <pre>
-          <code>blitz prisma migrate dev --preview-feature</code>
-        </pre>
+        <div style={{ marginBottom: "1rem" }}>(And select Yes to run prisma migrate)</div>
         <div>
           <p>
             Then <strong>restart the server</strong>


### PR DESCRIPTION
Closes: #1868

### What are the changes and their implications?

Adds a prompt to automatically run Prisma migrations when running `blitz generate`.

<img width="932" alt="Screen Shot 2021-02-08 at 10 36 35 PM" src="https://user-images.githubusercontent.com/2454632/107312427-6510c500-6a5e-11eb-9ba6-b39604bbec77.png">


### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
