### PR TITLE
Fix to not build custom server during `blitz start`

### DIFF
--- a/packages/server/src/build.ts
+++ b/packages/server/src/build.ts
@@ -3,7 +3,7 @@ import {copy} from "fs-extra"
 import {resolve} from "path"
 import {saveBlitzVersion} from "./blitz-version"
 import {normalize, ServerConfig} from "./config"
-import {nextBuild} from "./next-utils"
+import {buildCustomServer, customServerExists, nextBuild} from "./next-utils"
 import {configureStages} from "./stages"
 
 export async function build(config: ServerConfig) {
@@ -36,7 +36,7 @@ export async function build(config: ServerConfig) {
   })
 
   await saveBlitzVersion(buildFolder)
-
+  if (customServerExists()) await buildCustomServer({watch})
   await nextBuild(nextBin, buildFolder, manifest, config)
 
   const rootNextFolder = resolve(rootFolder, ".next")

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -2,7 +2,7 @@ import {getConfig} from "@blitzjs/config"
 import {log} from "@blitzjs/display"
 import {isVersionMatched, saveBlitzVersion} from "./blitz-version"
 import {normalize, ServerConfig} from "./config"
-import {buildCustomServer, customServerExists, nextStartDev, startCustomServer} from "./next-utils"
+import {customServerExists, nextStartDev, startCustomServer} from "./next-utils"
 import {configureStages} from "./stages"
 
 export async function dev(config: ServerConfig) {
@@ -46,7 +46,6 @@ export async function dev(config: ServerConfig) {
     const blitzConfig = getConfig()
     const watch = blitzConfig.customServer?.hotReload ?? true
 
-    await buildCustomServer()
     await startCustomServer(buildFolder, config, {watch})
   } else {
     await nextStartDev(nextBin, buildFolder, manifest, buildFolder, config)

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -2,7 +2,7 @@ import {getConfig} from "@blitzjs/config"
 import {log} from "@blitzjs/display"
 import {isVersionMatched, saveBlitzVersion} from "./blitz-version"
 import {normalize, ServerConfig} from "./config"
-import {customServerExists, nextStartDev, startCustomServer} from "./next-utils"
+import {buildCustomServer, customServerExists, nextStartDev, startCustomServer} from "./next-utils"
 import {configureStages} from "./stages"
 
 export async function dev(config: ServerConfig) {
@@ -46,6 +46,7 @@ export async function dev(config: ServerConfig) {
     const blitzConfig = getConfig()
     const watch = blitzConfig.customServer?.hotReload ?? true
 
+    await buildCustomServer()
     await startCustomServer(buildFolder, config, {watch})
   } else {
     await nextStartDev(nextBin, buildFolder, manifest, buildFolder, config)

--- a/packages/server/test/build.test.ts
+++ b/packages/server/test/build.test.ts
@@ -6,6 +6,8 @@ import {multiMock} from "./utils/multi-mock"
 const mocks = multiMock(
   {
     "next-utils": {
+      customServerExists: jest.fn().mockReturnValue(Boolean),
+      buildCustomServer: jest.fn().mockReturnValue(Promise.resolve()),
       nextBuild: jest.fn().mockReturnValue(Promise.resolve()),
     },
     "resolve-bin-async": {

--- a/packages/server/test/vercel-now.test.ts
+++ b/packages/server/test/vercel-now.test.ts
@@ -7,6 +7,8 @@ const mocks = multiMock(
   {
     "next-utils": {
       nextStartDev: jest.fn().mockReturnValue(Promise.resolve()),
+      customServerExists: jest.fn().mockReturnValue(Boolean),
+      buildCustomServer: jest.fn().mockReturnValue(Promise.resolve()),
       nextBuild: jest.fn().mockReturnValue(Promise.resolve()),
     },
     "resolve-bin-async": {


### PR DESCRIPTION
Closes: #2354

### What are the changes and their implications?
- Building Custom Server during Blitz Build
- `startCustomServer` function, now doesn't build by default.
- Introduce a separate `buildCustomServer` fn

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
