### PR TITLE
(newapp) change template to use typescript 4.1 because 4.2 is broken

### DIFF
--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -35,7 +35,7 @@
     "react": "0.0.0-experimental-3310209d0",
     "react-dom": "0.0.0-experimental-3310209d0",
     "react-error-boundary": "3.x",
-    "typescript": "4.x",
+    "typescript": "~4.1",
     "zod": "1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/2014

### What are the changes and their implications?

Change template to use typescript 4.1 because 4.2 is broken

Bug: https://github.com/microsoft/TypeScript/issues/42773


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
