### PR TITLE
Fix query parameter decoding

### DIFF
--- a/packages/core/src/router/router-hooks.ts
+++ b/packages/core/src/router/router-hooks.ts
@@ -116,25 +116,23 @@ export function useParam(
 }
 
 /*
- * Copied from https://github.com/lukeed/qss
+ * Based on the code of https://github.com/lukeed/qss
  */
 function decode(str: string) {
   if (!str) return {}
-  let tmp: any
-  let k
-  const out: Record<string, any> = {}
-  const arr = str.split("&")
 
-  // eslint-disable-next-line no-cond-assign
-  while ((tmp = arr.shift())) {
-    tmp = tmp.split("=")
-    k = tmp.shift()
-    if (out[k] !== void 0) {
-      out[k] = [].concat(out[k], tmp.shift())
+  let out: Record<string, string | string[]> = {}
+
+  for (const current of str.split("&")) {
+    let [key, value = ""] = current.split("=")
+    const decodedValue = decodeURIComponent(value)
+
+    if (key in out) {
+      out[key] = ([] as string[]).concat(out[key], decodedValue)
     } else {
-      out[k] = tmp.shift()
+      out[key] = decodedValue
     }
   }
 
-  return out as Record<string, string | string[]>
+  return out
 }

--- a/packages/core/src/router/router-hooks.ts
+++ b/packages/core/src/router/router-hooks.ts
@@ -125,12 +125,12 @@ function decode(str: string) {
 
   for (const current of str.split("&")) {
     let [key, value = ""] = current.split("=")
-    const decodedValue = decodeURIComponent(value)
+    value = decodeURIComponent(value)
 
     if (key in out) {
-      out[key] = ([] as string[]).concat(out[key], decodedValue)
+      out[key] = ([] as string[]).concat(out[key], value)
     } else {
-      out[key] = decodedValue
+      out[key] = value
     }
   }
 

--- a/packages/core/test/router-hooks.test.ts
+++ b/packages/core/test/router-hooks.test.ts
@@ -10,7 +10,7 @@ describe("useRouterQuery", () => {
     num: "0",
     bool: "true",
     float: "1.23",
-    empty: undefined,
+    empty: "",
   })
 })
 


### PR DESCRIPTION
### What are the changes and their implications?

- Decode URI components by default
- Change case `?key` from `{key: undefined}` to `{key: ''}`, to match `querystring` and `useRouter` behaviour

### Checklist

- [x] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes