### PR TITLE
Fix duplicated Set-Cookie header

### DIFF
--- a/packages/core/src/server/auth/sessions.ts
+++ b/packages/core/src/server/auth/sessions.ts
@@ -432,7 +432,33 @@ export const parseAnonymousSessionToken = (token: string) => {
 }
 
 export const setCookie = (res: ServerResponse, cookie: string) => {
-  append(res, "Set-Cookie", cookie)
+  const getCookieName = (c: string) => c.split("=", 2)[0]
+  const appendCookie = () => append(res, "Set-Cookie", cookie)
+
+  const cookiesHeader = res.getHeader("Set-Cookie")
+  const cookieName = getCookieName(cookie)
+
+  if (typeof cookiesHeader !== "string" && !Array.isArray(cookiesHeader)) {
+    appendCookie()
+    return
+  }
+
+  if (typeof cookiesHeader === "string") {
+    if (cookieName === getCookieName(cookiesHeader)) {
+      res.setHeader("Set-Cookie", cookie)
+    } else {
+      appendCookie()
+    }
+  } else {
+    for (let i = 0; i < cookiesHeader.length; i++) {
+      if (cookieName === getCookieName(cookiesHeader[i])) {
+        cookiesHeader[i] = cookie
+        res.setHeader("Set-Cookie", cookie)
+        return
+      }
+    }
+    appendCookie()
+  }
 }
 
 export const setHeader = (res: ServerResponse, name: string, value: string) => {


### PR DESCRIPTION
Closes: #1837 

### What are the changes and their implications?

This changes the `setCookie` function in `sessions.ts`. Instead of just appending a cookie header to `Set-Cookie`, it looks for duplicates. It shouldn't break anything

### Checklist

- [x] Changes covered by tests (tests added if needed)
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
