### PR TITLE
Fix error `name` fields not being sent to the client

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,6 +1,6 @@
 import SuperJson from "superjson"
 
-const errorProps = ["message", "code", "meta"]
+const errorProps = ["name", "message", "code", "meta"]
 if (process.env.JEST_WORKER_ID === undefined) {
   SuperJson.allowErrorProps(...errorProps)
 }


### PR DESCRIPTION


### What are the changes and their implications?

Fix error `name` fields not being sent to the client