### PR TITLE
(meta) added husky initialization in `pre-commit`

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,6 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
 yarn manypkg fix
 yarn lint-staged
 yarn pretty-quick --staged


### PR DESCRIPTION
Very simple change that runs [this script](https://github.com/typicode/husky/blob/main/scripts/husky.sh).

Husky adds it when you create a hook with `husky add` ([reference](https://github.com/typicode/husky/blob/main/src/commands/add.ts))
