### PR TITLE
Update `findModuleExportsExpressions` installer transform utility

### DIFF
--- a/packages/installer/src/transforms/find-module-exports-expressions.ts
+++ b/packages/installer/src/transforms/find-module-exports-expressions.ts
@@ -2,13 +2,14 @@ import j from "jscodeshift"
 import {Collection} from "jscodeshift/src/Collection"
 
 export function findModuleExportsExpressions(program: Collection<j.Program>) {
-  return program
-    .find(j.AssignmentExpression)
-    .filter(
-      (path) =>
-        path.value.left.type === "MemberExpression" &&
-        (path.value.left.object as any).name === "module" &&
-        (path.value.left.property as any).name === "exports" &&
-        path.value.right.type === "ObjectExpression",
+  return program.find(j.AssignmentExpression).filter((path) => {
+    const {left, right} = path.value
+    return (
+      left.type === "MemberExpression" &&
+      left.object.type === "Identifier" &&
+      left.property.type === "Identifier" &&
+      left.property.name === "exports" &&
+      right.type === "ObjectExpression"
     )
+  })
 }


### PR DESCRIPTION
Closes: N/A

### What are the changes and their implications?

@kevinlangleyjr updated `findModuleExportsExpressions` in #2112 for individual recipes. This updates the shared transform to that implementation.

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] Does this PR warrant documentation updates? If yes, open a second PR with doc changes to [blitzjs.com](https://github.com/blitz-js/blitzjs.com)

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
