### PR TITLE
add `useAuthenticatedSession()` hook and fix publicData types for authenticated sessions

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,11 +28,14 @@ export {
 export {
   getAntiCSRFToken,
   useSession,
+  useAuthorizedSession,
   useAuthorize,
   useRedirectAuthenticated,
-  SessionConfig, // new
+  SessionConfig,
   SessionContext,
   AuthenticatedSessionContext,
+  ClientSessionContext,
+  AuthorizedClientSessionContext,
 } from "./supertokens"
 
 export {SecurePassword, hash256, generateToken} from "./auth-utils"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,14 +28,14 @@ export {
 export {
   getAntiCSRFToken,
   useSession,
-  useAuthorizedSession,
+  useAuthenticatedSession,
   useAuthorize,
   useRedirectAuthenticated,
   SessionConfig,
   SessionContext,
   AuthenticatedSessionContext,
-  ClientSessionContext,
-  AuthorizedClientSessionContext,
+  ClientSession,
+  AuthenticatedClientSession,
 } from "./supertokens"
 
 export {SecurePassword, hash256, generateToken} from "./auth-utils"

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -60,12 +60,12 @@ export interface AuthenticatedSessionContext extends SessionContextBase, PublicD
 
 export const getAntiCSRFToken = () => readCookie(COOKIE_CSRF_TOKEN())
 
-export interface ClientSessionContext extends Partial<PublicData> {
+export interface ClientSession extends Partial<PublicData> {
   userId: PublicData["userId"] | null
   isLoading: boolean
 }
 
-export interface AuthorizedClientSessionContext extends PublicData {
+export interface AuthenticatedClientSession extends PublicData {
   isLoading: boolean
 }
 
@@ -74,10 +74,10 @@ interface UseSessionOptions {
   suspense?: boolean
 }
 
-export const useSession = (options: UseSessionOptions = {}): ClientSessionContext => {
+export const useSession = (options: UseSessionOptions = {}): ClientSession => {
   const suspense = options?.suspense ?? getBlitzRuntimeData().suspenseEnabled
 
-  let initialState: ClientSessionContext
+  let initialState: ClientSession
   if (options.initialPublicData) {
     initialState = {...options.initialPublicData, isLoading: false}
   } else if (suspense) {
@@ -104,9 +104,9 @@ export const useSession = (options: UseSessionOptions = {}): ClientSessionContex
   return session
 }
 
-export const useAuthorizedSession = (
+export const useAuthenticatedSession = (
   options: UseSessionOptions = {},
-): AuthorizedClientSessionContext => {
+): AuthenticatedClientSession => {
   useAuthorize()
   return useSession(options)
 }


### PR DESCRIPTION


### What are the changes and their implications?

- Adds `useAuthenticatedSession()` hook which throws `AuthenticationError` if not logged in and has `PublicData` return type instead of `Partial<PublicData>` type like `useSession` has
- Fixes `AuthenticatedSessionContext` type on the server to extend `PublicData` instead of `Partial<PublicData>`

### Checklist

- [x] Changes covered by tests (tests added if needed)
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
