### PR TITLE
Fix type of `options` for useQuery hooks

### DIFF
--- a/packages/core/src/use-query-hooks.ts
+++ b/packages/core/src/use-query-hooks.ts
@@ -25,6 +25,7 @@ type QueryNonLazyOptions =
   | {suspense: true; enabled?: never}
   | {suspense?: never; enabled: true}
   | {suspense: true; enabled: true}
+  | {suspense?: never; enabled?: never}
 
 // -------------------------
 // useQuery

--- a/packages/core/test/use-query.test.tsx
+++ b/packages/core/test/use-query.test.tsx
@@ -74,6 +74,11 @@ describe("useQuery", () => {
       expect(() => setupHook("test", upcase)).toThrowErrorMatchingSnapshot()
     })
   })
+
+  // it("works with options other than enabled & suspense without type error", () => {
+  //   const queryFn = ((() => true) as unknown) as () => Promise<boolean>
+  //   useQuery(queryFn, undefined, {refetchInterval: 10000})
+  // })
 })
 
 describe("useInfiniteQuery", () => {


### PR DESCRIPTION


### What are the changes and their implications?

Fix type of `options` for useQuery hooks


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
