### PR TITLE
fix `error.statusCode` missing in frontend (patch)

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,6 +1,6 @@
 import SuperJson from "superjson"
 
-const errorProps = ["name", "message", "code", "meta"]
+const errorProps = ["name", "message", "code", "statusCode", "meta"]
 if (process.env.JEST_WORKER_ID === undefined) {
   SuperJson.allowErrorProps(...errorProps)
 }


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1980

### What are the changes and their implications?

fix `error.statusCode` missing in frontend (patch)
