### PR TITLE
Fix query string spaces with `useRouterQuery()`

### DIFF
--- a/packages/core/src/router/router-hooks.ts
+++ b/packages/core/src/router/router-hooks.ts
@@ -7,7 +7,7 @@ export function useRouterQuery() {
   const router = useRouter()
 
   const query = useMemo(() => {
-    const query = decode(router.asPath.split("?")[1])
+    const query = decode(router.asPath.split("?", 2)[1])
     return query
   }, [router.asPath])
 

--- a/packages/core/src/router/router-hooks.ts
+++ b/packages/core/src/router/router-hooks.ts
@@ -118,6 +118,8 @@ export function useParam(
 /*
  * Based on the code of https://github.com/lukeed/qss
  */
+const decodeString = (str: string) => decodeURIComponent(str).replace(/\+/g, " ")
+
 function decode(str: string) {
   if (!str) return {}
 
@@ -125,7 +127,8 @@ function decode(str: string) {
 
   for (const current of str.split("&")) {
     let [key, value = ""] = current.split("=")
-    value = decodeURIComponent(value)
+    key = decodeString(key)
+    value = decodeString(value)
 
     if (key in out) {
       out[key] = ([] as string[]).concat(out[key], value)

--- a/packages/core/src/router/router-hooks.ts
+++ b/packages/core/src/router/router-hooks.ts
@@ -118,7 +118,7 @@ export function useParam(
 /*
  * Based on the code of https://github.com/lukeed/qss
  */
-const decodeString = (str: string) => decodeURIComponent(str).replace(/\+/g, " ")
+const decodeString = (str: string) => decodeURIComponent(str.replace(/\+/g, "%20"))
 
 function decode(str: string) {
   if (!str) return {}
@@ -129,6 +129,8 @@ function decode(str: string) {
     let [key, value = ""] = current.split("=")
     key = decodeString(key)
     value = decodeString(value)
+
+    if (key.length === 0) continue
 
     if (key in out) {
       out[key] = ([] as string[]).concat(out[key], value)

--- a/packages/core/test/router-hooks.test.ts
+++ b/packages/core/test/router-hooks.test.ts
@@ -2,20 +2,30 @@ import {extractRouterParams, useParam, useParams, useRouterQuery} from "../src/r
 import {renderHook} from "./test-utils"
 
 describe("useRouterQuery", () => {
-  const {result} = renderHook(() => useRouterQuery(), {
-    router: {
-      asPath:
-        "/?foo=foo&num=0&bool=true&float=1.23&empty&encoded=D%C3%A9j%C3%A0%20vu&spaces=Hello+World",
-    },
+  it("returns proper values", () => {
+    const {result} = renderHook(() => useRouterQuery(), {
+      router: {asPath: "/?foo=foo&num=0&bool=true&float=1.23&empty"},
+    })
+
+    expect(result.current).toEqual({
+      foo: "foo",
+      num: "0",
+      bool: "true",
+      float: "1.23",
+      empty: "",
+    })
   })
-  expect(result.current).toEqual({
-    foo: "foo",
-    num: "0",
-    bool: "true",
-    float: "1.23",
-    empty: "",
-    encoded: "Déjà vu",
-    spaces: "Hello World",
+
+  it("decode correctly", () => {
+    const {result} = renderHook(() => useRouterQuery(), {
+      router: {asPath: "/?encoded=D%C3%A9j%C3%A0%20vu&spaces=Hello+World&both=Hola%2C+Mundo%21"},
+    })
+
+    expect(result.current).toEqual({
+      encoded: "Déjà vu",
+      spaces: "Hello World",
+      both: "Hola, Mundo!",
+    })
   })
 })
 

--- a/packages/core/test/router-hooks.test.ts
+++ b/packages/core/test/router-hooks.test.ts
@@ -3,7 +3,10 @@ import {renderHook} from "./test-utils"
 
 describe("useRouterQuery", () => {
   const {result} = renderHook(() => useRouterQuery(), {
-    router: {asPath: "/?foo=foo&num=0&bool=true&float=1.23&empty"},
+    router: {
+      asPath:
+        "/?foo=foo&num=0&bool=true&float=1.23&empty&encoded=D%C3%A9j%C3%A0%20vu&spaces=Hello+World",
+    },
   })
   expect(result.current).toEqual({
     foo: "foo",
@@ -11,6 +14,8 @@ describe("useRouterQuery", () => {
     bool: "true",
     float: "1.23",
     empty: "",
+    encoded: "Déjà vu",
+    spaces: "Hello World",
   })
 })
 


### PR DESCRIPTION
### What are the changes and their implications?

Now, when doing something like `router.push({query: {search: "hello world"}})`, the result will be `{search: "hello world"}` instead of `{search: "hello+world"}`

### Checklist

- [x] Changes covered by tests (tests added if needed)
- [ ] Does this PR warrant documentation updates? If yes, open a second PR with doc changes to [blitzjs.com](https://github.com/blitz-js/blitzjs.com)

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
