### PR TITLE
Fix `useSession` return type to have `userId: number | null`

### DIFF
--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -58,6 +58,7 @@ export interface AuthenticatedSessionContext extends SessionContextBase {
 export const getAntiCSRFToken = () => readCookie(COOKIE_CSRF_TOKEN())
 
 export interface PublicDataWithLoading extends PublicData {
+  userId: PublicData["userId"] | null
   isLoading: boolean
 }
 


### PR DESCRIPTION
Closes: #1891 

### What are the changes and their implications?

This PR updates the return type of the `useSession` hook to contain `userId` being `number | null` as suggested in the discussion of #1891 by @flybayer.

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
