### PR TITLE
fix "role" of PublicData was lost by `$setPublicData`

### DIFF
--- a/packages/server/src/supertokens.ts
+++ b/packages/server/src/supertokens.ts
@@ -844,8 +844,11 @@ export async function syncPubicDataFieldsForUserIfNeeded(
   data: Record<string, unknown>,
 ) {
   const dataToSync: Record<string, unknown> = {}
-  config.publicDataKeysToSyncAcrossSessions.forEach((key) => (dataToSync[key] = data[key]))
-
+  config.publicDataKeysToSyncAcrossSessions.forEach((key) => {
+    if (data[key]) {
+      dataToSync[key] = data[key]
+    }
+  })
   if (Object.keys(dataToSync).length) {
     const sessions = await config.getSessions(userId)
 


### PR DESCRIPTION
Closes: ??

### What are the changes and their implications?


#### 【problem】
My sessions are like this:
```
{
      isLoading: false
      role: "user"
      userId: 1
      userName: "foo"
}
```

When I use `setPublicData` without "role", "role" is gone.

```tsx
ctx.session.$setPublicData({ userName: "bar" })
```

```
{
      isLoading: false
      userId: 1
      userName: "bar"
}
```

#### 【solution】

It was because of l847(`packages/server/src/supertokens.ts`):

```
config.publicDataKeysToSyncAcrossSessions.forEach((key) => (dataToSync[key] = data[key])
```

This made `dataToSync` as follows:

```
{
  role: undefined,
  roles: undefined,
}
```


### Checklist

- [x] Changes covered by tests (tests added if needed)
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
