### PR TITLE
(newapp) move dev dependencies to devDependencies in package.json (better for Docker)

### DIFF
--- a/packages/generator/templates/app/package.json
+++ b/packages/generator/templates/app/package.json
@@ -25,22 +25,24 @@
   },
   "dependencies": {
     "@prisma/client": "2.x",
-    "@types/react": "17.x",
-    "@types/preview-email": "2.x",
     "blitz": "canary",
+    "react-dom": "0.0.0-experimental-0eea57724",
+    "react-error-boundary": "3.x",
+    "react": "0.0.0-experimental-0eea57724",
+    "zod": "3.x"
+  },
+  "devDependencies": {
+    "@types/preview-email": "2.x",
+    "@types/react": "17.x",
     "eslint": "7.x",
     "husky": "6.x",
     "lint-staged": "10.x",
+    "prettier-plugin-prisma": "0.x",
     "prettier": "2.x",
     "pretty-quick": "3.x",
     "preview-email": "3.x",
-    "prettier-plugin-prisma": "0.x",
     "prisma": "2.x",
-    "react": "0.0.0-experimental-0eea57724",
-    "react-dom": "0.0.0-experimental-0eea57724",
-    "react-error-boundary": "3.x",
-    "typescript": "~4.2",
-    "zod": "3.x"
+    "typescript": "~4.2"
   },
   "private": true
 }


### PR DESCRIPTION
### What are the changes and their implications?

Prior to this commit devDependencies were moved to dependencies, in favor to fix issues with builds on some cloud server providers. But this results into a very large production container. If build as Docker image just the directory of node_modules is larger than 550MB. 

There is significant reduction by moving following dependencies back to devDependencies

- @types/preview-email
- @types/react
- eslint
- husky
- lint-staged
- prettier-plugin-prisma
- prettier
- pretty-quick
- preview-email
- prisma
- typescript"

## Testing


```
git clone https://github.com/kivi/blitz-docker-example ./testBlitzDevdeps
cd .\testBlitzDevdeps
yarn
```

Build the image:
```
docker build . -t blitz-devdeps
```

check if image was build. Check size
```
docker images | grep blitz-devdeps
```

Test run and open in browser
```
docker run --name blitz-devdeps-running -p 3031:3000 blitz-devdeps
```
