### PR TITLE
(newapp) remove `browserslist` from package.json because it only affects CSS

### DIFF
--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -10,9 +10,6 @@
     "test": "jest",
     "test:watch": "jest --watch"
   },
-  "browserslist": [
-    "defaults"
-  ],
   "prisma": {
     "schema": "db/schema.prisma"
   },


### PR DESCRIPTION


### What are the changes and their implications?

remove `browserslist` from new app package.json because it only affects CSS and most people won't need to use it.