### PR TITLE
Fix `-d` shorthand for `--dry-run` missing in blitz new

### DIFF
--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -48,7 +48,8 @@ export class New extends Command {
       allowNo: true,
     }),
     "dry-run": flags.boolean({
-      description: "show what files will be created without writing them to disk",
+      char: "d",
+      description: "Show what files will be created without writing them to disk",
     }),
     "no-git": flags.boolean({
       description: "Skip git repository creation",


### PR DESCRIPTION
### What are the changes and their implications?

According to [documentation](https://github.com/blitz-js/blitzjs.com/blob/main/app/pages/docs/cli-new.mdx), `blitz new` should support also shorthand flag `-d` for `--dry-run`. It didn't as yet. It has been added in this PR.
