### PR TITLE
Fix broken Vercel deployments from version 0.35+ (patch)

### DIFF
--- a/packages/server/src/stages/rpc/index.ts
+++ b/packages/server/src/stages/rpc/index.ts
@@ -66,7 +66,7 @@ import path from 'path'
 
 // Ensure these files are not eliminated by trace-based tree-shaking (like Vercel)
 path.resolve("next.config.js")
-path.resolve("blitz.config.js")
+path.resolve(".blitz/blitz.config.js")
 path.resolve(".next/blitz/db.js")
 // End anti-tree-shaking
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/blitz/issues/2365

### What are the changes and their implications?

Fix broken Vercel deployments from 0.35+