### PR TITLE
(recipe) Add `blitz install gh-action-yarn-mariadb` GH action config for testing a mariadb or mysql database

### DIFF
--- a/recipes/gh-action-yarn-mariadb/index.ts
+++ b/recipes/gh-action-yarn-mariadb/index.ts
@@ -1,0 +1,17 @@
+import {RecipeBuilder} from "@blitzjs/installer"
+import {join} from "path"
+
+export default RecipeBuilder()
+  .setName("Github Action Workflow For Yarn & MariaDB")
+  .setDescription("This Github Action config will build and test your blitz app on each push")
+  .setOwner("me@kevinlangleyjr.com")
+  .setRepoLink("https://github.com/blitz-js/blitz")
+  .addNewFilesStep({
+    stepId: "addWorkflow",
+    stepName: "Add .github/workflows/main.yml",
+    explanation: `NOTE: Your app must be configured to use MariaDB for this`,
+    targetDirectory: ".github/workflows/",
+    templatePath: join(__dirname, "templates"),
+    templateValues: {},
+  })
+  .build()

--- a/recipes/gh-action-yarn-mariadb/package.json
+++ b/recipes/gh-action-yarn-mariadb/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@blitzjs/recipe-gh-action-yarn-mariadb",
+  "private": true,
+  "version": "0.30.7",
+  "description": "The Blitz Recipe for adding github actions workflow with MariaDB",
+  "main": "index.ts",
+  "scripts": {
+    "test": "echo \"No tests yet\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/blitz-js/blitz.git"
+  },
+  "keywords": [
+    "blitz",
+    "blitzjs",
+    "github",
+    "actions"
+  ],
+  "author": "Kevin Langley Jr. <me@kevinlangleyjr.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/blitz-js/blitz/issues"
+  },
+  "homepage": "https://github.com/blitz-js/blitz#readme",
+  "dependencies": {
+    "@blitzjs/installer": "0.30.7"
+  }
+}

--- a/recipes/gh-action-yarn-mariadb/templates/main.yml
+++ b/recipes/gh-action-yarn-mariadb/templates/main.yml
@@ -1,0 +1,99 @@
+name: CI
+
+on: [push]
+
+jobs:
+  ###############
+  # Lint & Test
+  ###############
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: test
+      DATABASE_URL: mysql://root:password@127.0.0.1:3306/test
+    services:
+      mariadb:
+        image: mariadb:latest
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: password
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=5s
+          --health-timeout=2s
+          --health-retries=3
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Node
+      - name: Read .node-version
+        id: node_version
+        run: echo ::set-output name=NODE_VERSION::$(cat .node-version || echo "14")
+      - name: Setup Node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+
+      # Yarn cache/install
+      - name: Find yarn cache location
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: JS package cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.yarn-cache.outputs.dir }}
+            **/node_modules
+            /home/runner/.cache/Cypress
+            C:\Users\runneradmin\AppData\Local\Cypress\Cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install packages
+        run: yarn install --frozen-lockfile
+
+      # Lint Code
+      - name: Lint
+        run: yarn lint
+
+      # Migrate DB & generate prisma client
+      - name: Migrate DB & generate prisma client
+        run: yarn blitz prisma migrate dev --preview-feature
+
+      # Jest Tests (API/Frontend)
+      - name: Run Jest Tests
+        run: yarn test
+
+      # E2E Tests via Cypress
+      # - name: Run Cypress E2E Tests
+      #   uses: cypress-io/github-action@v2
+      #   with:
+      #     # we have already installed all dependencies above
+      #     install: false
+      #     start: yarn test:server --production
+      #     wait-on: "http://localhost:3099"
+      #     wait-on-timeout: 300
+      #   env:
+      #     NODE_ENV: test
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Upload Cypress Screenshots
+      #   uses: actions/upload-artifact@v1
+      #   # Only capture images on failure
+      #   if: failure()
+      #   with:
+      #     name: cypress-screenshots
+      #     path: cypress/screenshots
+      #     retention-days: 3
+      # - name: Upload Cypress Videos
+      #   uses: actions/upload-artifact@v1
+      #   # Test run video was always captured, so this action uses "always()" condition
+      #   if: always()
+      #   with:
+      #     name: cypress-videos
+      #     path: cypress/videos
+      #     retention-days: 3


### PR DESCRIPTION
### What are the changes and their implications?
Adding a new recipe to create the GitHub workflow for building and testing with a MariaDB database.

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
