### PR TITLE
(patch) fix another bug with queries/mutations when using `basePath`

### DIFF
--- a/packages/core/src/rpc-client.ts
+++ b/packages/core/src/rpc-client.ts
@@ -65,7 +65,7 @@ export const executeRpcCall = <TInput, TResult>(
   const controller = new AbortController()
 
   const promise = window
-    .fetch(apiUrl, {
+    .fetch(addBasePath(apiUrl), {
       method: "POST",
       headers,
       credentials: "include",


### PR DESCRIPTION
### What are the changes and their implications?
In the previous fix, the rpcClient.warm call was fixed but the rpcCall itself was not actually modified.  This PR fixes the rpcCall with correct basePath as well.


### Checklist

- [x] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
