### PR TITLE
(newapp) move all devDependencies to regular dependencies

### DIFF
--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -24,25 +24,23 @@
     ]
   },
   "dependencies": {
-    "prisma": "~2.20",
     "@prisma/client": "~2.20",
-    "blitz": "canary",
-    "react": "0.0.0-experimental-6a589ad71",
-    "react-dom": "0.0.0-experimental-6a589ad71",
-    "react-error-boundary": "3.x",
-    "typescript": "~4.2",
-    "zod": "1.x"
-  },
-  "devDependencies": {
     "@types/react": "17.x",
     "@types/preview-email": "2.x",
+    "blitz": "canary",
     "eslint": "7.x",
     "husky": "6.x",
     "lint-staged": "10.x",
     "prettier": "2.x",
     "pretty-quick": "3.x",
     "preview-email": "3.x",
-    "prettier-plugin-prisma": "0.7.x"
+    "prettier-plugin-prisma": "0.7.x",
+    "prisma": "~2.20",
+    "react": "0.0.0-experimental-6a589ad71",
+    "react-dom": "0.0.0-experimental-6a589ad71",
+    "react-error-boundary": "3.x",
+    "typescript": "~4.2",
+    "zod": "1.x"
   },
   "private": true
 }

--- a/recipes/emotion/index.ts
+++ b/recipes/emotion/index.ts
@@ -68,7 +68,7 @@ export default RecipeBuilder()
     packages: [
       {name: "@emotion/react", version: "11"},
       {name: "@emotion/styled", version: "11"},
-      {name: "@emotion/babel-plugin", version: "11", isDevDep: true},
+      {name: "@emotion/babel-plugin", version: "11"},
     ],
   })
   .addNewFilesStep({

--- a/recipes/quirrel/index.ts
+++ b/recipes/quirrel/index.ts
@@ -19,7 +19,6 @@ export default RecipeBuilder()
       {
         name: "concurrently",
         version: "latest",
-        isDevDep: true,
       },
     ],
   })

--- a/recipes/styled-components/index.ts
+++ b/recipes/styled-components/index.ts
@@ -49,7 +49,7 @@ export default RecipeBuilder()
     explanation: `Add 'styled-components' as a dependency and 'babel-plugin-styled-components' as a dev dependency.`,
     packages: [
       {name: "styled-components", version: "latest"},
-      {name: "babel-plugin-styled-components", version: "11", isDevDep: true},
+      {name: "babel-plugin-styled-components", version: "11"},
     ],
   })
   .addNewFilesStep({

--- a/recipes/tailwind/index.ts
+++ b/recipes/tailwind/index.ts
@@ -13,9 +13,9 @@ export default RecipeBuilder()
     stepName: "npm dependencies",
     explanation: `Tailwind CSS requires a couple of dependencies including PostCSS for removing unused styles from the production bundle`,
     packages: [
-      {name: "tailwindcss", version: "2.1.2", isDevDep: true},
-      {name: "autoprefixer", version: "10", isDevDep: true},
-      {name: "postcss", version: "8", isDevDep: true},
+      {name: "tailwindcss", version: "2.1.2"},
+      {name: "autoprefixer", version: "10"},
+      {name: "postcss", version: "8"},
     ],
   })
   .addNewFilesStep({


### PR DESCRIPTION


### What are the changes and their implications?

Too often devs run into issues where things in devDependencies that are required for the build don't get installed and the build fails. For web apps, the distinction between dev and prod dependencies is essentially worthless. Also providers like Vercel install all dependencies, including dev dependencies. Instead of always wondering should this be a regular or dev dependency, simplify your life and install everything as production dependencies.

