### PR TITLE
Fix to accept the previous, misspelled anti-csrf cookie for seamless transition for existing apps

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -14,6 +14,10 @@ export const COOKIE_SESSION_TOKEN = () =>
 export const COOKIE_REFRESH_TOKEN = () =>
   `${getBlitzRuntimeData().sessionCookiePrefix}_sIdRefreshToken`
 export const COOKIE_CSRF_TOKEN = () => `${getBlitzRuntimeData().sessionCookiePrefix}_sAntiCsrfToken`
+// TODO remove before 1.0 -
+// This is here for legacy compatability (misspelling)
+export const COOKIE_LEGACY_CSRF_TOKEN = () =>
+  `${getBlitzRuntimeData().sessionCookiePrefix}_sAntiCrfToken`
 export const COOKIE_PUBLIC_DATA_TOKEN = () =>
   `${getBlitzRuntimeData().sessionCookiePrefix}_sPublicDataToken`
 

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -1,4 +1,5 @@
 import {useEffect, useState} from "react"
+import {COOKIE_LEGACY_CSRF_TOKEN} from "."
 import {getBlitzRuntimeData} from "./blitz-data"
 import {COOKIE_CSRF_TOKEN} from "./constants"
 import {AuthenticationError} from "./errors"
@@ -58,7 +59,8 @@ export interface AuthenticatedSessionContext extends SessionContextBase, PublicD
   $publicData: PublicData
 }
 
-export const getAntiCSRFToken = () => readCookie(COOKIE_CSRF_TOKEN())
+export const getAntiCSRFToken = () =>
+  readCookie(COOKIE_CSRF_TOKEN()) || readCookie(COOKIE_LEGACY_CSRF_TOKEN())
 
 export interface ClientSession extends Partial<PublicData> {
   userId: PublicData["userId"] | null

--- a/packages/core/src/supertokens.ts
+++ b/packages/core/src/supertokens.ts
@@ -1,7 +1,6 @@
 import {useEffect, useState} from "react"
-import {COOKIE_LEGACY_CSRF_TOKEN} from "."
 import {getBlitzRuntimeData} from "./blitz-data"
-import {COOKIE_CSRF_TOKEN} from "./constants"
+import {COOKIE_CSRF_TOKEN, COOKIE_LEGACY_CSRF_TOKEN} from "./constants"
 import {AuthenticationError} from "./errors"
 import {Ctx} from "./middleware"
 import {publicDataStore} from "./public-data-store"


### PR DESCRIPTION


### What are the changes and their implications?

Fix to accept the previous, misspelled anti-csrf cookie to allow a seamless transition for existing apps.


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
