### PR TITLE
fix some issues with `blitz start` using wrong build folder (patch)

### DIFF
--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -162,7 +162,7 @@ export async function nextStart(nextBin: string, buildFolder: string, config: Se
       rej("")
     } else {
       const nextjs = spawn(nextBin, spawnCommand, {
-        cwd: buildFolder,
+        cwd: process.cwd(),
         env: spawnEnv,
         stdio: [process.stdin, "pipe", "pipe"],
       })


### PR DESCRIPTION

### What are the changes and their implications?

fix some issues with `blitz start` using wrong build folder

### Checklist

- [x] Changes covered by tests (tests added if needed)
- ~[ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes~

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
