### PR TITLE
Add experimental.initServer hook for running code on server start

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,7 +154,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: Test examples
-        run: yarn testonly:examples
+        run: yarn testonly:examples || yarn testonly:examples
         env:
           CI: true
 

--- a/examples/auth/blitz.config.js
+++ b/examples/auth/blitz.config.js
@@ -17,7 +17,9 @@ module.exports = withBundleAnalyzer({
     // level: "trace",
   },
   experimental: {
-    isomorphicResolverImports: false,
+    initServer() {
+      console.log("Hello world from initServer")
+    },
   },
   /*
   webpack: (config, {buildId, dev, isServer, defaultLoaders, webpack}) => {

--- a/nextjs/packages/next/next-server/server/config-shared.ts
+++ b/nextjs/packages/next/next-server/server/config-shared.ts
@@ -39,6 +39,7 @@ export type NextConfig = { [key: string]: any } & {
   experimental: {
     cpus?: number
     plugins?: boolean
+    initServer?: () => void
     profiling?: boolean
     sprFlushToDisk?: boolean
     reactMode?: 'legacy' | 'concurrent' | 'blocking'

--- a/nextjs/packages/next/next-server/server/next-server.ts
+++ b/nextjs/packages/next/next-server/server/next-server.ts
@@ -190,6 +190,7 @@ export default class Server {
       assetPrefix,
       generateEtags,
       compress,
+      experimental,
     } = this.nextConfig
 
     this.buildId = this.readBuildId()
@@ -245,6 +246,10 @@ export default class Server {
     this.customRoutes = this.getCustomRoutes()
     this.router = new Router(this.generateRoutes())
     this.setAssetPrefix(assetPrefix)
+
+    if (experimental.initServer) {
+      experimental.initServer()
+    }
 
     // call init-server middleware, this is also handled
     // individually in serverless bundles when deployed

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "testheadless": "cross-env HEADLESS=true yarn test:integration",
     "test:integration": "jest --runInBand",
     "test:packages": "yarn run build && yarn testonly:packages",
-    "test:examples": "yarn run build && yarn testonly:examples || yarn testonly:examples",
+    "test:examples": "yarn run build && yarn testonly:examples",
     "test:nextjs-size": "yarn --cwd nextjs testheadless --testPathPattern \"integration/(build-output|size-limit|fallback-modules)\"",
     "testonly": "yarn test:packages && yarn test:examples",
     "testonly:packages": "ultra -r --filter \"packages/*\" --concurrency 15 test",


### PR DESCRIPTION
### What are the changes and their implications?

This adds an experimental feature for running code on server start, for both serverful and serverless deployments.

```js
// blitz.config.js
module.exports = {
  experimental: {
    initServer() {
      console.log("Hello world from initServer")
    },
  },
}
```

If you try this feature, please give me feedback on how well it works and how well you like it.
