### PR TITLE
Fix `Routes` manifest type error. Change to `string` to `string | number`

### DIFF
--- a/examples/auth/app/pages/projects/[projectId].tsx
+++ b/examples/auth/app/pages/projects/[projectId].tsx
@@ -24,7 +24,7 @@ export const Project = () => {
         <h1>Project {project.id}</h1>
         <pre>{JSON.stringify(project, null, 2)}</pre>
 
-        <Link href={`/projects/${project.id}/edit`}>
+        <Link href={Routes.EditProjectPage({projectId: project.id})}>
           <a>Edit</a>
         </Link>
 

--- a/examples/auth/app/pages/projects/index.tsx
+++ b/examples/auth/app/pages/projects/index.tsx
@@ -24,7 +24,7 @@ export const ProjectsList = () => {
       <ul>
         {projects.map((project) => (
           <li key={project.id}>
-            <Link href={`/projects/${project.id}`}>
+            <Link href={Routes.ShowProjectPage({projectId: project.id})}>
               <a>{project.name}</a>
             </Link>
           </li>

--- a/packages/server/src/stages/route-import-manifest/route-import-manifest.spec.ts
+++ b/packages/server/src/stages/route-import-manifest/route-import-manifest.spec.ts
@@ -38,7 +38,7 @@ import type { ParsedUrlQueryInput } from "querystring"
 
 export const Routes: {
   Home(query?: ParsedUrlQueryInput): UrlObject;
-  CommentView(query: { postId: string; openedCommentPath: string[] } & ParsedUrlQueryInput): UrlObject;
+  CommentView(query: { postId: string | number; openedCommentPath: (string | number)[] } & ParsedUrlQueryInput): UrlObject;
 }
       `.trim(),
   })

--- a/packages/server/src/stages/route-import-manifest/route-import-manifest.ts
+++ b/packages/server/src/stages/route-import-manifest/route-import-manifest.ts
@@ -62,8 +62,8 @@ export function generateManifest(
       }
 
       return `${name}(query: { ${[
-        ...parameters.map((param) => param + ": string"),
-        ...multipleParameters.map((param) => param + ": string[]"),
+        ...parameters.map((param) => param + ": string | number"),
+        ...multipleParameters.map((param) => param + ": (string | number)[]"),
       ].join("; ")} } & ParsedUrlQueryInput): UrlObject`
     },
   )


### PR DESCRIPTION
### What are the changes and their implications?

Before this, something like this (taken from blitzjs.com) would throw a TypeScript error:

```tsx
<Link href={Routes.ProductsPage({ productId: 123 })} />
```

## Bug Checklist

- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
