### PR TITLE
Upgrade prisma to 2.19, remove `--preview-feature` from migrate

### DIFF
--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -14,7 +14,7 @@ model Project {
 2. DB migrate
 
 ```
-blitz prisma migrate dev --preview-feature
+blitz prisma migrate dev
 ```
 
 3. Start the dev server

--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -12,7 +12,7 @@
     "cy:run": "cypress run --browser chrome",
     "test": "prisma generate && yarn test:jest && yarn test:e2e",
     "test:jest": "jest",
-    "test:server": "cross-env NODE_ENV=test blitz prisma migrate deploy --preview-feature && blitz build && cross-env NODE_ENV=test blitz start -p 3099",
+    "test:server": "cross-env NODE_ENV=test blitz prisma migrate deploy && blitz build && cross-env NODE_ENV=test blitz start -p 3099",
     "test:e2e": "cross-env NODE_ENV=test start-server-and-test test:server http://localhost:3099 cy:run"
   },
   "browserslist": [
@@ -28,13 +28,13 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@prisma/client": "2.17.0",
+    "@prisma/client": "2.19.0",
     "blitz": "0.33.0",
     "final-form": "4.20.1",
     "passport-auth0": "1.4.0",
     "passport-github2": "0.1.12",
     "passport-twitter": "1.0.4",
-    "prisma": "2.17.0",
+    "prisma": "2.19.0",
     "react": "0.0.0-experimental-3310209d0",
     "react-dom": "0.0.0-experimental-3310209d0",
     "react-error-boundary": "3.1.1",

--- a/examples/custom-server/README.md
+++ b/examples/custom-server/README.md
@@ -8,7 +8,7 @@
    ```
 2. Migrate
    ```sh
-   blitz prisma migrate dev --preview-feature
+   blitz prisma migrate dev
    ```
 3. Start the dev server
 

--- a/examples/custom-server/app/pages/index.tsx
+++ b/examples/custom-server/app/pages/index.tsx
@@ -74,7 +74,7 @@ const Home: BlitzPage = () => {
           <code>blitz generate all project name:string</code>
         </pre>
         <pre>
-          <code>blitz prisma migrate dev --preview-feature</code>
+          <code>blitz prisma migrate dev</code>
         </pre>
         <div>
           <p>

--- a/examples/custom-server/package.json
+++ b/examples/custom-server/package.json
@@ -10,7 +10,7 @@
     "test-watch": "jest --watch",
     "cy-open": "cypress open",
     "cy-run": "cypress run",
-    "test:migrate": "prisma generate && blitz prisma migrate deploy --preview-feature",
+    "test:migrate": "prisma generate && blitz prisma migrate deploy",
     "test:jest": "jest --passWithNoTests",
     "test-server": "blitz build && blitz start",
     "test:e2e": "cross-env NODE_ENV=test PORT=3099 start-server-and-test test-server http://localhost:3099 cy-run",
@@ -29,10 +29,10 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@prisma/client": "2.17.0",
+    "@prisma/client": "2.19.0",
     "blitz": "0.33.0",
     "final-form": "4.20.1",
-    "prisma": "2.17.0",
+    "prisma": "2.19.0",
     "react": "0.0.0-experimental-3310209d0",
     "react-dom": "0.0.0-experimental-3310209d0",
     "react-error-boundary": "3.1.1",

--- a/examples/plain-js/README.md
+++ b/examples/plain-js/README.md
@@ -14,7 +14,7 @@ model Project {
 2. DB migrate
 
 ```
-blitz prisma migrate dev --preview-feature
+blitz prisma migrate dev
 ```
 
 3. Start the dev server

--- a/examples/plain-js/app/pages/index.js
+++ b/examples/plain-js/app/pages/index.js
@@ -3,7 +3,7 @@ const modelSnippet = `model Project {
   id      Int      @default(autoincrement()) @id
   name    String
 }`
-const migrateSnippet = `$ blitz prisma migrate dev --preview-feature
+const migrateSnippet = `$ blitz prisma migrate dev
 $ blitz generate all project`
 
 const Home = () => (

--- a/examples/plain-js/package.json
+++ b/examples/plain-js/package.json
@@ -3,7 +3,7 @@
   "version": "0.33.0",
   "scripts": {
     "dev": "blitz dev",
-    "build": "blitz prisma migrate deploy --preview-feature && blitz build",
+    "build": "blitz prisma migrate deploy && blitz build",
     "start": "blitz start",
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts,.tsx .",
     "test": "echo \"DISABLED\""
@@ -29,9 +29,9 @@
     ]
   },
   "dependencies": {
-    "@prisma/client": "2.17.0",
+    "@prisma/client": "2.19.0",
     "blitz": "0.33.0",
-    "prisma": "2.17.0",
+    "prisma": "2.19.0",
     "react": "0.0.0-experimental-3310209d0",
     "react-dom": "0.0.0-experimental-3310209d0"
   },

--- a/examples/static/package.json
+++ b/examples/static/package.json
@@ -32,10 +32,10 @@
     ]
   },
   "dependencies": {
-    "@prisma/client": "2.17.0",
+    "@prisma/client": "2.19.0",
     "blitz": "0.33.0",
     "final-form": "4.20.1",
-    "prisma": "2.17.0",
+    "prisma": "2.19.0",
     "react": "0.0.0-experimental-3310209d0",
     "react-dom": "0.0.0-experimental-3310209d0",
     "react-error-boundary": "3.1.1",

--- a/examples/static/yarn.lock
+++ b/examples/static/yarn.lock
@@ -541,7 +541,7 @@
     "@oclif/plugin-autocomplete" "0.3.0"
     "@oclif/plugin-help" "3.2.1"
     "@oclif/plugin-not-found" "1.2.4"
-    "@prisma/sdk" "2.17.0"
+    "@prisma/sdk" "2.19.0"
     "@salesforce/lazy-require" "0.4.0"
     camelcase "^6.2.0"
     chalk "4.1.0"

--- a/examples/store/README.md
+++ b/examples/store/README.md
@@ -3,7 +3,7 @@
 1. DB migrate
 
 ```
-yarn blitz prisma migrate dev --preview-feature
+yarn blitz prisma migrate dev
 ```
 
 2. Start the dev server

--- a/examples/store/package.json
+++ b/examples/store/package.json
@@ -3,10 +3,10 @@
   "version": "0.33.0",
   "private": true,
   "scripts": {
-    "build": "blitz prisma migrate deploy --preview-feature && blitz build",
+    "build": "blitz prisma migrate deploy && blitz build",
     "cy:open": "cypress open",
     "cy:run": "cypress run || cypress run",
-    "test:server": "prisma generate && blitz prisma migrate deploy --preview-feature && blitz db seed && blitz build && blitz start -p 3099",
+    "test:server": "prisma generate && blitz prisma migrate deploy && blitz db seed && blitz build && blitz start -p 3099",
     "test": "cross-env NODE_ENV=test start-server-and-test test:server http://localhost:3099 cy:run",
     "posttest": "node assert-tree-shaking-works.js"
   },
@@ -20,10 +20,10 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@prisma/client": "2.17.0",
+    "@prisma/client": "2.19.0",
     "blitz": "0.33.0",
     "final-form": "4.20.1",
-    "prisma": "2.17.0",
+    "prisma": "2.19.0",
     "react": "0.0.0-experimental-3310209d0",
     "react-dom": "0.0.0-experimental-3310209d0",
     "react-error-boundary": "3.1.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "@oclif/plugin-autocomplete": "0.3.0",
     "@oclif/plugin-help": "3.2.1",
     "@oclif/plugin-not-found": "1.2.4",
-    "@prisma/sdk": "2.17.0",
+    "@prisma/sdk": "2.19.0",
     "@salesforce/lazy-require": "0.4.0",
     "camelcase": "^6.2.0",
     "chalk": "^4.1.0",
@@ -59,7 +59,7 @@
     "@oclif/dev-cli": "1.26.0",
     "@oclif/test": "1.2.8",
     "nock": "13.0.6",
-    "prisma": "2.17.0",
+    "prisma": "2.19.0",
     "stdout-stderr": "0.1.13"
   },
   "jest": {

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -165,7 +165,7 @@ export class New extends Command {
             // Required in order for DATABASE_URL to be available
             require("dotenv-expand")(require("dotenv-flow").config({silent: true}))
             const result = await runPrisma(
-              ["migrate", "dev", "--preview-feature", "--name", "Initial migration"],
+              ["migrate", "dev", "--name", "Initial migration"],
               true,
             )
             if (!result) throw new Error()
@@ -174,7 +174,7 @@ export class New extends Command {
           } catch (error) {
             spinner.fail()
             postInstallSteps.push(
-              "blitz prisma migrate dev --preview-feature (when asked, you can name the migration anything)",
+              "blitz prisma migrate dev (when asked, you can name the migration anything)",
             )
           }
         },
@@ -186,7 +186,7 @@ export class New extends Command {
       if (needsInstall) {
         postInstallSteps.push(npm ? "npm install" : "yarn")
         postInstallSteps.push(
-          "blitz prisma migrate dev --preview-feature (when asked, you can name the migration anything)",
+          "blitz prisma migrate dev (when asked, you can name the migration anything)",
         )
       }
 

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -115,7 +115,7 @@ describe("`new` command", () => {
           expect(getStepsFromOutput()).toStrictEqual([
             `cd ${dirName}`,
             "yarn",
-            "blitz prisma migrate dev --preview-feature (when asked, you can name the migration anything)",
+            "blitz prisma migrate dev (when asked, you can name the migration anything)",
             "blitz dev",
           ])
         }),

--- a/packages/core/src/prisma-utils.ts
+++ b/packages/core/src/prisma-utils.ts
@@ -36,11 +36,9 @@ export const enhancePrisma = <TPrismaClientCtor extends Constructor>(
           }
           const prismaBin = which(process.cwd()).sync("prisma")
           await new Promise((res, rej) => {
-            const process = spawn(
-              prismaBin,
-              ["migrate", "reset", "--force", "--skip-generate", "--preview-feature"],
-              {stdio: "ignore"},
-            )
+            const process = spawn(prismaBin, ["migrate", "reset", "--force", "--skip-generate"], {
+              stdio: "ignore",
+            })
             process.on("exit", (code) => (code === 0 ? res(0) : rej(code)))
           })
           global._blitz_prismaClient.$disconnect()

--- a/packages/generator/src/generators/model-generator.ts
+++ b/packages/generator/src/generators/model-generator.ts
@@ -93,7 +93,7 @@ export class ModelGenerator extends Generator<ModelGeneratorOptions> {
     if (shouldMigrate) {
       await new Promise<void>((res, rej) => {
         const prismaBin = which(process.cwd()).sync("prisma")
-        const child = spawn(prismaBin, ["migrate", "dev", "--preview-feature"], {stdio: "inherit"})
+        const child = spawn(prismaBin, ["migrate", "dev"], {stdio: "inherit"})
         child.on("exit", (code) => (code === 0 ? res() : rej()))
       })
     }

--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -29,8 +29,8 @@
     ]
   },
   "dependencies": {
-    "prisma": "~2.17",
-    "@prisma/client": "~2.17",
+    "prisma": "~2.19",
+    "@prisma/client": "~2.19",
     "blitz": "canary",
     "react": "0.0.0-experimental-3310209d0",
     "react-dom": "0.0.0-experimental-3310209d0",

--- a/recipes/gh-action-yarn-mariadb/templates/main.yml
+++ b/recipes/gh-action-yarn-mariadb/templates/main.yml
@@ -63,7 +63,7 @@ jobs:
 
       # Migrate DB & generate prisma client
       - name: Migrate DB & generate prisma client
-        run: yarn blitz prisma migrate dev --preview-feature
+        run: yarn blitz prisma migrate dev
 
       # Jest Tests (API/Frontend)
       - name: Run Jest Tests

--- a/recipes/gh-action-yarn-postgres/templates/main.yml
+++ b/recipes/gh-action-yarn-postgres/templates/main.yml
@@ -62,7 +62,7 @@ jobs:
 
       # Migrate DB & generate prisma client
       - name: Migrate DB & generate prisma client
-        run: yarn blitz prisma migrate dev --preview-feature
+        run: yarn blitz prisma migrate dev
 
       # Jest Tests (API/Frontend)
       - name: Run Jest Tests

--- a/recipes/render/templates/render.yaml
+++ b/recipes/render/templates/render.yaml
@@ -3,7 +3,7 @@ services:
     name: blitzapp
     env: node
     plan: starter
-    buildCommand: yarn --frozen-lockfile --prod=false && blitz build && blitz prisma migrate deploy --preview-feature
+    buildCommand: yarn --frozen-lockfile --prod=false && blitz build && blitz prisma migrate deploy
     startCommand: blitz start
     envVars:
       # ⚠️  You must set SESSION_SECRET_KEY env var through the UI.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3360,30 +3360,30 @@
   dependencies:
     resolve "^1.17.0"
 
-"@prisma/client@2.17.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.17.0.tgz#e38462796c2e824504763416f5e3a7219d70652d"
-  integrity sha512-tzsBxtx9J1epOGCiBeXur1tEz81UIdWg2G/HpDmflXKcv/MJb+KCWSKSsEW49eXcvVwRgxNyxLoCO6CwvjQKcg==
+"@prisma/client@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.19.0.tgz#a45f17a59fd109e95b61bf4b56d4a7642169ec0e"
+  integrity sha512-QK4M8TjJh1QesyO9aLM7DeAQUi5+UnNHpEAm5kwqBO1cq/4Ag5yU9ladctJFJleEE5BLewXHwV2t9A+VfCZslg==
   dependencies:
-    "@prisma/engines-version" "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223"
+    "@prisma/engines-version" "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
 
-"@prisma/debug@2.17.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.17.0.tgz#0caa176d5c81e6cf1ad71c5da5e5796f4cb621ae"
-  integrity sha512-ZKjPqOhtSQUPJMmGQJT+XU3cmGzljgdAcJrXb5TcwEPSznUhsuCcC6MItbJ6QB+n1Aeeg3kK0CniRBlF8ZGw4A==
+"@prisma/debug@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.19.0.tgz#5d9c6b9deb0d5214360ee23644c4e40bee0f251d"
+  integrity sha512-rCFF69WVC2G8x89UaIf786m+Ik1CcEq8XiJ10kIHezOECJQRZAHVjuCXrCnHa9Z1D5r8xaSw6/SuCAmr0Fuedg==
   dependencies:
     debug "4.3.2"
     ms "^2.1.3"
 
-"@prisma/engine-core@2.17.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.17.0.tgz#c37c8d66d34c030a53c5bd172179c00ea79560ec"
-  integrity sha512-AVOCq+Mn4HISp8h4nle3ip3K8hnC7ns83pJSslozblAJILvPZ62fEee30aM3jWClnNGEIkfChB2qbe8lDELCBw==
+"@prisma/engine-core@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.19.0.tgz#89172fc048b4a02aa1062f81c2292697d95fdbe5"
+  integrity sha512-utcC150Rf1yWgLptVArTLis2beQBs4ce3lq5IApKdM6+U/5CDaF4pVCriHbyMcYqeeKMgf5SdFh1t1RJIbCsNQ==
   dependencies:
-    "@prisma/debug" "2.17.0"
-    "@prisma/engines" "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223"
-    "@prisma/generator-helper" "2.17.0"
-    "@prisma/get-platform" "2.17.0"
+    "@prisma/debug" "2.19.0"
+    "@prisma/engines" "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
+    "@prisma/generator-helper" "2.19.0"
+    "@prisma/get-platform" "2.19.0"
     chalk "^4.0.0"
     execa "^5.0.0"
     get-stream "^6.0.0"
@@ -3393,23 +3393,23 @@
     terminal-link "^2.1.1"
     undici "3.3.3"
 
-"@prisma/engines-version@2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223":
-  version "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223.tgz#9ae6ed4467a0febff8afaf216c1bb67225f51b84"
-  integrity sha512-9idv5blqPUlvUPVT48eVi3T0RS/NBklUcjrla3jWyV8AYfB2BdaG/Zci7H5ajyYLnfZZHG9tBpP0LcveQCFH8A==
+"@prisma/engines-version@2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d":
+  version "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d.tgz#a7f80d481ec6cb8e2975ab530664d4ca5fc9eba6"
+  integrity sha512-NzhbwC4iMbRQwJxdhNQX6eaVcOuNGtHRk6aesWE4KMf/YmlW5kfi3HDy7WZ/C4P0Iyn9oURDuk+xZV6QDUVjTw==
 
-"@prisma/engines@2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223":
-  version "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223.tgz#08bc3633fd27fb1935805ef16c37802ed713db5b"
-  integrity sha512-FKjVD6NYbGiQhwas3hA2uMpNchz+Mf3tv5qA8Ci9cAkKHGqt3jWjjUAK9juVBqeOcv4OPimQYMrkRX6SvaxBjg==
+"@prisma/engines@2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d":
+  version "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d.tgz#db2809a6f7f18584e3ca89b1f5bad884155629ec"
+  integrity sha512-rEWpaG7wZvPuWJC5SwkBB/Iwue//oC5yv58Mse7r+ibtgkA7vGdWc1bFDQ32DT9tDL5WSC6bBwqEASGV/1Gm1Q==
 
-"@prisma/fetch-engine@2.17.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.17.0.tgz#1814c421e648d0a911d158bbef761eb2256aa31d"
-  integrity sha512-LgFT40aZyGhJsGU+X9YXYxGhlK0diUlS/ZtxEyoNtFWy6dmToVvfn8il3tmTT6aC2rkTe1ppdDVXjPPip/CIlQ==
+"@prisma/fetch-engine@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.19.0.tgz#a01ebfc184ab09cc0ed9d6d4ef966c3846fb5332"
+  integrity sha512-Hc0OhvzWoGFQnsApGH//LSHdQggXIys/U1VQQpjOPowe5l1PQZBV/drHLrDo8jxkmQfTTFvSxcOeflkky2Bj0g==
   dependencies:
-    "@prisma/debug" "2.17.0"
-    "@prisma/get-platform" "2.17.0"
+    "@prisma/debug" "2.19.0"
+    "@prisma/get-platform" "2.19.0"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -3426,39 +3426,39 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.17.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.17.0.tgz#545485f3eccc3d20de88798ccbf17bbdca2be062"
-  integrity sha512-65CzPE/Redp8Un+pNK5y3sRkA2lXnDvNlSklrbs7nl6tFa9ZEVGoVAAt9ZdQy12g95S1Npj6LPO3qWbZxwnCbg==
+"@prisma/generator-helper@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.19.0.tgz#452ef6f47bf47d4df8cca79c0aff52160b0a7dc0"
+  integrity sha512-ZMTLyzPiqx7CETwZuo7DBlwLeckT3no3DbWN0r6iEGEyeOgOpoXhlL/ka3Payprc3j4MJ08M8MoI80biw/vdJw==
   dependencies:
-    "@prisma/debug" "2.17.0"
+    "@prisma/debug" "2.19.0"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.17.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.17.0.tgz#80a7706eb52e1dfae6c20c9fdd7a74057f1ddf3d"
-  integrity sha512-xqH1F3qm+hSgxBznNMhGj5xy3YS/osGtvE+tRxFNugx7Dw9OaVgCvvj1glVjBHSQbb0XXwfHRjYfp7zQjuLzlw==
+"@prisma/get-platform@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.19.0.tgz#1cf1fc975c28351cd50602c74f5f6532ca72bac5"
+  integrity sha512-tAv4BzJDxDDEdsU1mADdP0PKLVf8zbU9WI6nTDNSIhZsnVyBjMSWsHYnuoCgP94JtbnJ2gUSY35qJBvjLsl3kA==
   dependencies:
-    "@prisma/debug" "2.17.0"
+    "@prisma/debug" "2.19.0"
 
-"@prisma/sdk@2.17.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.17.0.tgz#e604b0a5f39669ba27cd1b88a1cb878671788f70"
-  integrity sha512-8EsU36rZEH16IyaJWbiBR0ORp/CiZf8XHBt95fzRQhFYAvI7uVYyQETdaLyn/jDPxcQDgz36CdbyzVXmscJwIQ==
+"@prisma/sdk@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.19.0.tgz#e871a4d34df64931fbdeb71613e6c10c6dc3bcc5"
+  integrity sha512-OeyinhRTWdcekIxpcfaGlXNADXukb80CWM9ok84rV8lh0q+++N3P8aiEvW85JAE5eMr5eTwlkzYlVDmfs17dRQ==
   dependencies:
-    "@prisma/debug" "2.17.0"
-    "@prisma/engine-core" "2.17.0"
-    "@prisma/engines" "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223"
-    "@prisma/fetch-engine" "2.17.0"
-    "@prisma/generator-helper" "2.17.0"
-    "@prisma/get-platform" "2.17.0"
+    "@prisma/debug" "2.19.0"
+    "@prisma/engine-core" "2.19.0"
+    "@prisma/engines" "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
+    "@prisma/fetch-engine" "2.19.0"
+    "@prisma/generator-helper" "2.19.0"
+    "@prisma/get-platform" "2.19.0"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^5.0.0"
     chalk "4.1.0"
-    checkpoint-client "1.1.18"
+    checkpoint-client "1.1.19"
     cli-truncate "^2.1.0"
     dotenv "^8.2.0"
     execa "^5.0.0"
@@ -3466,7 +3466,7 @@
     global-dirs "^3.0.0"
     globby "^11.0.0"
     has-yarn "^2.1.0"
-    is-ci "^2.0.0"
+    is-ci "^3.0.0"
     make-dir "^3.0.2"
     node-fetch "2.6.1"
     p-map "^4.0.0"
@@ -6299,18 +6299,18 @@ check-more-types@2.24.0, check-more-types@^2.24.0:
   resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
   integrity sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=
 
-checkpoint-client@1.1.18:
-  version "1.1.18"
-  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.18.tgz#7ce9d0fe3601393603235fb514334cc5dc4cbcf8"
-  integrity sha512-tTvUGOs/0Hncjq3Ko9h9Yx8facRrMpKsYXDBo7vSkl+sFKL7bxU56rQektBeEK7WcaLzGNmP2UfRfWar5P9qXA==
+checkpoint-client@1.1.19:
+  version "1.1.19"
+  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.19.tgz#8a32bddbbc6acf6e20542f18780b71e5e0b981ed"
+  integrity sha512-aChSq/qsvyu3TXAJdtKgA03JxzUD/w3fwKpUhILPGFnHEO8OHx+cg6dgjuchQsIs2r3lSPPcwzgi21xohqTrmQ==
   dependencies:
-    ci-info "2.0.0"
+    ci-info "3.1.1"
     env-paths "2.2.0"
     fast-write-atomic "0.2.1"
     make-dir "3.1.0"
-    ms "2.1.2"
+    ms "2.1.3"
     node-fetch "2.6.1"
-    uuid "8.3.0"
+    uuid "8.3.2"
 
 child-process-promise@^2.1.3:
   version "2.2.1"
@@ -6418,7 +6418,12 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-ci-info@2.0.0, ci-info@^2.0.0:
+ci-info@3.1.1, ci-info@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.1.1.tgz#9a32fcefdf7bcdb6f0a7e1c0f8098ec57897b80a"
+  integrity sha512-kdRWLBIJwdsYJWYJFtAFFYxybguqeF91qpZaggjG5Nf8QKdizFG2hjqvaTXbxFIcYbSaD74KpAXv6BSm17DHEQ==
+
+ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
@@ -10905,6 +10910,13 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
+is-ci@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz#c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994"
+  integrity sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==
+  dependencies:
+    ci-info "^3.1.1"
+
 is-color-stop@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-color-stop/-/is-color-stop-1.1.0.tgz#cfff471aee4dd5c9e158598fbe12967b5cdad345"
@@ -13487,7 +13499,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.0.0, ms@^2.1.1, ms@^2.1.2, ms@^2.1.3:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.2, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -15506,12 +15518,12 @@ preview-email@3.0.3:
     pug "^3.0.0"
     uuid "^8.3.1"
 
-prisma@2.17.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.17.0.tgz#686469914ed13d4b0926ee5f17efb7a9ab741e8a"
-  integrity sha512-NypJI7OCXCfDkRKubbVb3nmPeRJ1SjQfg6QAwK06KsreBZl1F96rFz2iB2bl4kIrhLAbIySBjwUJlG87Jsxt7g==
+prisma@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.19.0.tgz#2c14f9cbbfb0ab69c8a9473e16736759713d29ad"
+  integrity sha512-iartCNVrtR4XT20ABN3zrSi3R/pCBe75Y0ZH8681QIGm8qjRQzf3DnbscPZgZ9iY4KFuVxL8ZrBQVDmRhpN0EQ==
   dependencies:
-    "@prisma/engines" "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223"
+    "@prisma/engines" "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
 
 private@~0.1.5:
   version "0.1.8"
@@ -18980,20 +18992,15 @@ utils-merge@1.x.x:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
-  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
+uuid@8.3.2, uuid@^8.3.0, uuid@^8.3.1:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^8.3.0, uuid@^8.3.1:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@2.2.0, v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
   version "2.2.0"


### PR DESCRIPTION
Closes: ??

### What are the changes and their implications?
Prisma migrate is no longer in preview as of the 2.19 release.  If we upgrade to 2.19, we can remove the `--preview-feature` flag from scripts and docs.

### Checklist

- [✅] Changes covered by tests (tests added if needed)
- [✅] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
