### PR TITLE
Add ability to disable custom server hot reloading

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -33,6 +33,9 @@ export interface BlitzConfig extends Omit<PublicNextConfig, "experimental" | "fu
         cookiePrefix?: string
       }
     }[]
+  customServer?: {
+    hotReload?: boolean
+  }
 }
 
 export interface BlitzConfigNormalized extends BlitzConfig {

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -1,3 +1,4 @@
+import {getConfig} from "@blitzjs/config"
 import {log} from "@blitzjs/display"
 import {isVersionMatched, saveBlitzVersion} from "./blitz-version"
 import {normalize, ServerConfig} from "./config"
@@ -41,7 +42,11 @@ export async function dev(config: ServerConfig) {
 
   if (customServerExists()) {
     log.success("Using your custom server")
-    await startCustomServer(buildFolder, config, {watch: true})
+
+    const blitzConfig = getConfig()
+    const watch = blitzConfig.customServer?.hotReload ?? true
+
+    await startCustomServer(buildFolder, config, {watch})
   } else {
     await nextStartDev(nextBin, buildFolder, manifest, buildFolder, config)
   }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #2332

### What are the changes and their implications?

Implements a `customServer.hotReload` option to the blitz config. This defaults to `false` if it is not specified.

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [X] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
