### PR TITLE
fix type issues with Routes manifest

### DIFF
--- a/examples/auth/app/auth/pages/login.tsx
+++ b/examples/auth/app/auth/pages/login.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import {useRouter, BlitzPage} from "blitz"
 import Layout from "app/core/layouts/Layout"
 import {LoginForm} from "app/auth/components/LoginForm"
+import {Routes} from ".blitz"
 
 const LoginPage: BlitzPage = () => {
   const router = useRouter()
@@ -18,7 +19,7 @@ const LoginPage: BlitzPage = () => {
   )
 }
 
-LoginPage.redirectAuthenticatedTo = "/"
+LoginPage.redirectAuthenticatedTo = Routes.Home().pathname
 LoginPage.getLayout = (page) => <Layout title="Log In">{page}</Layout>
 
 export default LoginPage

--- a/packages/server/src/stages/route-import-manifest/route-import-manifest.test.ts
+++ b/packages/server/src/stages/route-import-manifest/route-import-manifest.test.ts
@@ -36,7 +36,7 @@ exports.Routes = {
 import type { UrlObject } from "url"
 import type { ParsedUrlQueryInput } from "querystring"
 
-interface RouteUrlObject extends UrlObject {
+interface RouteUrlObject extends Pick<UrlObject, 'pathname' | 'query'> {
   pathname: string
 }
 

--- a/packages/server/src/stages/route-import-manifest/route-import-manifest.test.ts
+++ b/packages/server/src/stages/route-import-manifest/route-import-manifest.test.ts
@@ -36,9 +36,13 @@ exports.Routes = {
 import type { UrlObject } from "url"
 import type { ParsedUrlQueryInput } from "querystring"
 
+interface RouteUrlObject extends UrlObject {
+  pathname: string
+}
+
 export const Routes: {
-  Home(query?: ParsedUrlQueryInput): UrlObject;
-  CommentView(query: { postId: string | number; openedCommentPath: (string | number)[] } & ParsedUrlQueryInput): UrlObject;
+  Home(query?: ParsedUrlQueryInput): RouteUrlObject;
+  CommentView(query: { postId: string | number; openedCommentPath: (string | number)[] } & ParsedUrlQueryInput): RouteUrlObject;
 }
       `.trim(),
   })

--- a/packages/server/src/stages/route-import-manifest/route-import-manifest.ts
+++ b/packages/server/src/stages/route-import-manifest/route-import-manifest.ts
@@ -75,7 +75,7 @@ export function generateManifest(
 import type { UrlObject } from "url"
 import type { ParsedUrlQueryInput } from "querystring"
 
-interface RouteUrlObject extends UrlObject {
+interface RouteUrlObject extends Pick<UrlObject, 'pathname' | 'query'> {
   pathname: string
 }
 

--- a/packages/server/src/stages/route-import-manifest/route-import-manifest.ts
+++ b/packages/server/src/stages/route-import-manifest/route-import-manifest.ts
@@ -58,13 +58,13 @@ export function generateManifest(
   const declarationLines = routesWithoutDuplicates.map(
     ([_path, {name, parameters, multipleParameters}]) => {
       if (parameters.length === 0 && multipleParameters.length === 0) {
-        return `${name}(query?: ParsedUrlQueryInput): UrlObject`
+        return `${name}(query?: ParsedUrlQueryInput): RouteUrlObject`
       }
 
       return `${name}(query: { ${[
         ...parameters.map((param) => param + ": string | number"),
         ...multipleParameters.map((param) => param + ": (string | number)[]"),
-      ].join("; ")} } & ParsedUrlQueryInput): UrlObject`
+      ].join("; ")} } & ParsedUrlQueryInput): RouteUrlObject`
     },
   )
 
@@ -74,6 +74,10 @@ export function generateManifest(
     declaration: `
 import type { UrlObject } from "url"
 import type { ParsedUrlQueryInput } from "querystring"
+
+interface RouteUrlObject extends UrlObject {
+  pathname: string
+}
 
 export const Routes: {
 ${declarationLines.map((line) => "  " + line).join(";\n")};


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/blitz/issues/2231

### What are the changes and their implications?

Fix to remove `null | undefined` from routes manifest type for pathname because it will always be a string.

This also removes type of keys that aren't not present. Now type signature reflects reality.

## Bug Checklist

- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
