### PR TITLE
(patch) fix `useRouterQuery` to not parse values (leave as string)

### DIFF
--- a/packages/core/src/router/router-hooks.ts
+++ b/packages/core/src/router/router-hooks.ts
@@ -118,13 +118,6 @@ export function useParam(
 /*
  * Copied from https://github.com/lukeed/qss
  */
-function toValue(mix: any) {
-  if (!mix) return ""
-  var str = decodeURIComponent(mix)
-  if (str === "false") return false
-  if (str === "true") return true
-  return +str * 0 === 0 ? +str : str
-}
 function decode(str: string) {
   if (!str) return {}
   let tmp: any
@@ -137,11 +130,11 @@ function decode(str: string) {
     tmp = tmp.split("=")
     k = tmp.shift()
     if (out[k] !== void 0) {
-      out[k] = [].concat(out[k], toValue(tmp.shift()) as any)
+      out[k] = [].concat(out[k], tmp.shift())
     } else {
-      out[k] = toValue(tmp.shift())
+      out[k] = tmp.shift()
     }
   }
 
-  return out
+  return out as Record<string, string | string[]>
 }

--- a/packages/core/test/router-hooks.test.ts
+++ b/packages/core/test/router-hooks.test.ts
@@ -1,5 +1,18 @@
-import {extractRouterParams, useParam, useParams} from "../src/router/router-hooks"
+import {extractRouterParams, useParam, useParams, useRouterQuery} from "../src/router/router-hooks"
 import {renderHook} from "./test-utils"
+
+describe("useRouterQuery", () => {
+  const {result} = renderHook(() => useRouterQuery(), {
+    router: {asPath: "/?foo=foo&num=0&bool=true&float=1.23&empty"},
+  })
+  expect(result.current).toEqual({
+    foo: "foo",
+    num: "0",
+    bool: "true",
+    float: "1.23",
+    empty: undefined,
+  })
+})
 
 describe("extractRouterParams", () => {
   it("returns proper params", () => {


### PR DESCRIPTION


### What are the changes and their implications?

 fix `useRouterQuery` to not parse values (leave as string)

### Checklist

- [x] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
