### PR TITLE
typescript support for module css

### DIFF
--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -48,7 +48,7 @@
     "preview-email": "3.x",
     "prettier-plugin-prisma": "0.x",
     "typescript": "4.x",
-    "typescript-plugin-css-modules": "^3.x",
+    "typescript-plugin-css-modules": "^3.x"
   },
   "private": true
 }

--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -47,7 +47,8 @@
     "prettier": "2.x",
     "pretty-quick": "3.x",
     "preview-email": "3.x",
-    "prettier-plugin-prisma": "0.x"
+    "prettier-plugin-prisma": "0.x",
+    "typescript-plugin-css-modules": "^3.x",
   },
   "private": true
 }

--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -35,7 +35,6 @@
     "react": "0.0.0-experimental-3310209d0",
     "react-dom": "0.0.0-experimental-3310209d0",
     "react-error-boundary": "3.x",
-    "typescript": "4.x",
     "zod": "1.x"
   },
   "devDependencies": {
@@ -48,6 +47,7 @@
     "pretty-quick": "3.x",
     "preview-email": "3.x",
     "prettier-plugin-prisma": "0.x",
+    "typescript": "4.x",
     "typescript-plugin-css-modules": "^3.x",
   },
   "private": true

--- a/packages/generator/templates/app/tsconfig.json
+++ b/packages/generator/templates/app/tsconfig.json
@@ -16,7 +16,16 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "tsBuildInfoFile": ".tsbuildinfo"
+    "tsBuildInfoFile": ".tsbuildinfo",
+    "plugins": [
+      {
+        "name": "typescript-plugin-css-modules",
+        "options": {
+          "classnameTransform": "camelCase",
+          "customMatcher": "\\.module\\.scss$"
+        }
+      }
+    ]
   },
   "exclude": ["node_modules", "**/*.e2e.ts", "cypress"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/1947 https://github.com/blitz-js/blitz/issues/1531 

### What are the changes and their implications?
The main reason is to have autocomplete of module css classes in components using module css.
![deepin-screen-recorder_Select area_20210223225400](https://user-images.githubusercontent.com/468006/108906952-29fbbd80-762a-11eb-84a2-af59a2ef8056.gif)


### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
If you are using vscode also you should change typescript version to locally installed one
```
{
  "typescript.tsdk": "node_modules/typescript/lib"
}
```