### PR TITLE
Fix `Routes.X` is not a function when inside a monorepo 

### DIFF
--- a/packages/server/src/stages/route-import-manifest/route-import-manifest.ts
+++ b/packages/server/src/stages/route-import-manifest/route-import-manifest.ts
@@ -148,6 +148,16 @@ export function parseParametersFromRoute(
   }
 }
 
+/**
+ * Will resolve the real node_modules root.
+ * We're not fooled by you, `yarn workspace`!
+ */
+function findNodeModulesRoot(src: string) {
+  const nodeModules = join(src, "node_modules")
+  const includesBlitzPackage = fs.existsSync(join(nodeModules, "blitz"))
+  return includesBlitzPackage ? nodeModules : join(nodeModules, "../../../node_modules")
+}
+
 export const createStageRouteImportManifest: Stage & {overrideTriage: OverrideTriage} = ({
   getRouteCache,
   config,
@@ -156,7 +166,7 @@ export const createStageRouteImportManifest: Stage & {overrideTriage: OverrideTr
 
   const routes: Record<string, Route> = {}
 
-  const dotBlitz = join(config.src, "node_modules", ".blitz")
+  const dotBlitz = join(findNodeModulesRoot(config.src), ".blitz")
 
   const writeManifestImplementation = makeDebouncedWriter(join(dotBlitz, "index.js"))
   const writeManifestBrowserImplementation = makeDebouncedWriter(join(dotBlitz, "index-browser.js"))


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #2272

### What are the changes and their implications?
Fixes #2272 by detecting the location of `node_modules/blitz` and emitting besides it.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
