### PR TITLE
Fix query cache being deleted on login instead of being invalidated

### DIFF
--- a/examples/auth/cypress/integration/index.test.ts
+++ b/examples/auth/cypress/integration/index.test.ts
@@ -19,6 +19,7 @@ describe("index page", () => {
     const user = createRandomUser()
 
     cy.signup(user)
+    cy.wait(500)
 
     cy.location("pathname").should("equal", "/")
     cy.contains("button", "Logout")
@@ -28,8 +29,8 @@ describe("index page", () => {
     const user = createRandomUser()
 
     cy.signup(user)
-
     cy.wait(500)
+
     cy.contains("button", "Logout").click()
     cy.contains("a", /login/i).click()
 
@@ -46,6 +47,7 @@ describe("index page", () => {
     const user = createRandomUser()
 
     cy.signup(user)
+    cy.wait(500)
 
     cy.contains("button", "Logout").click()
 
@@ -63,6 +65,7 @@ describe("index page", () => {
     cy.contains('"views": 2')
 
     cy.signup(user)
+    cy.wait(500)
 
     cy.contains('"views": 2')
   })

--- a/packages/core/src/rpc.ts
+++ b/packages/core/src/rpc.ts
@@ -91,7 +91,7 @@ export const executeRpcCall = <TInput, TResult>(
         }
         if (response.headers.get(HEADER_SESSION_CREATED)) {
           clientDebug("Session created")
-          queryCache.clear()
+          await queryCache.invalidateQueries("")
         }
         if (response.headers.get(HEADER_CSRF_ERROR)) {
           const err = new CSRFTokenMismatchError()


### PR DESCRIPTION


### What are the changes and their implications?

Fix query cache being deleted on login instead of being invalidated
