### PR TITLE
Fix Prisma @@map in Enums break the model generator

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -34,7 +34,7 @@
     "@babel/core": "7.12.10",
     "@babel/plugin-transform-typescript": "7.12.1",
     "@blitzjs/display": "0.36.4",
-    "@mrleebo/prisma-ast": "^0.2.3",
+    "@mrleebo/prisma-ast": "^0.2.4",
     "@types/jscodeshift": "0.7.2",
     "chalk": "^4.1.0",
     "cross-spawn": "7.0.3",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -33,7 +33,7 @@
     "@blitzjs/config": "0.36.4",
     "@blitzjs/display": "0.36.4",
     "@blitzjs/generator": "0.36.4",
-    "@mrleebo/prisma-ast": "^0.2.3",
+    "@mrleebo/prisma-ast": "^0.2.4",
     "@prisma/sdk": "2.19.0",
     "@types/jscodeshift": "0.7.2",
     "cross-spawn": "7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,10 +2772,10 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/tag/-/tag-0.18.0.tgz#386d687deaed7133699a420d74612acdd1ed1c26"
   integrity sha512-3g1NOnbw+sJZohNOEN9NlaYYDdzq1y34S7PDimSn3zLV8etCu7pTCMFbnFHMSe6mMmm4yJ1gfbS3QiE7t+WMGA==
 
-"@mrleebo/prisma-ast@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@mrleebo/prisma-ast/-/prisma-ast-0.2.3.tgz#d3b3c7051e897d2e478dca8cddd08104a9906b7d"
-  integrity sha512-coY/5Ae1JlKsjJkfOt5jV2QCWjSllbweOy+x8M2gBUHpFaQJQZTuYpGh9ymBhTU01lb9JgwIpkUMyNrRdZHlMw==
+"@mrleebo/prisma-ast@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@mrleebo/prisma-ast/-/prisma-ast-0.2.4.tgz#93a413e8db03b360ebe8aa315cdb5984420f466b"
+  integrity sha512-0hjx2e8EVbpa7R8oxs+Y6L4FYxu82H2BxEoogHKoZUo0qQ6vLxy9I4mcrlfhfCR5EbOYOROQhUjH6ShPPQqRrg==
   dependencies:
     chevrotain "^9.0.1"
 


### PR DESCRIPTION
Closes: #2421 

### What are the changes and their implications?

v0.2.4 of prisma-ast has the fix for the error parsing attributes inside enum blocks. This change just updates the version of the dependency in blitz.

## Bug Checklist

- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
(test added upstream)
