### PR TITLE
Fix CSRF 401 errors for HEAD requests (patch)

### DIFF
--- a/packages/core/src/server/auth/sessions.ts
+++ b/packages/core/src/server/auth/sessions.ts
@@ -590,7 +590,7 @@ export async function getSessionKernel(
   const sessionToken = req.cookies[COOKIE_SESSION_TOKEN()] // for essential method
   const idRefreshToken = req.cookies[COOKIE_REFRESH_TOKEN()] // for advanced method
   const enableCsrfProtection =
-    req.method !== "GET" && req.method !== "OPTIONS" && !process.env.DISABLE_CSRF_PROTECTION
+    req.method !== "GET" && req.method !== "OPTIONS" && req.method !== "HEAD" && !process.env.DISABLE_CSRF_PROTECTION
   const antiCSRFToken = req.headers[HEADER_CSRF] as string
 
   if (sessionToken) {

--- a/packages/core/src/server/auth/sessions.ts
+++ b/packages/core/src/server/auth/sessions.ts
@@ -590,7 +590,10 @@ export async function getSessionKernel(
   const sessionToken = req.cookies[COOKIE_SESSION_TOKEN()] // for essential method
   const idRefreshToken = req.cookies[COOKIE_REFRESH_TOKEN()] // for advanced method
   const enableCsrfProtection =
-    req.method !== "GET" && req.method !== "OPTIONS" && req.method !== "HEAD" && !process.env.DISABLE_CSRF_PROTECTION
+    req.method !== "GET" &&
+    req.method !== "OPTIONS" &&
+    req.method !== "HEAD" &&
+    !process.env.DISABLE_CSRF_PROTECTION
   const antiCSRFToken = req.headers[HEADER_CSRF] as string
 
   if (sessionToken) {


### PR DESCRIPTION
Closes: https://discord.com/channels/802917734999523368/814627789180239893/850016373384020008

### What are the changes and their implications?

Disable CSRF validation for HEAD requests. This issue started popping up as a result of the changes in https://github.com/blitz-js/blitz/pull/2364 when HEAD requests are completely handled by blitz.
