### PR TITLE
Fix auth & middleware not working on Vercel (No longer need the `path.resolve` workaround) (patch)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -27,6 +27,7 @@ eslint.config.*
 /recipes/*/templates
 /packages/generator/templates
 /packages/cli/lib
+/packages/babel-preset/src/fix-node-file-trace/tests/**
 
 
 // COPIED FROM nextjs/.eslintignore

--- a/.eslintignore
+++ b/.eslintignore
@@ -28,6 +28,7 @@ eslint.config.*
 /packages/generator/templates
 /packages/cli/lib
 /packages/babel-preset/src/fix-node-file-trace/tests/**
+/test/integration/**/out/**
 
 
 // COPIED FROM nextjs/.eslintignore

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,9 @@ jobs:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
             **/node_modules
-          key: ${{ runner.os }}-${{ runner.node_version}}-yarn-v8-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-${{ runner.node_version}}-yarn-v9-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.node_version}}-yarn-v8-
+            ${{ runner.os }}-${{ runner.node_version}}-yarn-v9-
       - name: Install dependencies
         run: yarn install --frozen-lockfile --silent
         env:
@@ -72,9 +72,9 @@ jobs:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
             **/node_modules
-          key: ${{ runner.os }}-${{ runner.node_version}}-yarn-v8-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-${{ runner.node_version}}-yarn-v9-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.node_version}}-yarn-v8-
+            ${{ runner.os }}-${{ runner.node_version}}-yarn-v9-
       - run: yarn install --frozen-lockfile --check-files
       - name: Build Packages
         run: yarn build
@@ -140,9 +140,9 @@ jobs:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
             **/node_modules
-          key: ${{ runner.os }}-${{ runner.node_version}}-yarn-v8-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-${{ runner.node_version}}-yarn-v9-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.node_version}}-yarn-v8-
+            ${{ runner.os }}-${{ runner.node_version}}-yarn-v9-
       - run: yarn install --frozen-lockfile --check-files
       # - run: yarn cpy node_modules/.blitz packages/core/node_modules/.blitz
       #   if: matrix.os == 'windows-latest'
@@ -375,9 +375,9 @@ jobs:
             **/node_modules
             /home/runner/.cache/Cypress
             C:\Users\runneradmin\AppData\Local\Cypress\Cache
-          key: ${{ runner.os }}-${{ runner.node_version}}-yarn-v8-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-${{ runner.node_version}}-yarn-v9-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.node_version}}-yarn-v8-
+            ${{ runner.os }}-${{ runner.node_version}}-yarn-v9-
 
       - run: yarn install --check-files
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}

--- a/examples/store/app/admin/api/users.ts
+++ b/examples/store/app/admin/api/users.ts
@@ -1,13 +1,5 @@
-import db, {Product} from "db"
+import db from "db"
 import {BlitzApiRequest, BlitzApiResponse} from "blitz"
-import {mean} from "lodash"
-
-// this is here mainly as an integration test for
-// importing from api/
-export function meanPrice(products: Product[]) {
-  const prices = products.map((p) => p.price).filter((p) => !!p) as number[]
-  return mean(prices)
-}
 
 export default async function users(_req: BlitzApiRequest, res: BlitzApiResponse) {
   const products = await db.product.findMany()

--- a/examples/store/app/admin/pages/admin/products/index.tsx
+++ b/examples/store/app/admin/pages/admin/products/index.tsx
@@ -1,7 +1,15 @@
 import {Suspense, useState} from "react"
 import {useQuery, Link, useRouterQuery, invalidateQuery, setQueryData} from "blitz"
 import getProducts from "app/products/queries/getProducts"
-import {meanPrice} from "app/admin/api/users"
+import {mean} from "lodash"
+import {Product} from "@prisma/client"
+
+// this is here mainly as an integration test for
+// importing from api/
+export function meanPrice(products: Product[]) {
+  const prices = products.map((p) => p.price).filter((p) => !!p) as number[]
+  return mean(prices)
+}
 
 function reversedProductList(productsList) {
   return {...productsList, products: [...productsList.products].reverse()}

--- a/packages/babel-preset/src/fix-node-file-trace.ts
+++ b/packages/babel-preset/src/fix-node-file-trace.ts
@@ -1,0 +1,167 @@
+import { PluginObj } from '@babel/core';
+import { getFileName, wrapExportDefaultDeclaration } from './utils';
+import type { NodePath, PluginObj, PluginPass } from '@babel/core';
+import { addNamed as addNamedImport } from '@babel/helper-module-imports';
+import {
+  callExpression,
+  ClassDeclaration,
+  classExpression,
+  ExportNamedDeclaration,
+  Expression,
+  FunctionDeclaration,
+  functionExpression,
+  isClassDeclaration,
+  isExportDefaultDeclaration,
+  isExportNamedDeclaration,
+  isFunctionDeclaration,
+  isFunctionExpression,
+  isIdentifier,
+  isVariableDeclaration,
+  variableDeclaration,
+  variableDeclarator,
+  arrayExpression,
+  stringLiteral,
+} from '@babel/types';
+import * as nodePath from 'path';
+
+function functionDeclarationToExpression(declaration: FunctionDeclaration) {
+  return functionExpression(
+    declaration.id,
+    declaration.params,
+    declaration.body,
+    declaration.generator,
+    declaration.async
+  );
+}
+
+function classDeclarationToExpression(declaration: ClassDeclaration) {
+  return classExpression(
+    declaration.id,
+    declaration.superClass,
+    declaration.body,
+    declaration.decorators
+  );
+}
+
+function getFileName(state: PluginPass) {
+  const { filename, cwd } = state;
+
+  if (!filename) {
+    return undefined;
+  }
+
+  if (cwd && filename.startsWith(cwd)) {
+    return filename.slice(cwd.length);
+  }
+
+  return filename;
+}
+
+const functionsToReplace = ['getServerSideProps', 'getStaticProps'];
+
+function transformPropGetters(
+  path: NodePath<ExportNamedDeclaration>,
+  transform: (v: Expression) => Expression
+) {
+  const { node } = path;
+
+  if (isFunctionDeclaration(node.declaration)) {
+    const { id: functionId } = node.declaration;
+    if (!functionId) {
+      return;
+    }
+
+    if (!functionsToReplace.includes(functionId.name)) {
+      return;
+    }
+
+    node.declaration = variableDeclaration('const', [
+      variableDeclarator(
+        functionId,
+        transform(functionDeclarationToExpression(node.declaration))
+      ),
+    ]);
+
+    return;
+  }
+
+  if (isVariableDeclaration(node.declaration)) {
+    node.declaration.declarations.forEach((declaration) => {
+      if (
+        isIdentifier(declaration.id) &&
+        functionsToReplace.includes(declaration.id.name) &&
+        declaration.init
+      ) {
+        declaration.init = transform(declaration.init);
+      }
+    });
+  }
+}
+
+function addWithSuperJSONPropsImport(path: NodePath<any>) {
+  return addNamedImport(
+    path,
+    'withSuperJSONProps',
+    'babel-plugin-superjson-next/tools'
+  );
+}
+
+const filesToSkip = ([] as string[]).concat(
+  ...['_app', '_document', '_error'].map((name) => [
+    name + '.js',
+    name + '.jsx',
+    name + '.ts',
+    name + '.tsx',
+  ])
+);
+
+function shouldBeSkipped(filePath: string) {
+  if (!filePath.includes('pages' + nodePath.sep)) {
+    return true;
+  }
+  if (filePath.includes('pages' + nodePath.sep + 'api')) {
+    return true;
+  }
+  return filesToSkip.some((fileToSkip) => filePath.includes(fileToSkip));
+}
+
+function FixNodeFileTrace(): PluginObj {
+  return {
+    name: 'FixNodeFileTrace',
+    visitor: {
+      Program(path, state) {
+        const propsToBeExcluded = (state.opts as any).exclude as
+          | string[]
+          | undefined;
+
+        const filePath =
+          getFileName(state) ?? nodePath.join('pages', 'Default.js');
+
+        if (shouldBeSkipped(filePath)) {
+          return;
+        }
+
+        const body = path.get('body');
+
+        body
+          .filter((path) => isExportNamedDeclaration(path))
+          .forEach((path) => {
+            transformPropGetters(
+              path as NodePath<ExportNamedDeclaration>,
+              (decl) => {
+                return callExpression(addWithSuperJSONPropsImport(path), [
+                  decl,
+                  arrayExpression(
+                    propsToBeExcluded?.map((prop) => stringLiteral(prop))
+                  ),
+                ]);
+              }
+            );
+          });
+      },
+    },
+  };
+}
+
+// eslint-disable-next-line import/no-default-export
+export default FixNodeFileTrace;

--- a/packages/babel-preset/src/fix-node-file-trace/fix-node-file-trace.test.ts
+++ b/packages/babel-preset/src/fix-node-file-trace/fix-node-file-trace.test.ts
@@ -1,0 +1,50 @@
+import pluginTester from 'babel-plugin-tester';
+import path from 'path';
+import FixNodeFileTrace from './index';
+
+pluginTester({
+  pluginName: FixNodeFileTrace.name,
+  plugin: FixNodeFileTrace,
+  // babelOptions: require('../../../../babel.config.js'),
+  fixtures: path.join(__dirname, 'tests'),
+  // filename: 'pages/index.tsx',
+  //   tests: [
+  //     {
+  //       code: `export const getStaticProps = async () => {
+  //   const products = [
+  //     {
+  //       name: 'Hat',
+  //       publishedAt: new Date(0),
+  //     },
+  //   ];
+  //   return {
+  //     props: {
+  //       products,
+  //     },
+  //   };
+  // };
+  //
+  // export default function Page({ products }) {
+  //   return JSON.stringify(products);
+  // }`,
+  //       output: `import { withFixNodeFileTrace as _withFixNodeFileTrace } from '@blitzjs/core/server';
+  // export const getStaticProps = _withFixNodeFileTrace(async () => {
+  //   const products = [
+  //     {
+  //       name: 'Hat',
+  //       publishedAt: new Date(0),
+  //     },
+  //   ];
+  //   return {
+  //     props: {
+  //       products,
+  //     },
+  //   };
+  // });
+  //
+  // export default function Page({ products }) {
+  //   return JSON.stringify(products);
+  // }`,
+  //     },
+  //   ],
+});

--- a/packages/babel-preset/src/fix-node-file-trace/fix-node-file-trace.test.ts
+++ b/packages/babel-preset/src/fix-node-file-trace/fix-node-file-trace.test.ts
@@ -5,46 +5,5 @@ import FixNodeFileTrace from './index';
 pluginTester({
   pluginName: FixNodeFileTrace.name,
   plugin: FixNodeFileTrace,
-  // babelOptions: require('../../../../babel.config.js'),
   fixtures: path.join(__dirname, 'tests'),
-  // filename: 'pages/index.tsx',
-  //   tests: [
-  //     {
-  //       code: `export const getStaticProps = async () => {
-  //   const products = [
-  //     {
-  //       name: 'Hat',
-  //       publishedAt: new Date(0),
-  //     },
-  //   ];
-  //   return {
-  //     props: {
-  //       products,
-  //     },
-  //   };
-  // };
-  //
-  // export default function Page({ products }) {
-  //   return JSON.stringify(products);
-  // }`,
-  //       output: `import { withFixNodeFileTrace as _withFixNodeFileTrace } from '@blitzjs/core/server';
-  // export const getStaticProps = _withFixNodeFileTrace(async () => {
-  //   const products = [
-  //     {
-  //       name: 'Hat',
-  //       publishedAt: new Date(0),
-  //     },
-  //   ];
-  //   return {
-  //     props: {
-  //       products,
-  //     },
-  //   };
-  // });
-  //
-  // export default function Page({ products }) {
-  //   return JSON.stringify(products);
-  // }`,
-  //     },
-  //   ],
 });

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/api/api-route/code.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/api/api-route/code.js
@@ -1,0 +1,3 @@
+export default function HealthCheck(_req, res) {
+  res.status(200).send('ok');
+}

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/api/api-route/output.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/api/api-route/output.js
@@ -1,0 +1,7 @@
+import { withFixNodeFileTrace as _withFixNodeFileTrace } from '@blitzjs/core/server';
+
+function HealthCheck(_req, res) {
+  res.status(200).send('ok');
+}
+
+export default _withFixNodeFileTrace(HealthCheck);

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/class component/code.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/class component/code.js
@@ -1,0 +1,18 @@
+export const getServerSideProps = async () => {
+  const products = [
+    {
+      name: 'Hat',
+      publishedAt: new Date(0),
+    },
+  ];
+
+  return {
+    props: { products },
+  };
+};
+
+export default class Page {
+  render({ products }) {
+    return JSON.stringify(products);
+  }
+}

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/class component/output.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/class component/output.js
@@ -1,0 +1,19 @@
+import { withFixNodeFileTrace as _withFixNodeFileTrace } from '@blitzjs/core/server';
+export const getServerSideProps = _withFixNodeFileTrace(async () => {
+  const products = [
+    {
+      name: 'Hat',
+      publishedAt: new Date(0),
+    },
+  ];
+  return {
+    props: {
+      products,
+    },
+  };
+});
+export default class Page {
+  render({ products }) {
+    return JSON.stringify(products);
+  }
+}

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSP arrow function with implicit return/code.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSP arrow function with implicit return/code.js
@@ -1,0 +1,7 @@
+export const getStaticProps = () => ({
+  props: { today: new Date() },
+});
+
+export default function IndexPage({ today }) {
+  return JSON.stringify({ today });
+}

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSP arrow function with implicit return/output.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSP arrow function with implicit return/output.js
@@ -1,0 +1,11 @@
+import { withFixNodeFileTrace as _withFixNodeFileTrace } from '@blitzjs/core/server';
+export const getStaticProps = _withFixNodeFileTrace(() => ({
+  props: {
+    today: new Date(),
+  },
+}));
+export default function IndexPage({ today }) {
+  return JSON.stringify({
+    today,
+  });
+}

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSP arrow function/code.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSP arrow function/code.js
@@ -1,0 +1,17 @@
+export const getStaticProps = async () => {
+  const products = [
+    {
+      name: 'Hat',
+      publishedAt: new Date(0),
+    },
+  ];
+  return {
+    props: {
+      products,
+    },
+  };
+};
+
+export default function Page({ products }) {
+  return JSON.stringify(products);
+}

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSP arrow function/output.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSP arrow function/output.js
@@ -1,0 +1,17 @@
+import { withFixNodeFileTrace as _withFixNodeFileTrace } from '@blitzjs/core/server';
+export const getStaticProps = _withFixNodeFileTrace(async () => {
+  const products = [
+    {
+      name: 'Hat',
+      publishedAt: new Date(0),
+    },
+  ];
+  return {
+    props: {
+      products,
+    },
+  };
+});
+export default function Page({ products }) {
+  return JSON.stringify(products);
+}

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSP function declaration/code.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSP function declaration/code.js
@@ -1,0 +1,17 @@
+export async function getStaticProps() {
+  const products = [
+    {
+      name: 'Hat',
+      publishedAt: new Date(0),
+    },
+  ];
+  return {
+    props: {
+      products,
+    },
+  };
+}
+
+export default function Page({ products }) {
+  return JSON.stringify(products);
+}

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSP function declaration/output.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSP function declaration/output.js
@@ -1,0 +1,19 @@
+import { withFixNodeFileTrace as _withFixNodeFileTrace } from '@blitzjs/core/server';
+export const getStaticProps = _withFixNodeFileTrace(
+  async function getStaticProps() {
+    const products = [
+      {
+        name: 'Hat',
+        publishedAt: new Date(0),
+      },
+    ];
+    return {
+      props: {
+        products,
+      },
+    };
+  }
+);
+export default function Page({ products }) {
+  return JSON.stringify(products);
+}

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSSP function declaration/code.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSSP function declaration/code.js
@@ -1,0 +1,17 @@
+export async function getServerSideProps() {
+  const products = [
+    {
+      name: 'Hat',
+      publishedAt: new Date(0),
+    },
+  ];
+  return {
+    props: {
+      products,
+    },
+  };
+}
+
+export default function Page({ products }) {
+  return JSON.stringify(products);
+}

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSSP function declaration/output.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/gSSP function declaration/output.js
@@ -1,0 +1,19 @@
+import { withFixNodeFileTrace as _withFixNodeFileTrace } from '@blitzjs/core/server';
+export const getServerSideProps = _withFixNodeFileTrace(
+  async function getServerSideProps() {
+    const products = [
+      {
+        name: 'Hat',
+        publishedAt: new Date(0),
+      },
+    ];
+    return {
+      props: {
+        products,
+      },
+    };
+  }
+);
+export default function Page({ products }) {
+  return JSON.stringify(products);
+}

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/separate export declaration/code.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/separate export declaration/code.js
@@ -1,0 +1,20 @@
+export const getServerSideProps = async () => {
+  const products = [
+    {
+      name: 'Hat',
+      publishedAt: new Date(0),
+    },
+  ];
+
+  return {
+    props: {
+      products,
+    },
+  };
+};
+
+function Page({ products }) {
+  return JSON.stringify(products);
+}
+
+export default Page;

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/separate export declaration/output.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/separate export declaration/output.js
@@ -1,0 +1,20 @@
+import { withFixNodeFileTrace as _withFixNodeFileTrace } from '@blitzjs/core/server';
+export const getServerSideProps = _withFixNodeFileTrace(async () => {
+  const products = [
+    {
+      name: 'Hat',
+      publishedAt: new Date(0),
+    },
+  ];
+  return {
+    props: {
+      products,
+    },
+  };
+});
+
+function Page({ products }) {
+  return JSON.stringify(products);
+}
+
+export default Page;

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/transforms a valid example/code.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/transforms a valid example/code.js
@@ -1,0 +1,18 @@
+export const getServerSideProps = async () => {
+  const products = [
+    {
+      name: 'Hat',
+      publishedAt: new Date(0),
+    },
+  ];
+
+  return {
+    props: {
+      products,
+    },
+  };
+};
+
+export default function Page({ products }) {
+  return JSON.stringify(products);
+}

--- a/packages/babel-preset/src/fix-node-file-trace/tests/pages/transforms a valid example/output.js
+++ b/packages/babel-preset/src/fix-node-file-trace/tests/pages/transforms a valid example/output.js
@@ -1,0 +1,17 @@
+import { withFixNodeFileTrace as _withFixNodeFileTrace } from '@blitzjs/core/server';
+export const getServerSideProps = _withFixNodeFileTrace(async () => {
+  const products = [
+    {
+      name: 'Hat',
+      publishedAt: new Date(0),
+    },
+  ];
+  return {
+    props: {
+      products,
+    },
+  };
+});
+export default function Page({ products }) {
+  return JSON.stringify(products);
+}

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -1,6 +1,6 @@
 import type { TransformOptions } from '@babel/core';
 import AddBlitzAppRoot from './add-blitz-app-root';
-// import FixNodeFileTrace from './fix-node-file-trace';
+import FixNodeFileTrace from './fix-node-file-trace';
 import RewriteImports from './rewrite-imports';
 
 // eslint-disable-next-line import/no-default-export
@@ -17,7 +17,7 @@ export default function preset(_api: any, options = {}) {
         { exclude: ['dehydratedState'] },
       ],
       AddBlitzAppRoot,
-      // FixNodeFileTrace
+      FixNodeFileTrace,
     ],
   };
 

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -12,12 +12,12 @@ export default function preset(_api: any, options = {}) {
   const config: TransformOptions = {
     presets: [[require('next/babel'), options]],
     plugins: [
+      FixNodeFileTrace,
       [
         require('babel-plugin-superjson-next'),
         { exclude: ['dehydratedState'] },
       ],
       AddBlitzAppRoot,
-      FixNodeFileTrace,
     ],
   };
 

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -1,5 +1,6 @@
 import type { TransformOptions } from '@babel/core';
 import AddBlitzAppRoot from './add-blitz-app-root';
+// import FixNodeFileTrace from './fix-node-file-trace';
 import RewriteImports from './rewrite-imports';
 
 // eslint-disable-next-line import/no-default-export
@@ -16,6 +17,7 @@ export default function preset(_api: any, options = {}) {
         { exclude: ['dehydratedState'] },
       ],
       AddBlitzAppRoot,
+      // FixNodeFileTrace
     ],
   };
 

--- a/packages/core/src/server/auth/sessions.ts
+++ b/packages/core/src/server/auth/sessions.ts
@@ -8,7 +8,7 @@ import cookie from "cookie"
 import {IncomingMessage, ServerResponse} from "http"
 import {sign as jwtSign, verify as jwtVerify} from "jsonwebtoken"
 import {getCookieParser} from "next/dist/next-server/server/api-utils"
-import {join} from "path"
+import path, {join} from "path"
 import {
   EmptyPublicData,
   IsAuthorizedArgs,
@@ -222,6 +222,10 @@ export async function getSession(
 ): Promise<SessionContext> {
   ensureBlitzApiRequest(req)
   ensureMiddlewareResponse(res)
+
+  path.resolve("next.config.js")
+  path.resolve(".blitz/blitz.config.js")
+  path.resolve(".next/blitz/db.js")
 
   let response = res as MiddlewareResponse<{session?: SessionContext}>
 

--- a/packages/core/src/server/auth/sessions.ts
+++ b/packages/core/src/server/auth/sessions.ts
@@ -8,7 +8,7 @@ import cookie from "cookie"
 import {IncomingMessage, ServerResponse} from "http"
 import {sign as jwtSign, verify as jwtVerify} from "jsonwebtoken"
 import {getCookieParser} from "next/dist/next-server/server/api-utils"
-import path, {join} from "path"
+import {join} from "path"
 import {
   EmptyPublicData,
   IsAuthorizedArgs,
@@ -222,10 +222,6 @@ export async function getSession(
 ): Promise<SessionContext> {
   ensureBlitzApiRequest(req)
   ensureMiddlewareResponse(res)
-
-  path.resolve("next.config.js")
-  path.resolve(".blitz/blitz.config.js")
-  path.resolve(".next/blitz/db.js")
 
   let response = res as MiddlewareResponse<{session?: SessionContext}>
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -30,7 +30,7 @@ export const fixNodeFileTrace = () => {
   path.resolve(".blitz/blitz.config.js")
   path.resolve(".next/blitz/db.js")
 }
-export const withNodeFileTrace = (fn: Function) => {
+export const withFixNodeFileTrace = (fn: Function) => {
   fixNodeFileTrace()
   return fn
 }

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -23,3 +23,14 @@ export {passportAuth} from "./auth/passport-adapter"
 export {SecurePassword, hash256, generateToken} from "./auth/auth-utils"
 
 export {rpcApiHandler} from "./rpc-server"
+
+export const fixNodeFileTrace = () => {
+  const path = require("path")
+  path.resolve("next.config.js")
+  path.resolve(".blitz/blitz.config.js")
+  path.resolve(".next/blitz/db.js")
+}
+export const withNodeFileTrace = (fn: Function) => {
+  fixNodeFileTrace()
+  return fn
+}

--- a/packages/server/src/stages/rpc/index.ts
+++ b/packages/server/src/stages/rpc/index.ts
@@ -60,11 +60,9 @@ export default getIsomorphicEnhancedResolver(
 const apiHandlerTemplate = (originalPath: string, useTypes: boolean, useDb: boolean) => `
 // This imports the output of getIsomorphicEnhancedResolver()
 import enhancedResolver from '${originalPath}'
-import {getAllMiddlewareForModule, fixNodeFileTrace} from '@blitzjs/core/server'
+import {getAllMiddlewareForModule} from '@blitzjs/core/server'
 import {rpcApiHandler} from '@blitzjs/core/server'
 import path from 'path'
-
-fixNodeFileTrace()
 
 let db${useTypes ? ": any" : ""}
 let connect${useTypes ? ": any" : ""}

--- a/packages/server/src/stages/rpc/index.ts
+++ b/packages/server/src/stages/rpc/index.ts
@@ -60,15 +60,11 @@ export default getIsomorphicEnhancedResolver(
 const apiHandlerTemplate = (originalPath: string, useTypes: boolean, useDb: boolean) => `
 // This imports the output of getIsomorphicEnhancedResolver()
 import enhancedResolver from '${originalPath}'
-import {getAllMiddlewareForModule} from '@blitzjs/core/server'
+import {getAllMiddlewareForModule, fixNodeFileTrace} from '@blitzjs/core/server'
 import {rpcApiHandler} from '@blitzjs/core/server'
 import path from 'path'
 
-// Ensure these files are not eliminated by trace-based tree-shaking (like Vercel)
-path.resolve("next.config.js")
-path.resolve(".blitz/blitz.config.js")
-path.resolve(".next/blitz/db.js")
-// End anti-tree-shaking
+fixNodeFileTrace()
 
 let db${useTypes ? ": any" : ""}
 let connect${useTypes ? ": any" : ""}

--- a/patches/@preconstruct+cli+2.0.7.patch
+++ b/patches/@preconstruct+cli+2.0.7.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@preconstruct/cli/cli/dist/cli.cjs.dev.js b/node_modules/@preconstruct/cli/cli/dist/cli.cjs.dev.js
-index 972d57b..e6bc64b 100644
+index 972d57b..9215a89 100644
 --- a/node_modules/@preconstruct/cli/cli/dist/cli.cjs.dev.js
 +++ b/node_modules/@preconstruct/cli/cli/dist/cli.cjs.dev.js
 @@ -166,7 +166,7 @@ function format(args, messageType, scope) {
@@ -15,7 +15,7 @@ index 972d57b..e6bc64b 100644
      external.push(...builtInModules);
    }
  
-+  external.push('next', 'react', '@babel/core', 'prettier', '.blitz')
++  external.push('next', 'react', '@babel/core', 'prettier', '.blitz', "@babel/types")
 +
    let input = {};
    entrypoints.forEach(entrypoint => {

--- a/test/integration/export-image-default/pages/index.js
+++ b/test/integration/export-image-default/pages/index.js
@@ -1,8 +1,10 @@
 import {Image} from "blitz"
 
-export default () => (
-  <div>
-    <p>Should error during export</p>
-    <Image src="/i.png" width="10" height="10" />
-  </div>
-)
+export default function ImageDefault() {
+  return (
+    <div>
+      <p>Should error during export</p>
+      <Image src="/i.png" width="10" height="10" />
+    </div>
+  )
+}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/blitz/issues/794

### What are the changes and their implications?

This adds an internal babel plugin that wraps `getServerSideProps`, `getStaticProps`, and all API routes with `withFixNodeFileTrace()` which runs `path.resolve` on any required files.

## Bug Checklist

- [x] Test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

