### PR TITLE
Automatically clear console on `blitz dev` (can disable with `cli.clearConsoleOnBlitzDev = false` in blitz.config.js

### DIFF
--- a/packages/blitz/jest-preset/server/setup-after-env.js
+++ b/packages/blitz/jest-preset/server/setup-after-env.js
@@ -1,5 +1,7 @@
 require("@testing-library/jest-dom")
 
+jest.setTimeout(10000)
+
 afterAll(async () => {
   try {
     await global._blitz_prismaClient.$disconnect()

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,6 +1,4 @@
-import {log} from "@blitzjs/display"
 import {ServerConfig} from "@blitzjs/server"
-import {getConfig} from "@blitzjs/config"
 import {Command, flags} from "@oclif/command"
 
 export class Dev extends Command {
@@ -39,9 +37,11 @@ export class Dev extends Command {
 
     try {
       const dev = (await import("@blitzjs/server")).dev
+      const {getConfig} = await import("@blitzjs/config")
 
       const blitzConfig = getConfig()
       if (blitzConfig.cli?.clearConsoleOnBlitzDev !== false) {
+        const {log} = await import("@blitzjs/display")
         log.clearConsole()
       }
 

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -22,6 +22,9 @@ export class Dev extends Command {
     ["no-incremental-build"]: flags.boolean({
       description: "Disable incremental build and start from a fresh cache",
     }),
+    ["no-clear-console"]: flags.boolean({
+      description: "Prevent console clearing",
+    }),
   }
 
   async run() {
@@ -38,7 +41,9 @@ export class Dev extends Command {
 
     try {
       const dev = (await import("@blitzjs/server")).dev
-      log.clearConsole()
+
+      if (!flags["no-clear-console"]) log.clearConsole()
+
       await dev(config)
     } catch (err) {
       console.error(err)

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,5 +1,6 @@
 import {log} from "@blitzjs/display"
 import {ServerConfig} from "@blitzjs/server"
+import {getConfig} from "@blitzjs/config"
 import {Command, flags} from "@oclif/command"
 
 export class Dev extends Command {
@@ -22,9 +23,6 @@ export class Dev extends Command {
     ["no-incremental-build"]: flags.boolean({
       description: "Disable incremental build and start from a fresh cache",
     }),
-    ["no-clear-console"]: flags.boolean({
-      description: "Prevent console clearing",
-    }),
   }
 
   async run() {
@@ -42,7 +40,10 @@ export class Dev extends Command {
     try {
       const dev = (await import("@blitzjs/server")).dev
 
-      if (!flags["no-clear-console"]) log.clearConsole()
+      const blitzConfig = getConfig()
+      if (blitzConfig.cli?.clearConsoleOnBlitzDev !== false) {
+        log.clearConsole()
+      }
 
       await dev(config)
     } catch (err) {

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,3 +1,4 @@
+import {log} from "@blitzjs/display"
 import {ServerConfig} from "@blitzjs/server"
 import {Command, flags} from "@oclif/command"
 
@@ -37,6 +38,7 @@ export class Dev extends Command {
 
     try {
       const dev = (await import("@blitzjs/server")).dev
+      log.clearConsole()
       await dev(config)
     } catch (err) {
       console.error(err)

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,4 +1,3 @@
-import {log} from "@blitzjs/display"
 import {ServerConfig} from "@blitzjs/server"
 import {Command, flags} from "@oclif/command"
 
@@ -35,7 +34,6 @@ export class Start extends Command {
 
     try {
       const prod = (await import("@blitzjs/server")).prod
-      log.clearConsole()
       await prod(config)
     } catch (err) {
       console.error(err)

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,3 +1,4 @@
+import {log} from "@blitzjs/display"
 import {ServerConfig} from "@blitzjs/server"
 import {Command, flags} from "@oclif/command"
 
@@ -34,6 +35,7 @@ export class Start extends Command {
 
     try {
       const prod = (await import("@blitzjs/server")).prod
+      log.clearConsole()
       await prod(config)
     } catch (err) {
       console.error(err)

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -27,6 +27,9 @@ export interface BlitzConfig extends Record<string, unknown> {
     isomorphicResolverImports?: boolean
     reactMode?: string
   }
+  cli?: {
+    clearConsoleOnBlitzDev?: boolean
+  }
   _meta: {
     packageName: string
   }

--- a/packages/display/src/index.ts
+++ b/packages/display/src/index.ts
@@ -77,6 +77,14 @@ const clearLine = (msg?: string) => {
   msg && process.stdout.write(msg)
 }
 
+const clearConsole = () => {
+  if (process.platform === "win32") {
+    process.stdout.write("\x1B[2J\x1B[0f")
+  } else {
+    process.stdout.write("\x1B[2J\x1B[3J\x1B[H")
+  }
+}
+
 /**
  * Logs a red error message to stderr.
  *
@@ -212,6 +220,7 @@ export const log = {
   withProgress,
   branded,
   clearLine,
+  clearConsole,
   error,
   warning,
   meta,


### PR DESCRIPTION
### What are the changes and their implications?

Like Snowpack, the console will be cleaned when `blitz dev` ~~or `blitz start` are~~ is run. This should be a QoL feature for the developers.

### Checklist

- [x] Changes covered by tests (tests added if needed)
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
