### PR TITLE
Remove prisma 2.19 version upgrade from GQL recipe

### DIFF
--- a/recipes/graphql-apollo-server/index.ts
+++ b/recipes/graphql-apollo-server/index.ts
@@ -15,8 +15,6 @@ export default RecipeBuilder()
     packages: [
       {name: "apollo-server-micro", version: "2"},
       {name: "graphql", version: "15"},
-      {name: "prisma", version: "2.19"},
-      {name: "@prisma/client", version: "2.19"},
       {name: "nexus", version: "1"},
       {name: "nexus-prisma", version: "0.24"},
     ],


### PR DESCRIPTION
### What are the changes and their implications?

While we're cleaning up recipes, here's another small fix.

Since the recipe required prisma 2.19 but we were only on 2.17 when I wrote it, it included the version upgrade in the added packages, but now that apps are 2.19 by default thanks to https://github.com/blitz-js/blitz/pull/2138, this recipe doesn't need to do that.

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] Does this PR warrant documentation updates? If yes, open a second PR with doc changes to [blitzjs.com](https://github.com/blitz-js/blitzjs.com)

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
