### PR TITLE
Fix `blitz install` when using npm (patch)

### DIFF
--- a/packages/installer/src/executors/add-dependency-executor.tsx
+++ b/packages/installer/src/executors/add-dependency-executor.tsx
@@ -81,10 +81,12 @@ export function getPackageManager() {
  */
 export async function installPackages(packages: NpmPackage[], isDev = false) {
   const packageManager = getPackageManager()
-  const args: string[] = ["add"]
+  const isNPM = packageManager === "npm"
+  const pkgInstallArg = isNPM ? "install" : "add"
+  const args: string[] = [pkgInstallArg]
 
   if (isDev) {
-    args.push(packageManager === "yarn" ? "-D" : "--save-dev")
+    args.push(isNPM ? "--save-dev" : "-D")
   }
   packages.forEach((pkg) => {
     pkg.version ? args.push(`${pkg.name}@${pkg.version}`) : args.push(pkg.name)

--- a/packages/installer/src/executors/add-dependency-executor.tsx
+++ b/packages/installer/src/executors/add-dependency-executor.tsx
@@ -70,10 +70,10 @@ const DependencyList = ({
  * Exported for unit testing purposes
  */
 export function getPackageManager() {
-  if (fs.existsSync(path.resolve("package-lock.json"))) {
-    return "npm"
+  if (fs.existsSync(path.resolve("yarn.lock"))) {
+    return "yarn"
   }
-  return "yarn"
+  return "npm"
 }
 
 /**

--- a/packages/installer/test/executors/add-dependency-executor.test.ts
+++ b/packages/installer/test/executors/add-dependency-executor.test.ts
@@ -27,9 +27,9 @@ describe("add dependency executor", () => {
   })
 
   it("should choose proper package manager according to lock file", () => {
-    mocked(existsSync).mockReturnValueOnce(false)
-    expect(AddDependencyExecutor.getPackageManager()).toEqual("npm")
+    mocked(existsSync).mockReturnValueOnce(true)
     expect(AddDependencyExecutor.getPackageManager()).toEqual("yarn")
+    expect(AddDependencyExecutor.getPackageManager()).toEqual("npm")
   })
 
   it("should issue proper commands according to the specified packages", async () => {

--- a/packages/installer/test/executors/add-dependency-executor.test.ts
+++ b/packages/installer/test/executors/add-dependency-executor.test.ts
@@ -27,7 +27,7 @@ describe("add dependency executor", () => {
   })
 
   it("should choose proper package manager according to lock file", () => {
-    mocked(existsSync).mockReturnValueOnce(true)
+    mocked(existsSync).mockReturnValueOnce(false)
     expect(AddDependencyExecutor.getPackageManager()).toEqual("npm")
     expect(AddDependencyExecutor.getPackageManager()).toEqual("yarn")
   })
@@ -37,12 +37,12 @@ describe("add dependency executor", () => {
     mocked(spawn).mockImplementation(mockedSpawn.spawn as any)
 
     // NPM
-    mocked(existsSync).mockReturnValue(true)
+    mocked(existsSync).mockReturnValue(false)
     await AddDependencyExecutor.installPackages(testConfiguration.packages, true)
     await AddDependencyExecutor.installPackages(testConfiguration.packages, false)
 
     // Yarn
-    mocked(existsSync).mockReturnValue(false)
+    mocked(existsSync).mockReturnValue(true)
     await AddDependencyExecutor.installPackages(testConfiguration.packages, true)
     await AddDependencyExecutor.installPackages(testConfiguration.packages, false)
 

--- a/packages/installer/test/executors/add-dependency-executor.test.ts
+++ b/packages/installer/test/executors/add-dependency-executor.test.ts
@@ -47,8 +47,8 @@ describe("add dependency executor", () => {
     await AddDependencyExecutor.installPackages(testConfiguration.packages, false)
 
     expect(mockedSpawn.calls.length).toEqual(4)
-    expect(mockedSpawn.calls[0]).toEqual("npm add --save-dev typescript@4 ts-node")
-    expect(mockedSpawn.calls[1]).toEqual("npm add typescript@4 ts-node")
+    expect(mockedSpawn.calls[0]).toEqual("npm install --save-dev typescript@4 ts-node")
+    expect(mockedSpawn.calls[1]).toEqual("npm install typescript@4 ts-node")
     expect(mockedSpawn.calls[2]).toEqual("yarn add -D typescript@4 ts-node")
     expect(mockedSpawn.calls[3]).toEqual("yarn add typescript@4 ts-node")
   })


### PR DESCRIPTION
Closes: #1953

### What are the changes and their implications?

When installing any recipe via npm as the default package manager, then it will pass `install` instead of `add` which is for yarn.


### Checklist

- [x] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
