### PR TITLE
redirectAuthenticatedTo can be null from Routes manifest

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,7 +37,7 @@ export type BlitzPage<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (component: JSX.Element) => JSX.Element
   authenticate?: boolean | {redirectTo?: string}
   suppressFirstRenderFlicker?: boolean
-  redirectAuthenticatedTo?: string
+  redirectAuthenticatedTo?: string | null
 }
 
 export interface DefaultCtx {}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,7 +35,7 @@ export interface AppProps<P = {}> extends NextAppProps<P> {
 }
 export type BlitzPage<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (component: JSX.Element) => JSX.Element
-  authenticate?: boolean | {redirectTo?: string}
+  authenticate?: boolean | {redirectTo?: string | null}
   suppressFirstRenderFlicker?: boolean
   redirectAuthenticatedTo?: string | null
 }


### PR DESCRIPTION
Closes: #2231 

### What are the changes and their implications?

Update type of `redirectAuthenticatedTo` to accept `null`

null or undefined will have the same effect because the `blitz-app-root` component is just checking if the value is truthy:

- https://github.com/blitz-js/blitz/blob/563720bb5798b0c43d6858ffe502d19d78be1c5b/packages/core/src/blitz-app-root.tsx#L61
- https://github.com/blitz-js/blitz/blob/563720bb5798b0c43d6858ffe502d19d78be1c5b/packages/core/src/blitz-app-root.tsx#L82

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
