### PR TITLE
(patch) Fix node 14 global install by removing use of peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     ]
   },
   "scripts": {
-    "postinstall": "husky install",
+    "postinstall": "patch-package && husky install",
     "dev:tsc": "tsc --watch --pretty --preserveWatchOutput",
     "dev:cli": "yarn workspace @blitzjs/cli dev",
     "dev:templates": "yarn workspace @blitzjs/generator dev",
@@ -42,8 +42,6 @@
     "publish-canary": "yarn run publish-prep && lerna publish --force-publish --preid canary --pre-dist-tag canary",
     "publish-latest": "yarn run publish-prep && lerna publish --force-publish",
     "publish-danger": "lerna publish --canary --pre-dist-tag danger --preid danger.$(git rev-parse --short HEAD) --allow-branch * --force-publish",
-    "prerelease": "patch-package",
-    "release": "release",
     "pull-nextjs": "git subrepo nextjs pull",
     "push-nextjs": "git subrepo nextjs push"
   },

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     ]
   },
   "scripts": {
-    "postinstall": "patch-package && husky install",
+    "postinstall": "husky install",
     "dev:tsc": "tsc --watch --pretty --preserveWatchOutput",
     "dev:cli": "yarn workspace @blitzjs/cli dev",
     "dev:templates": "yarn workspace @blitzjs/generator dev",
     "dev": "preconstruct dev && concurrently --names \"typecheck,cli,templates\" -c \"blue,green,yellow,magenta\" -p \"{name}\" \"npm:dev:tsc\" \"npm:dev:cli\" \"npm:dev:templates\"",
-    "build": "cross-env BLITZ_PROD_BUILD=true preconstruct build && ultra -r --filter 'packages/*' buildpkg && tsc",
+    "build": "patch-package && cross-env BLITZ_PROD_BUILD=true preconstruct build && ultra -r --filter 'packages/*' buildpkg && tsc",
     "lint": "eslint --ext \".js,.ts,.tsx\" .",
     "link-cli": "yarn workspace blitz link",
     "unlink-cli": "yarn workspace blitz unlink",

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -34,9 +34,6 @@
     "@babel/helper-module-imports": "^7.0.0",
     "babel-plugin-superjson-next": "0.2.2"
   },
-  "peerDependencies": {
-    "@babel/core": "*"
-  },
   "devDependencies": {
     "@babel/core": "7.13.1"
   }

--- a/packages/blitz/package.json
+++ b/packages/blitz/package.json
@@ -76,9 +76,6 @@
   "devDependencies": {
     "next": "10.0.7"
   },
-  "peerDependencies": {
-    "next": "*"
-  },
   "keywords": [
     "blitz",
     "blitzjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,8 @@
     "with-blitz"
   ],
   "dependencies": {
+    "@blitzjs/config": "0.31.1",
+    "@blitzjs/display": "0.31.1",
     "@types/secure-password": "3.1.0",
     "b64-lite": "^1.4.0",
     "bad-behavior": "^1.0.1",
@@ -52,15 +54,7 @@
     "secure-password": "4.0.0",
     "superjson": "1.7.2"
   },
-  "peerDependencies": {
-    "@blitzjs/config": "*",
-    "@blitzjs/display": "*",
-    "react": ">=0.0.0 || >=0.0.0-experimental",
-    "zod": "*"
-  },
   "devDependencies": {
-    "@blitzjs/config": "0.31.1",
-    "@blitzjs/display": "0.31.1",
     "react": "0.0.0-experimental-3310209d0",
     "zod": "1.11.11"
   },

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -28,17 +28,12 @@
     "url": "git+https://github.com/blitz-js/blitz.git"
   },
   "dependencies": {
+    "@blitzjs/config": "0.31.1",
     "@blitzjs/display": "0.31.1",
     "chalk": "^4.1.0",
     "console-table-printer": "^2.7.5",
     "ora": "^5.3.0",
     "readline": "1.3.0",
     "tslog": "^3.1.1"
-  },
-  "peerDependencies": {
-    "@blitzjs/config": "*"
-  },
-  "devDependencies": {
-    "@blitzjs/config": "0.31.1"
   }
 }

--- a/packages/file-pipeline/package.json
+++ b/packages/file-pipeline/package.json
@@ -28,6 +28,7 @@
     "url": "git+https://github.com/blitz-js/blitz.git"
   },
   "dependencies": {
+    "@blitzjs/display": "0.31.1",
     "chalk": "^4.1.0",
     "chokidar": "3.5.1",
     "flush-write-stream": "2.0.0",
@@ -45,11 +46,5 @@
     "vinyl": "2.2.1",
     "vinyl-file": "3.0.0",
     "vinyl-fs": "3.0.3"
-  },
-  "peerDependencies": {
-    "@blitzjs/display": "*"
-  },
-  "devDependencies": {
-    "@blitzjs/display": "0.31.1"
   }
 }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -51,11 +51,8 @@
     "username": "^5.1.0",
     "vinyl": "2.2.1"
   },
-  "peerDependencies": {
-    "prettier": "*"
-  },
-  "gitHead": "d3b9fce0bdd251c2b1890793b0aa1cd77c1c0922",
   "devDependencies": {
     "prettier": "2.2.1"
-  }
+  },
+  "gitHead": "d3b9fce0bdd251c2b1890793b0aa1cd77c1c0922"
 }

--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -28,16 +28,11 @@
     "url": "git+https://github.com/blitz-js/blitz.git"
   },
   "dependencies": {
+    "@blitzjs/config": "0.31.1",
     "chokidar": "3.5.1",
     "globby": "11.0.2",
     "pkg-dir": "^5.0.0",
     "progress": "^2.0.3"
   },
-  "peerDependencies": {
-    "@blitzjs/config": "*"
-  },
-  "gitHead": "d3b9fce0bdd251c2b1890793b0aa1cd77c1c0922",
-  "devDependencies": {
-    "@blitzjs/config": "0.31.1"
-  }
+  "gitHead": "d3b9fce0bdd251c2b1890793b0aa1cd77c1c0922"
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,6 +23,9 @@
     "register"
   ],
   "dependencies": {
+    "@blitzjs/config": "0.31.1",
+    "@blitzjs/core": "0.31.1",
+    "@blitzjs/display": "0.31.1",
     "@blitzjs/file-pipeline": "0.31.1",
     "cross-spawn": "7.0.3",
     "detect-port": "1.3.0",
@@ -43,17 +46,6 @@
     "slash": "^3.0.0",
     "through2": "4.0.2",
     "vinyl": "2.2.1"
-  },
-  "devDependencies": {
-    "@blitzjs/config": "0.31.1",
-    "@blitzjs/core": "0.31.1",
-    "@blitzjs/display": "0.31.1",
-    "next": "10.0.7"
-  },
-  "peerDependencies": {
-    "@blitzjs/config": "*",
-    "@blitzjs/core": "*",
-    "@blitzjs/display": "*"
   },
   "gitHead": "d3b9fce0bdd251c2b1890793b0aa1cd77c1c0922"
 }

--- a/patches/@preconstruct+cli+2.0.5.patch
+++ b/patches/@preconstruct+cli+2.0.5.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@preconstruct/cli/cli/dist/cli.cjs.dev.js b/node_modules/@preconstruct/cli/cli/dist/cli.cjs.dev.js
+index 7e40755..fde60cc 100644
+--- a/node_modules/@preconstruct/cli/cli/dist/cli.cjs.dev.js
++++ b/node_modules/@preconstruct/cli/cli/dist/cli.cjs.dev.js
+@@ -1770,6 +1770,8 @@ let getRollupConfig = (pkg, entrypoints, aliases, type, reportTransformedFile) =
+     external.push(...builtInModules);
+   }
+ 
++  external.push('next', 'react', '@babel/core', 'prettier')
++
+   let input = {};
+   entrypoints.forEach(entrypoint => {
+     input[path__default.relative(pkg.directory, path__default.join(entrypoint.directory, "dist", getNameForDistForEntrypoint(entrypoint)))] = entrypoint.source;


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/2065

### What are the changes and their implications?


Fix node 14 global install by removing use of peer dependencies