### PR TITLE
Export `BlitzApiHandler` type

### DIFF
--- a/packages/core/src/server/auth/passport-adapter.ts
+++ b/packages/core/src/server/auth/passport-adapter.ts
@@ -9,7 +9,7 @@ import {
   SessionContext,
   VerifyCallbackResult,
 } from "../../auth/auth-types"
-import {BlitzApiRequest, BlitzApiResponse, ConnectMiddleware, Ctx, Middleware} from "../../types"
+import {BlitzApiHandler, ConnectMiddleware, Ctx, Middleware} from "../../types"
 import {
   connectMiddleware,
   getAllMiddlewareForModule,
@@ -30,8 +30,8 @@ const isVerifyCallbackResult = (value: unknown): value is VerifyCallbackResult =
 
 const INTERNAL_REDIRECT_URL_KEY = "_redirectUrl"
 
-export function passportAuth(config: BlitzPassportConfig) {
-  return async function authHandler(req: BlitzApiRequest, res: BlitzApiResponse) {
+export function passportAuth(config: BlitzPassportConfig): BlitzApiHandler {
+  return async function authHandler(req, res) {
     const globalMiddleware = getAllMiddlewareForModule({} as any)
     await handleRequestWithMiddleware(req, res, globalMiddleware)
 

--- a/packages/core/src/server/middleware.test.ts
+++ b/packages/core/src/server/middleware.test.ts
@@ -2,7 +2,7 @@ import http from "http"
 import {apiResolver} from "next/dist/next-server/server/api-utils"
 import fetch from "node-fetch"
 import listen from "test-listen"
-import {BlitzApiRequest, BlitzApiResponse, Middleware} from "../types"
+import {BlitzApiHandler, Middleware} from "../types"
 import {handleRequestWithMiddleware} from "./middleware"
 
 describe("handleRequestWithMiddleware", () => {
@@ -102,7 +102,7 @@ describe("handleRequestWithMiddleware", () => {
 })
 
 async function mockServer(middleware: Middleware[], callback: (url: string) => Promise<void>) {
-  const apiEndpoint = async (req: BlitzApiRequest, res: BlitzApiResponse) => {
+  const apiEndpoint: BlitzApiHandler = async (req, res) => {
     try {
       await handleRequestWithMiddleware(req, res, middleware, {stackPrintOnError: false})
     } catch (err) {

--- a/packages/core/src/server/rpc-server.ts
+++ b/packages/core/src/server/rpc-server.ts
@@ -1,7 +1,7 @@
 import {baseLogger, log as displayLog} from "@blitzjs/display"
 import chalk from "chalk"
 import {deserialize, serialize} from "superjson"
-import {BlitzApiRequest, BlitzApiResponse, EnhancedResolver, Middleware} from "../types"
+import {BlitzApiHandler, EnhancedResolver, Middleware} from "../types"
 import {prettyMs} from "../utils/pretty-ms"
 import {handleRequestWithMiddleware} from "./middleware"
 
@@ -104,11 +104,11 @@ export function rpcApiHandler<TInput, TResult>(
   resolver: EnhancedResolver<TInput, TResult>,
   middleware: Middleware[] = [],
   connectDb?: () => any,
-) {
+): BlitzApiHandler {
   // RPC Middleware is always the last middleware to run
   middleware.push(rpcMiddleware(resolver, connectDb))
 
-  return (req: BlitzApiRequest, res: BlitzApiResponse) => {
+  return (req, res) => {
     return handleRequestWithMiddleware(req, res, middleware, {
       throwOnError: false,
     })

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,7 @@
 import {IncomingMessage, ServerResponse} from "http"
 import {AppProps as NextAppProps} from "next/app"
 import {
+  NextApiHandler,
   NextApiRequest,
   NextApiResponse,
   NextComponentType,
@@ -24,8 +25,9 @@ export type {
   PageConfig,
   Redirect,
 } from "next"
+export type BlitzApiHandler<T = any> = NextApiHandler<T>
 export type BlitzApiRequest = NextApiRequest
-export type BlitzApiResponse = NextApiResponse
+export type BlitzApiResponse<T = any> = NextApiResponse<T>
 export type BlitzPageContext = NextPageContext
 
 export type BlitzComponentType<C = NextPageContext, IP = {}, P = {}> = NextComponentType<C, IP, P>


### PR DESCRIPTION
### What are the changes and their implications?

Exports `BlitzApiHandler` type and added a missing generic of `BlitzApiResponse`

## Feature Checklist

- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
