### PR TITLE
Add helpful error when trying `blitz export` with blitz auth (patch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ examples/auth2
 .ultra.cache.json
 db.sqlite-journal
 test/integration/**/db.json
+test/**/*/out

--- a/nextjs/packages/next/build/index.ts
+++ b/nextjs/packages/next/build/index.ts
@@ -660,6 +660,7 @@ export default async function build(
       customAppGetInitialProps,
       namedExports,
       isNextImageImported,
+      isBlitzSessionMiddlewareUsed,
       hasSsrAmpPages,
       hasNonStaticErrorPage,
     } = await staticCheckSpan.traceAsyncFn(async () => {
@@ -713,6 +714,8 @@ export default async function build(
 
       // eslint-disable-next-line no-shadow
       let isNextImageImported: boolean | undefined
+      // eslint-disable-next-line no-shadow
+      let isBlitzSessionMiddlewareUsed: boolean | undefined
       // eslint-disable-next-line no-shadow
       let hasSsrAmpPages = false
 
@@ -776,6 +779,10 @@ export default async function build(
 
                 if (workerResult.isNextImageImported) {
                   isNextImageImported = true
+                }
+
+                if (workerResult.isBlitzSessionMiddlewareUsed) {
+                  isBlitzSessionMiddlewareUsed = true
                 }
 
                 if (workerResult.hasStaticProps) {
@@ -856,6 +863,7 @@ export default async function build(
         customAppGetInitialProps: await customAppGetInitialPropsPromise,
         namedExports: await namedExportsPromise,
         isNextImageImported,
+        isBlitzSessionMiddlewareUsed,
         hasSsrAmpPages,
         hasNonStaticErrorPage: await nonStaticErrorPagePromise,
       }
@@ -1516,6 +1524,7 @@ export default async function build(
         hasExportPathMap: typeof config.exportPathMap === 'function',
         exportTrailingSlash: config.trailingSlash === true,
         isNextImageImported: isNextImageImported === true,
+        isBlitzSessionMiddlewareUsed: isBlitzSessionMiddlewareUsed === true,
       }),
       'utf8'
     )

--- a/nextjs/packages/next/build/utils.ts
+++ b/nextjs/packages/next/build/utils.ts
@@ -855,7 +855,8 @@ export async function isPageStatic(
       }
 
       const isNextImageImported = (global as any).__NEXT_IMAGE_IMPORTED
-      const isBlitzSessionMiddlewareUsed = (global as any).__NEXT_IMAGE_IMPORTED
+      const isBlitzSessionMiddlewareUsed = (global as any)
+        .__BLITZ_SESSION_MIDDLEWARE_USED
       const config = mod.config || {}
       return {
         isStatic: !hasStaticProps && !hasGetInitialProps && !hasServerProps,

--- a/nextjs/packages/next/build/utils.ts
+++ b/nextjs/packages/next/build/utils.ts
@@ -761,6 +761,7 @@ export async function isPageStatic(
   encodedPrerenderRoutes?: string[]
   prerenderFallback?: boolean | 'blocking'
   isNextImageImported?: boolean
+  isBlitzSessionMiddlewareUsed?: boolean
 }> {
   const isPageStaticSpan = trace('is-page-static-utils', parentId)
   return isPageStaticSpan.traceAsyncFn(async () => {
@@ -854,6 +855,7 @@ export async function isPageStatic(
       }
 
       const isNextImageImported = (global as any).__NEXT_IMAGE_IMPORTED
+      const isBlitzSessionMiddlewareUsed = (global as any).__NEXT_IMAGE_IMPORTED
       const config = mod.config || {}
       return {
         isStatic: !hasStaticProps && !hasGetInitialProps && !hasServerProps,
@@ -865,6 +867,7 @@ export async function isPageStatic(
         hasStaticProps,
         hasServerProps,
         isNextImageImported,
+        isBlitzSessionMiddlewareUsed,
       }
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') return {}

--- a/nextjs/packages/next/export/index.ts
+++ b/nextjs/packages/next/export/index.ts
@@ -328,7 +328,10 @@ export default async function exportApp(
     }
 
     if (!options.buildExport) {
-      const { isNextImageImported } = await nextExportSpan
+      const {
+        isNextImageImported,
+        isBlitzSessionMiddlewareUsed,
+      } = await nextExportSpan
         .traceChild('is-next-image-imported')
         .traceAsyncFn(() =>
           promises
@@ -336,6 +339,15 @@ export default async function exportApp(
             .then((text) => JSON.parse(text))
             .catch(() => ({}))
         )
+
+      if (isBlitzSessionMiddlewareUsed) {
+        throw new Error(
+          `Blitz sessionMiddleware is not compatible with \`blitz export\`.
+  Possible solutions:
+    - Use \`blitz start\` to run a server, which supports middleware.
+    - Remove \`sessionMiddleware\` import from \`blitz.config.js\`.\n`
+        )
+      }
 
       if (isNextImageImported && loader === 'default' && !hasNextSupport) {
         throw new Error(

--- a/nextjs/test/integration/export-intent/test/index.test.js
+++ b/nextjs/test/integration/export-intent/test/index.test.js
@@ -30,8 +30,8 @@ describe('Application Export Intent Output', () => {
         Object {
           "exportTrailingSlash": false,
           "hasExportPathMap": false,
-          "isNextImageImported": false,
           "isBlitzSessionMiddlewareUsed": false,
+          "isNextImageImported": false,
           "version": 1,
         }
       `)
@@ -72,8 +72,8 @@ describe('Application Export Intent Output', () => {
         Object {
           "exportTrailingSlash": false,
           "hasExportPathMap": true,
-          "isNextImageImported": false,
           "isBlitzSessionMiddlewareUsed": false,
+          "isNextImageImported": false,
           "version": 1,
         }
       `)
@@ -114,8 +114,8 @@ describe('Application Export Intent Output', () => {
         Object {
           "exportTrailingSlash": true,
           "hasExportPathMap": false,
-          "isNextImageImported": false,
           "isBlitzSessionMiddlewareUsed": false,
+          "isNextImageImported": false,
           "version": 1,
         }
       `)
@@ -156,8 +156,8 @@ describe('Application Export Intent Output', () => {
         Object {
           "exportTrailingSlash": false,
           "hasExportPathMap": false,
-          "isNextImageImported": false,
           "isBlitzSessionMiddlewareUsed": false,
+          "isNextImageImported": false,
           "version": 1,
         }
       `)
@@ -197,8 +197,8 @@ describe('Application Export Intent Output', () => {
         Object {
           "exportTrailingSlash": false,
           "hasExportPathMap": false,
-          "isNextImageImported": false,
           "isBlitzSessionMiddlewareUsed": false,
+          "isNextImageImported": false,
           "version": 1,
         }
       `)

--- a/nextjs/test/integration/export-intent/test/index.test.js
+++ b/nextjs/test/integration/export-intent/test/index.test.js
@@ -31,6 +31,7 @@ describe('Application Export Intent Output', () => {
           "exportTrailingSlash": false,
           "hasExportPathMap": false,
           "isNextImageImported": false,
+          "isBlitzSessionMiddlewareUsed": false,
           "version": 1,
         }
       `)
@@ -72,6 +73,7 @@ describe('Application Export Intent Output', () => {
           "exportTrailingSlash": false,
           "hasExportPathMap": true,
           "isNextImageImported": false,
+          "isBlitzSessionMiddlewareUsed": false,
           "version": 1,
         }
       `)
@@ -113,6 +115,7 @@ describe('Application Export Intent Output', () => {
           "exportTrailingSlash": true,
           "hasExportPathMap": false,
           "isNextImageImported": false,
+          "isBlitzSessionMiddlewareUsed": false,
           "version": 1,
         }
       `)
@@ -154,6 +157,7 @@ describe('Application Export Intent Output', () => {
           "exportTrailingSlash": false,
           "hasExportPathMap": false,
           "isNextImageImported": false,
+          "isBlitzSessionMiddlewareUsed": false,
           "version": 1,
         }
       `)
@@ -194,6 +198,7 @@ describe('Application Export Intent Output', () => {
           "exportTrailingSlash": false,
           "hasExportPathMap": false,
           "isNextImageImported": false,
+          "isBlitzSessionMiddlewareUsed": false,
           "version": 1,
         }
       `)

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -7,6 +7,10 @@ export class Export extends Command {
 
   static flags = {
     help: flags.help({char: "h"}),
+    outdir: flags.string({
+      char: "o",
+      description: "set the output dir (defaults to 'out')",
+    }),
   }
 
   async run() {

--- a/packages/core/src/server/auth/sessions.ts
+++ b/packages/core/src/server/auth/sessions.ts
@@ -143,6 +143,8 @@ export const sessionMiddleware = (sessionConfig: Partial<SessionConfig> = {}): M
     sessionConfig.isAuthorized,
     "You must provide an authorization implementation to sessionMiddleware as isAuthorized(userRoles, input)",
   )
+  ;(global as any).__BLITZ_SESSION_MIDDLEWARE_USED = true
+
   global.sessionConfig = {
     ...defaultConfig,
     ...sessionConfig,

--- a/test/integration/auth/pages/_app.tsx
+++ b/test/integration/auth/pages/_app.tsx
@@ -4,7 +4,7 @@ import {ErrorBoundary} from "react-error-boundary"
 import {ReactQueryDevtools} from "react-query/devtools"
 
 if (typeof window !== "undefined") {
-  window["DEBUG_BLITZ"] = 1
+  ;(window as any).DEBUG_BLITZ = 1
 }
 
 export default function App({Component, pageProps}: AppProps) {

--- a/test/integration/auth/pages/prefetching.tsx
+++ b/test/integration/auth/pages/prefetching.tsx
@@ -37,16 +37,16 @@ export default function Page() {
 
 Page.authenticate = true
 
-// export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-//   const queryClient = new QueryClient()
-//
-//   await queryClient.prefetchQuery(getQueryKey(getAuthenticatedBasic, null), () =>
-//     invokeWithMiddleware(getAuthenticatedBasic, null, ctx),
-//   )
-//
-//   return {
-//     props: {
-//       dehydratedState: dehydrate(queryClient),
-//     },
-//   }
-// }
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  const queryClient = new QueryClient()
+
+  await queryClient.prefetchQuery(getQueryKey(getAuthenticatedBasic, null), () =>
+    invokeWithMiddleware(getAuthenticatedBasic, null, ctx),
+  )
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+  }
+}

--- a/test/integration/auth/pages/prefetching.tsx
+++ b/test/integration/auth/pages/prefetching.tsx
@@ -37,16 +37,16 @@ export default function Page() {
 
 Page.authenticate = true
 
-export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  const queryClient = new QueryClient()
-
-  await queryClient.prefetchQuery(getQueryKey(getAuthenticatedBasic, null), () =>
-    invokeWithMiddleware(getAuthenticatedBasic, null, ctx),
-  )
-
-  return {
-    props: {
-      dehydratedState: dehydrate(queryClient),
-    },
-  }
-}
+// export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+//   const queryClient = new QueryClient()
+//
+//   await queryClient.prefetchQuery(getQueryKey(getAuthenticatedBasic, null), () =>
+//     invokeWithMiddleware(getAuthenticatedBasic, null, ctx),
+//   )
+//
+//   return {
+//     props: {
+//       dehydratedState: dehydrate(queryClient),
+//     },
+//   }
+// }

--- a/test/integration/auth/test/index.test.ts
+++ b/test/integration/auth/test/index.test.ts
@@ -1,5 +1,14 @@
 /* eslint-env jest */
-import {findPort, killApp, launchApp, renderViaHTTP, waitFor} from "lib/blitz-test-utils"
+import fs from "fs-extra"
+import {
+  blitzBuild,
+  blitzExport,
+  findPort,
+  killApp,
+  launchApp,
+  renderViaHTTP,
+  waitFor,
+} from "lib/blitz-test-utils"
 import webdriver from "lib/next-webdriver"
 import {join} from "path"
 import rimraf from "rimraf"
@@ -105,5 +114,21 @@ describe("Auth", () => {
       expect(text).toMatch(/authenticated-basic-result/)
       if (browser) await browser.close()
     })
+  })
+})
+
+const appDir = join(__dirname, "../")
+const outdir = join(appDir, "out")
+
+describe("auth - blitz export should not work", () => {
+  it("should build successfully", async () => {
+    await fs.remove(join(appDir, ".next"))
+    const {code} = await blitzBuild(appDir)
+    if (code !== 0) throw new Error(`build failed with status ${code}`)
+  })
+
+  it("should have error during blitz export", async () => {
+    const {stderr} = await blitzExport(appDir, {outdir}, {stderr: true})
+    expect(stderr).toContain("Blitz sessionMiddleware is not compatible with `blitz export`.")
   })
 })

--- a/test/integration/export-image-default/babel.config.js
+++ b/test/integration/export-image-default/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ["blitz/babel"],
+  plugins: [],
+}

--- a/test/integration/export-image-default/blitz.config.js
+++ b/test/integration/export-image-default/blitz.config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/integration/export-image-default/pages/_app.js
+++ b/test/integration/export-image-default/pages/_app.js
@@ -1,0 +1,7 @@
+export default function App({Component, pageProps}) {
+  return (
+    <>
+      <Component {...pageProps} />
+    </>
+  )
+}

--- a/test/integration/export-image-default/pages/index.js
+++ b/test/integration/export-image-default/pages/index.js
@@ -1,0 +1,8 @@
+import {Image} from "blitz"
+
+export default () => (
+  <div>
+    <p>Should error during export</p>
+    <Image src="/i.png" width="10" height="10" />
+  </div>
+)

--- a/test/integration/export-image-default/test/index.test.js
+++ b/test/integration/export-image-default/test/index.test.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+
+import fs from "fs-extra"
+import {blitzBuild, blitzExport} from "lib/blitz-test-utils"
+import {join} from "path"
+
+jest.setTimeout(1000 * 60 * 5)
+const appDir = join(__dirname, "../")
+const outdir = join(appDir, "out")
+
+describe("Export with default loader image component", () => {
+  it("should build successfully", async () => {
+    await fs.remove(join(appDir, ".next"))
+    const {code} = await blitzBuild(appDir)
+    if (code !== 0) throw new Error(`build failed with status ${code}`)
+  })
+
+  it("should have error during blitzx export", async () => {
+    const {stderr} = await blitzExport(appDir, {outdir}, {stderr: true})
+    expect(stderr).toContain(
+      "Image Optimization using Next.js' default loader is not compatible with `next export`.",
+    )
+  })
+})

--- a/test/integration/misc/test/index.test.ts
+++ b/test/integration/misc/test/index.test.ts
@@ -1,5 +1,13 @@
 /* eslint-env jest */
-import {findPort, killApp, launchApp, renderViaHTTP} from "lib/blitz-test-utils"
+import fs from "fs-extra"
+import {
+  blitzBuild,
+  blitzExport,
+  findPort,
+  killApp,
+  launchApp,
+  renderViaHTTP,
+} from "lib/blitz-test-utils"
 import webdriver from "lib/next-webdriver"
 import {join} from "path"
 
@@ -27,6 +35,22 @@ describe("Misc", () => {
       text = await browser.elementByCss("#error").text()
       expect(text).toMatch(/query failed/)
       if (browser) await browser.close()
+    })
+  })
+
+  const appDir = join(__dirname, "../")
+  const outdir = join(appDir, "out")
+
+  describe("blitz export", () => {
+    it("should build successfully", async () => {
+      await fs.remove(join(appDir, ".next"))
+      const {code} = await blitzBuild(appDir)
+      if (code !== 0) throw new Error(`build failed with status ${code}`)
+    })
+
+    it("should export successfully", async () => {
+      const {code} = await blitzExport(appDir, {outdir})
+      if (code !== 0) throw new Error(`export failed with status ${code}`)
     })
   })
 })

--- a/test/lib/blitz-test-utils.ts
+++ b/test/lib/blitz-test-utils.ts
@@ -126,7 +126,7 @@ export function runBlitzCommand(argv: any[], options: RunBlitzCommandOptions = {
     __NEXT_TEST_MODE: "true",
   }
 
-  return new Promise((resolve, reject) => {
+  return new Promise<any>((resolve, reject) => {
     console.log(`Running command "blitz ${argv.join(" ")}"`)
     const instance = spawn("node", ["--no-deprecation", blitzBin, ...argv], {
       ...options.spawnOptions,
@@ -141,14 +141,14 @@ export function runBlitzCommand(argv: any[], options: RunBlitzCommandOptions = {
 
     let stderrOutput = ""
     if (options.stderr) {
-      instance.stderr.on("data", function (chunk) {
+      instance.stderr?.on("data", function (chunk) {
         stderrOutput += chunk
       })
     }
 
     let stdoutOutput = ""
     if (options.stdout) {
-      instance.stdout.on("data", function (chunk) {
+      instance.stdout?.on("data", function (chunk) {
         stdoutOutput += chunk
       })
     }


### PR DESCRIPTION


Closes: https://github.com/blitz-js/blitz/issues/2279

### What are the changes and their implications?

Add helpful error when trying `blitz export` with blitz auth. 

## Bug Checklist

- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
