### PR TITLE
[Fix] Make Typescript happy on `forgotPassword.test.ts`, closes #2378

### DIFF
--- a/packages/generator/templates/app/app/auth/mutations/forgotPassword.test.ts
+++ b/packages/generator/templates/app/app/auth/mutations/forgotPassword.test.ts
@@ -41,7 +41,7 @@ describe("forgotPassword mutation", () => {
     await forgotPassword({ email: user.email }, {} as Ctx)
 
     const tokens = await db.token.findMany({ where: { userId: user.id } })
-    const token = tokens[0]
+    const token = tokens[0]!
 
     // delete's existing tokens
     expect(tokens.length).toBe(1)


### PR DESCRIPTION
Make Typescript happy on failing test in `forgotPassword.test.ts`.

Closes: #2378
