### PR TITLE
Add Typescript & esmodule support and hot reloading to custom servers

### DIFF
--- a/examples/custom-server/package.json
+++ b/examples/custom-server/package.json
@@ -2,7 +2,7 @@
   "name": "@examples/custom-server",
   "version": "0.34.0-canary.0",
   "scripts": {
-    "dev": "nodemon --watch server.js --exec 'blitz dev'",
+    "dev": "blitz dev",
     "build": "blitz build",
     "start": "blitz start",
     "studio": "blitz prisma studio",

--- a/examples/custom-server/server.ts
+++ b/examples/custom-server/server.ts
@@ -1,7 +1,7 @@
-const {createServer} = require("http")
-const {parse} = require("url")
-const blitz = require("blitz/custom-server")
-const {log} = require("@blitzjs/display")
+import blitz from "blitz/custom-server"
+import {createServer} from "http"
+import {parse} from "url"
+import {log} from "@blitzjs/display"
 
 const {PORT = "3000"} = process.env
 const dev = process.env.NODE_ENV !== "production"
@@ -10,7 +10,7 @@ const handle = app.getRequestHandler()
 
 app.prepare().then(() => {
   createServer((req, res) => {
-    const parsedUrl = parse(req.url, true)
+    const parsedUrl = parse(req.url!, true)
     const {pathname} = parsedUrl
 
     if (pathname === "/hello") {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "wait:nextjs-types": "wait-on -d 1000 nextjs/packages/next/dist/build/index.d.ts",
     "dev:nextjs": "yarn workspace next dev",
     "dev:nextjs-types": "yarn wait:nextjs && yarn workspace next types && echo 'Finished building nextjs types'",
-    "dev:blitz": "preconstruct watch",
+    "dev:blitz": "cross-env BLITZ_PROD_BUILD=true preconstruct watch",
     "dev:tsc": "yarn dev:nextjs-types && tsc --watch --pretty --preserveWatchOutput",
     "dev:cli": "yarn wait:nextjs && yarn workspace @blitzjs/cli dev",
     "dev:templates": "yarn workspace @blitzjs/generator dev",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,6 +29,7 @@
     "@blitzjs/file-pipeline": "0.34.3",
     "cross-spawn": "7.0.3",
     "detect-port": "1.3.0",
+    "esbuild": "0.11.12",
     "expand-tilde": "2.0.2",
     "fast-glob": "3.2.5",
     "flush-write-stream": "2.0.0",

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -39,9 +39,9 @@ export async function dev(config: ServerConfig) {
 
   if (!versionMatched) await saveBlitzVersion(buildFolder)
 
-  if (customServerExists(buildFolder)) {
+  if (customServerExists()) {
     log.success("Using your custom server")
-    await startCustomServer(buildFolder, config)
+    await startCustomServer(buildFolder, config, {watch: true})
   } else {
     await nextStartDev(nextBin, buildFolder, manifest, buildFolder, config)
   }

--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -1,8 +1,9 @@
 import {getProjectRoot} from "@blitzjs/config"
 import {log} from "@blitzjs/display"
+import {ChildProcess} from "child_process"
 import {spawn} from "cross-spawn"
 import detect from "detect-port"
-import fs from "fs"
+import * as esbuild from "esbuild"
 import path from "path"
 import {ServerConfig, standardBuildFolderPathRegex} from "./config"
 import {Manifest} from "./stages/manifest"
@@ -206,16 +207,35 @@ export async function nextStart(nextBin: string, buildFolder: string, config: Se
   })
 }
 
-export function getCustomServerPath(cwd: string) {
-  return path.resolve(cwd, "server.js")
+export function getCustomServerPath() {
+  const projectRoot = getProjectRoot()
+  return require.resolve(path.join(projectRoot, "server"))
+}
+export function getCustomServerBuildPath() {
+  const projectRoot = getProjectRoot()
+  return path.resolve(projectRoot, ".blitz", "custom-server.js")
 }
 
-export function customServerExists(cwd: string) {
-  return fs.existsSync(getCustomServerPath(cwd))
+export function customServerExists() {
+  try {
+    getCustomServerPath()
+    return true
+  } catch {
+    return false
+  }
 }
 
-export function startCustomServer(cwd: string, config: ServerConfig) {
-  const serverPath = getCustomServerPath(cwd)
+interface CustomServerOptions {
+  watch?: boolean
+}
+
+export function startCustomServer(
+  cwd: string,
+  config: ServerConfig,
+  {watch}: CustomServerOptions = {},
+) {
+  const serverSrcPath = getCustomServerPath()
+  const serverBuildPath = getCustomServerBuildPath()
 
   let spawnEnv = getSpawnEnv(config)
   if (config.env === "prod") {
@@ -223,17 +243,60 @@ export function startCustomServer(cwd: string, config: ServerConfig) {
   }
 
   return new Promise<void>((res, rej) => {
-    spawn("node", [serverPath], {
-      cwd,
-      env: spawnEnv,
-      stdio: "inherit",
+    let process: ChildProcess
+
+    const RESTART_CODE = 777777
+
+    const spawnServer = () => {
+      process = spawn("node", [serverBuildPath], {
+        cwd,
+        env: spawnEnv,
+        stdio: "inherit",
+      })
+        .on("exit", (code: number) => {
+          if (code === 0) {
+            res()
+          } else if (watch && code === RESTART_CODE) {
+            spawnServer()
+          } else {
+            rej(`server.js failed with status code: ${code}`)
+          }
+        })
+        .on("error", (err) => {
+          console.error(err)
+          rej(err)
+        })
+    }
+
+    const esbuildOptions: esbuild.BuildOptions = {
+      entryPoints: [serverSrcPath],
+      outfile: getCustomServerBuildPath(),
+      format: "cjs",
+      bundle: true,
+      platform: "node",
+      external: ["blitz", "next", ...Object.keys(require("blitz/package").dependencies)],
+    }
+
+    if (watch) {
+      esbuildOptions.watch = {
+        onRebuild(error) {
+          if (error) {
+            log.error("Failed to re-build custom server")
+          } else {
+            log.newline()
+            log.progress("Custom server changed - restarting...")
+            log.newline()
+            //@ts-ignore -- incorrect TS type from node
+            process.exitCode = RESTART_CODE
+            process.kill("SIGABRT")
+          }
+        },
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    esbuild.build(esbuildOptions).then(() => {
+      spawnServer()
     })
-      .on("exit", (code: number) => {
-        code === 0 ? res() : rej(`server.js failed with status code: ${code}`)
-      })
-      .on("error", (err) => {
-        console.error(err)
-        rej(err)
-      })
   })
 }

--- a/packages/server/src/prod.ts
+++ b/packages/server/src/prod.ts
@@ -10,7 +10,7 @@ export async function prod(config: ServerConfig) {
     process.exit(1)
   }
 
-  if (customServerExists(buildFolder)) {
+  if (customServerExists()) {
     log.success("Using your custom server")
     await startCustomServer(buildFolder, config)
   } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9100,6 +9100,11 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.3:
     d "^1.0.1"
     ext "^1.1.2"
 
+esbuild@0.11.12:
+  version "0.11.12"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.11.12.tgz#8cbe15bcb44212624c3e77c896a835f74dc71c3c"
+  integrity sha512-c8cso/1RwVj+fbDvLtUgSG4ZJQ0y9Zdrl6Ot/GAjyy4pdMCHaFnDMts5gqFnWRPLajWtEnI+3hlET4R9fVoZng==
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/blitz/issues/1987

### What are the changes and their implications?

This adds support for Typescript & esmodule to Custom Servers and adds hot reloading to custom servers.

Now `server.ts` or `server.js` with `import` statements will just seamlessly work!

## Feature Checklist

- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [x] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
