### PR TITLE
add ability to increase bodyParser size for queries & mutations

### DIFF
--- a/examples/auth/app/auth/mutations/login.ts
+++ b/examples/auth/app/auth/mutations/login.ts
@@ -27,3 +27,11 @@ export default resolver.pipe(resolver.zod(Login), async ({email, password}, ctx)
 
   return user
 })
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "2mb",
+    },
+  },
+}

--- a/packages/core/src/rpc-client.ts
+++ b/packages/core/src/rpc-client.ts
@@ -230,6 +230,7 @@ export function getIsomorphicEnhancedResolver<TInput, TResult>(
     if (!resolver) throw new Error("resolver is missing on the server")
     const enhancedResolver = (resolver.default as unknown) as EnhancedResolver<TInput, TResult>
     enhancedResolver.middleware = resolver.middleware
+    enhancedResolver.config = resolver.config
     enhancedResolver._meta = {
       name: resolverName,
       type: resolverType,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -119,6 +119,7 @@ export type Resolver<TInput, TResult> = (input: TInput, ctx?: any) => Promise<TR
 export type ResolverModule<TInput, TResult> = {
   default: Resolver<TInput, TResult>
   middleware?: Middleware[]
+  config?: Record<string, any>
 }
 
 export type RpcOptions = {
@@ -141,6 +142,7 @@ export interface ResolverRpcExecutor<TInput, TResult> {
 export type ResolverType = "query" | "mutation"
 
 export interface ResolverEnhancement {
+  config?: Record<string, any>
   _meta: {
     name: string
     type: ResolverType

--- a/packages/server/src/stages/rpc/index.ts
+++ b/packages/server/src/stages/rpc/index.ts
@@ -94,7 +94,9 @@ export default rpcApiHandler(
 )
 
 export const config = {
+  ...enhancedResolver.config,
   api: {
+    ...enhancedResolver.config?.api,
     externalResolver: true,
   },
 }

--- a/test/integration/misc/app/queries/getBasic.ts
+++ b/test/integration/misc/app/queries/getBasic.ts
@@ -1,0 +1,3 @@
+export default async function getBasic() {
+  return "basic-result"
+}

--- a/test/integration/misc/app/queries/getError.ts
+++ b/test/integration/misc/app/queries/getError.ts
@@ -1,0 +1,11 @@
+export default async function getError() {
+  return "should-not-succeed"
+}
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "0kb",
+    },
+  },
+}

--- a/test/integration/misc/babel.config.js
+++ b/test/integration/misc/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ["blitz/babel"],
+  plugins: [],
+}

--- a/test/integration/misc/blitz.config.js
+++ b/test/integration/misc/blitz.config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/integration/misc/pages/_app.tsx
+++ b/test/integration/misc/pages/_app.tsx
@@ -1,0 +1,11 @@
+import {AppProps} from "blitz"
+import {ReactQueryDevtools} from "react-query/devtools"
+
+export default function App({Component, pageProps}: AppProps) {
+  return (
+    <>
+      <Component {...pageProps} />
+      <ReactQueryDevtools />
+    </>
+  )
+}

--- a/test/integration/misc/pages/_document.tsx
+++ b/test/integration/misc/pages/_document.tsx
@@ -1,0 +1,23 @@
+import {BlitzScript, Document, DocumentHead, Html, Main} from "blitz"
+
+class MyDocument extends Document {
+  // Only uncomment if you need to customize this behaviour
+  // static async getInitialProps(ctx: DocumentContext) {
+  //   const initialProps = await Document.getInitialProps(ctx)
+  //   return {...initialProps}
+  // }
+
+  render() {
+    return (
+      <Html lang="en">
+        <DocumentHead />
+        <body>
+          <Main />
+          <BlitzScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/test/integration/misc/pages/body-parser.tsx
+++ b/test/integration/misc/pages/body-parser.tsx
@@ -1,0 +1,24 @@
+import getError from "app/queries/getError"
+import {useQuery} from "blitz"
+import {Suspense} from "react"
+import {ErrorBoundary} from "react-error-boundary"
+
+function Content() {
+  const [result] = useQuery(getError, undefined)
+
+  return <div id="content">{result}</div>
+}
+
+function Page() {
+  return (
+    <div id="page">
+      <ErrorBoundary FallbackComponent={() => <div id="error">query failed</div>}>
+        <Suspense fallback="Loading...">
+          <Content />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  )
+}
+
+export default Page

--- a/test/integration/misc/test/index.test.ts
+++ b/test/integration/misc/test/index.test.ts
@@ -1,0 +1,32 @@
+/* eslint-env jest */
+import {findPort, killApp, launchApp, renderViaHTTP, waitFor} from "lib/blitz-test-utils"
+import webdriver from "lib/next-webdriver"
+import {join} from "path"
+
+const context: any = {}
+jest.setTimeout(1000 * 60 * 5)
+
+describe("Misc", () => {
+  beforeAll(async () => {
+    context.appPort = await findPort()
+    context.server = await launchApp(join(__dirname, "../"), context.appPort, {
+      env: {__NEXT_TEST_WITH_DEVTOOL: 1},
+    })
+
+    const prerender = ["/body-parser"]
+    await Promise.all(prerender.map((route) => renderViaHTTP(context.appPort, route)))
+  })
+  afterAll(() => killApp(context.server))
+
+  describe("body parser config", () => {
+    it("should render query result", async () => {
+      const browser = await webdriver(context.appPort, "/body-parser")
+      let text = await browser.elementByCss("#page").text()
+      expect(text).toMatch(/Loading/)
+      await browser.waitForElementByCss("#error")
+      text = await browser.elementByCss("#error").text()
+      expect(text).toMatch(/query failed/)
+      if (browser) await browser.close()
+    })
+  })
+})

--- a/test/integration/misc/tsconfig.json
+++ b/test/integration/misc/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "baseUrl": "./",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "tsBuildInfoFile": ".tsbuildinfo",
+    "paths": {
+      "lib/*": ["../../lib/*"]
+    }
+  },
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
+}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #2210

### What are the changes and their implications?

Add ability to increase bodyParser size for queries & mutations, same as for API routes.

You can export a config object from a blitz query or mutation like this:

```ts
export const config = {
  api: {
    bodyParser: {
      sizeLimit: "2mb",
    },
  },
};
```

## Feature Checklist

- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
