### PR TITLE
(newapp) fix react-hook-form reset password page

### DIFF
--- a/packages/generator/templates/app/app/auth/pages/reset-password.tsx
+++ b/packages/generator/templates/app/app/auth/pages/reset-password.tsx
@@ -23,11 +23,11 @@ const ResetPasswordPage: BlitzPage = () => {
       ) : (
         <Form
           submitText="Reset Password"
-          schema={ResetPassword}
-          initialValues={{ password: "", passwordConfirmation: "", token: query.token as string }}
+          schema={ResetPassword.omit({ token: true })}
+          initialValues={{ password: "", passwordConfirmation: "" }}
           onSubmit={async (values) => {
             try {
-              await resetPasswordMutation(values)
+              await resetPasswordMutation({ ...values, token: query.token })
             } catch (error) {
               if (error.name === "ResetPasswordError") {
                 return {


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1884

### What are the changes and their implications?

fix react-hook-form reset password page


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
