### PR TITLE
Fix Cannot read property 'toString' of null for `blitz new`

### DIFF
--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -67,7 +67,7 @@ export class New extends Command {
 
     if (!flags["skip-upgrade"]) {
       const latestVersion = (await getLatestVersion("blitz")).value || this.config.version
-      if (true) {
+      if (lt(this.config.version, latestVersion)) {
         const upgradeChoices: Array<{name: string; message?: string}> = [
           {name: "yes", message: `Yes - Upgrade to ${latestVersion}`},
           {

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -67,7 +67,7 @@ export class New extends Command {
 
     if (!flags["skip-upgrade"]) {
       const latestVersion = (await getLatestVersion("blitz")).value || this.config.version
-      if (lt(this.config.version, latestVersion)) {
+      if (true) {
         const upgradeChoices: Array<{name: string; message?: string}> = [
           {name: "yes", message: `Yes - Upgrade to ${latestVersion}`},
           {
@@ -84,10 +84,13 @@ export class New extends Command {
         })
 
         if (promptUpgrade.upgrade === "yes") {
-          const checkYarn = spawn.sync("yarn", ["global", "list"], {stdio: "pipe"})
-          const useYarn = checkYarn.stdout.toString().includes("blitz@")
-          const upgradeOpts = useYarn ? ["global", "add", "blitz"] : ["i", "-g", "blitz@latest"]
+          var useYarn: boolean = false
 
+          const checkYarn = spawn.sync("yarn", ["global", "list"], {stdio: "pipe"})
+          if (checkYarn && checkYarn.stdout) {
+            useYarn = checkYarn.stdout.toString().includes("blitz@")
+          }
+          const upgradeOpts = useYarn ? ["global", "add", "blitz"] : ["i", "-g", "blitz@latest"]
           spawn.sync(useYarn ? "yarn" : "npm", upgradeOpts, {stdio: "inherit"})
 
           const versionResult = spawn.sync("blitz", ["--version"], {stdio: "pipe"})


### PR DESCRIPTION
Closes: #1998 

### What are the changes and their implications?
Adding checks to make sure the checkYarn buffer and its stdout are not null or undefined before calling .toString() on them. This ensures that the useYarn variable which determines whether we use yarn or npm to upgrade blitz is properly set, and the rest of the upgrade happens without an error being thrown if the user doesn't have yarn installed

### Checklist

- [ ] Changes covered by tests (tests added if needed)
I was unable to test this because the issue was only occurring when I didn't have yarn installed, but I needed yarn installed and needed to be running the yarn dev command in order to run the commands using the local blitz version I was working on in the example directory
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
