### PR TITLE
Change `blitz generate` default syntax from `default[value]` to `default=value`

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -140,11 +140,11 @@ export class Generate extends Command {
 # will generate the proper database model for a Task.`)}
 > blitz generate model task \\
     name:string \\
-    completed:boolean:default[false] \\
+    completed:boolean:default=false \\
     belongsTo:project?
 > blitz generate all tasks \\
     name:string \\
-    completed:boolean:default[false] \\
+    completed:boolean:default=false \\
     belongsTo:project?
     `,
     `${chalk.dim(`# Sometimes you want just a single query with no generated

--- a/packages/generator/src/prisma/field.ts
+++ b/packages/generator/src/prisma/field.ts
@@ -35,7 +35,7 @@ const fallbackIfUndef = <T extends any>(defaultValue: T, input?: T) => {
   return input
 }
 
-const defaultValueTest = /\[([\w]+)\]/
+const defaultValueTest = /=([\w]+)$/
 const builtInGenerators = ["autoincrement", "now", "uuid", "cuid"]
 
 class MissingFieldNameError extends Error {}

--- a/packages/generator/test/prisma/field.test.ts
+++ b/packages/generator/test/prisma/field.test.ts
@@ -30,16 +30,16 @@ describe("Field model", () => {
   })
 
   it("handles single default attribute", () => {
-    expect(Field.parse("isActive:boolean:default[true]").toString()).toMatchInlineSnapshot(
+    expect(Field.parse("isActive:boolean:default=true").toString()).toMatchInlineSnapshot(
       `"isActive  Boolean  @default(true)"`,
     )
   })
 
   it("handles built-in default attribute", () => {
-    expect(Field.parse("id:string:default[uuid]").toString()).toMatchInlineSnapshot(
+    expect(Field.parse("id:string:default=uuid").toString()).toMatchInlineSnapshot(
       `"id  String  @default(uuid())"`,
     )
-    expect(Field.parse("id:int:default[autoincrement]"))
+    expect(Field.parse("id:int:default=autoincrement"))
   })
 
   it("has default field type", () => {


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/724

### What are the changes and their implications?

Change `blitz generate` default syntax from `default[value]` to `default=value`

### Checklist

- [x] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
