### PR TITLE
Prevent using Reserved Keywords in `generate` command

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -184,6 +184,15 @@ export class Generate extends Command {
     }
   }
 
+  checkReservedKeyword(modelName: string) {
+    const reservedKeywords = ["page"]
+
+    if (reservedKeywords.includes(modelName)) {
+      console.error(`The model name ${modelName} is a reserved keyword and cannot be used.`)
+      throw new Error("Reserved keyword")
+    }
+  }
+
   getModelNameAndContext(modelName: string, context?: string): {model: string; context?: string} {
     const modelSegments = modelName.split(/[\\/]/)
 
@@ -216,6 +225,8 @@ export class Generate extends Command {
     try {
       const {model, context} = this.getModelNameAndContext(args.model, flags.context)
       const singularRootContext = modelName(model)
+
+      this.checkReservedKeyword(singularRootContext)
 
       const generators = generatorMap[args.type]
       for (const GeneratorClass of generators) {

--- a/packages/cli/test/commands/generate.test.ts
+++ b/packages/cli/test/commands/generate.test.ts
@@ -48,4 +48,13 @@ describe("`generate` command", () => {
       })
     })
   })
+
+  describe("when passing model name", () => {
+    it("should stop generating model with reserved keyword", function () {
+      const checkReservedKeyword = Generate.prototype.checkReservedKeyword
+      expect(() => {
+        checkReservedKeyword("page")
+      }).toThrow("Reserved keyword")
+    })
+  })
 })


### PR DESCRIPTION
Closes: #2380

### What are the changes and their implications?

Comparing model name against reserved keywords list.

## Bug Checklist

- [x] Unit test added
