### PR TITLE
Fix not being able to use `await` in `blitz console` for some users

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,9 +17,6 @@
     "url": "https://twitter.com/flybayer"
   },
   "main": "lib/src/index.js",
-  "bin": {
-    "blitz": "./bin/run"
-  },
   "files": [
     "/bin",
     "/lib"


### PR DESCRIPTION
### What are the changes and their implications?

@paulpanther noticed that `await db.project.findMany()` fails with `SyntaxError: await is only valid in async functions and the top level bodies of modules` when he tries it on CMD / Node v14.15 / Blitz 0.31

It seems to be b/c https://github.com/blitz-js/blitz/blob/canary/packages/blitz/bin/blitz is never executed.

Interestingly enough, it works when using MinGW!

Our assumption: Blitz has two packages that register a binary called `blitz`, CMD chooses the wrong one while MinGW / Bash etc use the right one. This is backed up by the output of `where blitz` (the same as `which blitz` on Unix).

This PR removes the superfluous "bin" entry to (hopefully) solve this issue.

We haven't been able to properly test this, though. @flybayer could you publish his PR as a danger release?

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
