### PR TITLE
remove all unneeded imports of `React` from templates (patch)

### DIFF
--- a/examples/auth/test/utils.tsx
+++ b/examples/auth/test/utils.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import {RouterContext, BlitzRouter} from "blitz"
 import {render as defaultRender} from "@testing-library/react"
 import {renderHook as defaultRenderHook} from "@testing-library/react-hooks"

--- a/packages/generator/templates/app/_forms/finalform/Form.tsx
+++ b/packages/generator/templates/app/_forms/finalform/Form.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, PropsWithoutRef } from "react"
+import { ReactNode, PropsWithoutRef } from "react"
 import { Form as FinalForm, FormProps as FinalFormProps } from "react-final-form"
 import * as z from "zod"
 export { FORM_ERROR } from "final-form"

--- a/packages/generator/templates/app/_forms/finalform/LabeledTextField.tsx
+++ b/packages/generator/templates/app/_forms/finalform/LabeledTextField.tsx
@@ -1,5 +1,5 @@
-import React, {PropsWithoutRef} from "react"
-import {useField} from "react-final-form"
+import { forwardRef, PropsWithoutRef } from "react"
+import { useField } from "react-final-form"
 
 export interface LabeledTextFieldProps extends PropsWithoutRef<JSX.IntrinsicElements["input"]> {
   /** Field name. */
@@ -11,13 +11,13 @@ export interface LabeledTextFieldProps extends PropsWithoutRef<JSX.IntrinsicElem
   outerProps?: PropsWithoutRef<JSX.IntrinsicElements["div"]>
 }
 
-export const LabeledTextField = React.forwardRef<HTMLInputElement, LabeledTextFieldProps>(
-  ({name, label, outerProps, ...props}, ref) => {
+export const LabeledTextField = forwardRef<HTMLInputElement, LabeledTextFieldProps>(
+  ({ name, label, outerProps, ...props }, ref) => {
     const {
       input,
-      meta: {touched, error, submitError, submitting},
+      meta: { touched, error, submitError, submitting },
     } = useField(name, {
-      parse: props.type === "number" ? Number : undefined
+      parse: props.type === "number" ? Number : undefined,
     })
 
     const normalizedError = Array.isArray(error) ? error.join(", ") : error || submitError
@@ -30,7 +30,7 @@ export const LabeledTextField = React.forwardRef<HTMLInputElement, LabeledTextFi
         </label>
 
         {touched && normalizedError && (
-          <div role="alert" style={{color: "red"}}>
+          <div role="alert" style={{ color: "red" }}>
             {normalizedError}
           </div>
         )}
@@ -53,7 +53,7 @@ export const LabeledTextField = React.forwardRef<HTMLInputElement, LabeledTextFi
         `}</style>
       </div>
     )
-  },
+  }
 )
 
 export default LabeledTextField

--- a/packages/generator/templates/app/_forms/formik/Form.tsx
+++ b/packages/generator/templates/app/_forms/formik/Form.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactNode, PropsWithoutRef } from "react"
+import { useState, ReactNode, PropsWithoutRef } from "react"
 import { Formik, FormikProps } from "formik"
 import * as z from "zod"
 

--- a/packages/generator/templates/app/_forms/formik/LabeledTextField.tsx
+++ b/packages/generator/templates/app/_forms/formik/LabeledTextField.tsx
@@ -1,57 +1,55 @@
-import React, { PropsWithoutRef } from "react";
-import { useField, useFormikContext, ErrorMessage } from "formik";
+import { forwardRef, PropsWithoutRef } from "react"
+import { useField, useFormikContext, ErrorMessage } from "formik"
 
-export interface LabeledTextFieldProps
-  extends PropsWithoutRef<JSX.IntrinsicElements["input"]> {
+export interface LabeledTextFieldProps extends PropsWithoutRef<JSX.IntrinsicElements["input"]> {
   /** Field name. */
-  name: string;
+  name: string
   /** Field label. */
-  label: string;
+  label: string
   /** Field type. Doesn't include radio buttons and checkboxes */
-  type?: "text" | "password" | "email" | "number";
-  outerProps?: PropsWithoutRef<JSX.IntrinsicElements["div"]>;
+  type?: "text" | "password" | "email" | "number"
+  outerProps?: PropsWithoutRef<JSX.IntrinsicElements["div"]>
 }
 
-export const LabeledTextField = React.forwardRef<
-  HTMLInputElement,
-  LabeledTextFieldProps
->(({ name, label, outerProps, ...props }, ref) => {
-  const [input] = useField(name);
-  const { isSubmitting } = useFormikContext();
+export const LabeledTextField = forwardRef<HTMLInputElement, LabeledTextFieldProps>(
+  ({ name, label, outerProps, ...props }, ref) => {
+    const [input] = useField(name)
+    const { isSubmitting } = useFormikContext()
 
-  return (
-    <div {...outerProps}>
-      <label>
-        {label}
-        <input {...input} disabled={isSubmitting} {...props} ref={ref} />
-      </label>
+    return (
+      <div {...outerProps}>
+        <label>
+          {label}
+          <input {...input} disabled={isSubmitting} {...props} ref={ref} />
+        </label>
 
-      <ErrorMessage name={name}>
-        {(msg) => (
-          <div role="alert" style={{ color: "red" }}>
-            {msg}
-          </div>
-        )}
-      </ErrorMessage>
+        <ErrorMessage name={name}>
+          {(msg) => (
+            <div role="alert" style={{ color: "red" }}>
+              {msg}
+            </div>
+          )}
+        </ErrorMessage>
 
-      <style jsx>{`
-        label {
-          display: flex;
-          flex-direction: column;
-          align-items: start;
-          font-size: 1rem;
-        }
-        input {
-          font-size: 1rem;
-          padding: 0.25rem 0.5rem;
-          border-radius: 3px;
-          border: 1px solid purple;
-          appearance: none;
-          margin-top: 0.5rem;
-        }
-      `}</style>
-    </div>
-  );
-});
+        <style jsx>{`
+          label {
+            display: flex;
+            flex-direction: column;
+            align-items: start;
+            font-size: 1rem;
+          }
+          input {
+            font-size: 1rem;
+            padding: 0.25rem 0.5rem;
+            border-radius: 3px;
+            border: 1px solid purple;
+            appearance: none;
+            margin-top: 0.5rem;
+          }
+        `}</style>
+      </div>
+    )
+  }
+)
 
-export default LabeledTextField;
+export default LabeledTextField

--- a/packages/generator/templates/app/_forms/hookform/Form.tsx
+++ b/packages/generator/templates/app/_forms/hookform/Form.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactNode, PropsWithoutRef } from "react"
+import { useState, ReactNode, PropsWithoutRef } from "react"
 import { FormProvider, useForm, UseFormOptions } from "react-hook-form"
 import * as z from "zod"
 

--- a/packages/generator/templates/app/_forms/hookform/LabeledTextField.tsx
+++ b/packages/generator/templates/app/_forms/hookform/LabeledTextField.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithoutRef } from "react"
+import { forwardRef, PropsWithoutRef } from "react"
 import { useFormContext } from "react-hook-form"
 
 export interface LabeledTextFieldProps extends PropsWithoutRef<JSX.IntrinsicElements["input"]> {
@@ -11,7 +11,7 @@ export interface LabeledTextFieldProps extends PropsWithoutRef<JSX.IntrinsicElem
   outerProps?: PropsWithoutRef<JSX.IntrinsicElements["div"]>
 }
 
-export const LabeledTextField = React.forwardRef<HTMLInputElement, LabeledTextFieldProps>(
+export const LabeledTextField = forwardRef<HTMLInputElement, LabeledTextFieldProps>(
   ({ label, outerProps, ...props }, ref) => {
     const {
       register,

--- a/packages/generator/templates/app/app/auth/components/LoginForm.tsx
+++ b/packages/generator/templates/app/app/auth/components/LoginForm.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { AuthenticationError, Link, useMutation } from "blitz"
 import { LabeledTextField } from "app/core/components/LabeledTextField"
 import { Form, FORM_ERROR } from "app/core/components/Form"

--- a/packages/generator/templates/app/app/auth/components/SignupForm.tsx
+++ b/packages/generator/templates/app/app/auth/components/SignupForm.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { useMutation } from "blitz"
 import { LabeledTextField } from "app/core/components/LabeledTextField"
 import { Form, FORM_ERROR } from "app/core/components/Form"

--- a/packages/generator/templates/app/app/auth/pages/login.tsx
+++ b/packages/generator/templates/app/app/auth/pages/login.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { useRouter, BlitzPage } from "blitz"
 import Layout from "app/core/layouts/Layout"
 import { LoginForm } from "app/auth/components/LoginForm"

--- a/packages/generator/templates/app/app/auth/pages/signup.tsx
+++ b/packages/generator/templates/app/app/auth/pages/signup.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { useRouter, BlitzPage } from "blitz"
 import Layout from "app/core/layouts/Layout"
 import { SignupForm } from "app/auth/components/SignupForm"

--- a/packages/generator/templates/app/app/pages/index.test.tsx
+++ b/packages/generator/templates/app/app/pages/index.test.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { render } from "test/utils"
 
 import Home from "./index"

--- a/packages/generator/templates/app/test/utils.tsx
+++ b/packages/generator/templates/app/test/utils.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { RouterContext, BlitzRouter } from "blitz"
 import { render as defaultRender } from "@testing-library/react"
 import { renderHook as defaultRenderHook } from "@testing-library/react-hooks"


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1921

### What are the changes and their implications?

remove all unneeded imports of `React` from templates 

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
