### PR TITLE
fix: don't recreate the dom on query parameter changes

### DIFF
--- a/examples/auth/app/pages/test.tsx
+++ b/examples/auth/app/pages/test.tsx
@@ -1,0 +1,13 @@
+import {useRouter} from "next/router"
+import React from "react"
+
+export default function Test() {
+  const {replace} = useRouter()
+
+  const handleChange = (event: any) => {
+    // replace({ query }, undefined, { shallow: true })
+    replace(`/test?p=${event.target.value}`)
+  }
+
+  return <input onChange={handleChange} />
+}

--- a/packages/core/src/blitz-app-root.tsx
+++ b/packages/core/src/blitz-app-root.tsx
@@ -1,8 +1,8 @@
-import React, {ComponentPropsWithoutRef, useEffect} from "react"
+import React, {useEffect} from "react"
 import {useAuthorizeIf} from "./auth/auth-client"
 import {publicDataStore} from "./auth/public-data-store"
 import {Head} from "./head"
-import {AppProps, BlitzPage} from "./types"
+import {AppProps} from "./types"
 
 const customCSS = `
   body::before {
@@ -38,19 +38,15 @@ const NoPageFlicker = () => {
   )
 }
 
-export function withBlitzInnerWrapper(Page: BlitzPage) {
-  const BlitzInnerRoot = (props: ComponentPropsWithoutRef<BlitzPage>) => {
-    useAuthorizeIf(Page.authenticate === true)
-
-    return <Page {...props} />
-  }
-  for (let [key, value] of Object.entries(Page)) {
-    ;(BlitzInnerRoot as any)[key] = value
+function AuthGuard({Component, ...rest}: any) {
+  useAuthorizeIf(Component.authenticate === true)
+  for (let [key, value] of Object.entries(rest)) {
+    ;(Component as any)[key] = value
   }
   if (process.env.NODE_ENV !== "production") {
-    BlitzInnerRoot.displayName = `BlitzInnerRoot`
+    Component.displayName = `BlitzInnerRoot`
   }
-  return BlitzInnerRoot
+  return Component
 }
 
 export function withBlitzAppRoot(UserAppRoot: React.ComponentType<any>) {
@@ -86,7 +82,7 @@ export function withBlitzAppRoot(UserAppRoot: React.ComponentType<any>) {
     return (
       <>
         {noPageFlicker && <NoPageFlicker />}
-        <UserAppRoot {...props} Component={withBlitzInnerWrapper(props.Component)} />
+        <UserAppRoot {...props} Component={AuthGuard(props)} />
       </>
     )
   }


### PR DESCRIPTION
Closes: #2047

### What are the changes and their implications?
`BlitzInnerRoot` is no longer recreated on each route change throwing away the dom.

### Checklist

- [x] Changes covered by tests. As I understand it, regression should be covered by auth tests already.
- [x] Does this PR warrant documentation updates? No.

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->


My React fu isn't great, so please double check if this fix makes sense.
I didn't understand what role:
```
for (let [key, value] of Object.entries(Page)) {
    ;(BlitzInnerRoot as any)[key] = value
  }
```
plays here, but removing it didn't break any test for me :man_shrugging: 