### PR TITLE
Fix Regression on Tailwind Recipe purging in production

### DIFF
--- a/recipes/tailwind/templates/config/tailwind.config.js
+++ b/recipes/tailwind/templates/config/tailwind.config.js
@@ -1,11 +1,7 @@
 // tailwind.config.js
 module.exports = {
   mode: "jit",
-  purge: {
-    content: ["./app/**/*.{js,ts,jsx,tsx}"],
-    mode: "all",
-    preserveHtmlElements: false,
-  },
+  purge: ["{pages,app}/**/*.{js,ts,jsx,tsx}"],
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {},


### PR DESCRIPTION
Fix Regression on Tailwind Recipe for css-purging in production (originally fixed in #930, broken since #2304) and remove the aggressive, non-standard purge-settings as they may result in over-purging.
