### PR TITLE
(patch) fix `build build` failure in a weird nextjs edgecase

### DIFF
--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -140,7 +140,7 @@ export function nextBuild(
       stdio: [process.stdin, "pipe", "pipe"],
     })
       .on("exit", (code: number) => {
-        if (code === 0) {
+        if (code === 0 || code === null) {
           res()
         } else {
           process.exit(code)


### PR DESCRIPTION
Closes: https://discord.com/channels/802917734999523368/814628067788062750/818625127725924363

### What are the changes and their implications?

fix `build build` failure in a weird nextjs edgecase where the exit code is null