### PR TITLE
change `blitz generate` delete mutation to use `db.deleteMany` instead of `db.delete` (minor)

### DIFF
--- a/packages/generator/templates/mutations/delete__ModelName__.ts
+++ b/packages/generator/templates/mutations/delete__ModelName__.ts
@@ -11,7 +11,7 @@ export default resolver.pipe(
   resolver.authorize(),
   async ({id}) => {
     // TODO: in multi-tenant app, you must add validation to ensure correct tenant
-    const __modelName__ = await db.__modelName__.delete({where: {id}})
+    const __modelName__ = await db.__modelName__.deleteMany({where: {id}})
 
     return __modelName__
   },


### PR DESCRIPTION

### What are the changes and their implications?

change `blitz generate` delete mutation to use `db.deleteMany` instead of `db.delete`.

Because this is usually what you will use so you can scope the delete by other attributes.



<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
