### PR TITLE
fix `db.$reset` to not spew prisma logs (patch)

### DIFF
--- a/packages/core/src/prisma-utils.ts
+++ b/packages/core/src/prisma-utils.ts
@@ -39,7 +39,7 @@ export const enhancePrisma = <TPrismaClientCtor extends Constructor>(
             const process = spawn(
               prismaBin,
               ["migrate", "reset", "--force", "--skip-generate", "--preview-feature"],
-              {stdio: "inherit"},
+              {stdio: "ignore"},
             )
             process.on("exit", (code) => (code === 0 ? res(0) : rej(code)))
           })


### PR DESCRIPTION


### What are the changes and their implications?

fix `db.$reset` to not spew prisma logs


<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
