### PR TITLE
(newapp) Fix husky scripts to use `npx` for binaries instead of `npm run`

### DIFF
--- a/packages/generator/templates/app/.husky/pre-commit
+++ b/packages/generator/templates/app/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run lint-staged
-npm run pretty-quick --staged
+npx lint-staged
+npx pretty-quick --staged

--- a/packages/generator/templates/app/.husky/pre-push
+++ b/packages/generator/templates/app/.husky/pre-push
@@ -1,6 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run tsc
+npx tsc
 npm run lint
 npm run test


### PR DESCRIPTION


<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/blitz/issues/2208

### What are the changes and their implications?

Fix husky scripts to use `npx` for binaries instead of `npm run`
