### PR TITLE
fix `BlitzConfig` type to allow extra fields (patch)

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,21 +1,21 @@
 import * as esbuild from "esbuild"
 import fs from "fs"
 import {existsSync, readJSONSync} from "fs-extra"
-import {PublicNextConfig} from "next/dist/next-server/server/config"
+import {NextConfig} from "next/dist/next-server/server/config"
 import path, {join} from "path"
 import pkgDir from "pkg-dir"
 const debug = require("debug")("blitz:config")
 
-type NextExperimental = PublicNextConfig["experimental"]
+type NextExperimental = NextConfig["experimental"]
 
 interface Experimental extends NextExperimental {
   isomorphicResolverImports?: boolean
 }
 
-export interface BlitzConfig extends Omit<PublicNextConfig, "experimental" | "future"> {
+export interface BlitzConfig extends Omit<NextConfig, "experimental" | "future"> {
   target?: string
   experimental?: Experimental
-  future?: PublicNextConfig["future"]
+  future?: NextConfig["future"]
   cli?: {
     clearConsoleOnBlitzDev?: boolean
     httpProxy?: string


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #2466

### What are the changes and their implications?

There are a number of Next.js configuration options, like the `images` key which are not included in the [PublicNextConfig](https://github.com/blitz-js/blitz/blob/canary/nextjs/packages/next/next-server/server/config-shared.ts#L12) type. In Next.js, they handle this by appending `Record<string, any>` via the [NextConfig](https://github.com/blitz-js/blitz/blob/canary/nextjs/packages/next/next-server/server/config-shared.ts#L69) type.

To allow all the documented Next.js config options to be passed into BlitzConfig, without typescript complaining, this PR updates BlitzConfig to extend [NextConfig](https://github.com/blitz-js/blitz/blob/canary/nextjs/packages/next/next-server/server/config-shared.ts#L69), rather than [PublicNextConfig](https://github.com/blitz-js/blitz/blob/canary/nextjs/packages/next/next-server/server/config-shared.ts#L12), which includes the `Record<string, any>` escape hatch.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
