### PR TITLE
Remove unneeded `cd` message during `blitz install` in some cases

### DIFF
--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -145,7 +145,7 @@ export class New extends Command {
 
       const {"dry-run": dryRun, "skip-install": skipInstall, npm} = flags
       const needsInstall = dryRun || skipInstall
-      const postInstallSteps = [`cd ${args.name}`]
+      const postInstallSteps = args.name === "." ? [] : [`cd ${args.name}`];
       const AppGenerator = require("@blitzjs/generator").AppGenerator
 
       const generator = new AppGenerator({


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: No issue on this

> This was a simple bug when used `blitz new .`, it has these postinstall steps.
![image](https://user-images.githubusercontent.com/51731966/120827720-5b651d00-c579-11eb-871d-718e5e25d46f.png)
So this simple fix removes the `cd` step from the array if `args.name` is "."

### What are the changes and their implications?

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))