### PR TITLE
fix pages to never render if `Page.authenticate=true` and logged out (patch)

### DIFF
--- a/packages/core/src/auth/auth-client.ts
+++ b/packages/core/src/auth/auth-client.ts
@@ -57,13 +57,11 @@ export const useAuthorize = () => {
 }
 
 export const useAuthorizeIf = (condition?: boolean) => {
-  useEffect(() => {
-    if (condition && !publicDataStore.getData().userId) {
-      const error = new AuthenticationError()
-      error.stack = null!
-      throw error
-    }
-  })
+  if (typeof window !== "undefined" && condition && !publicDataStore.getData().userId) {
+    const error = new AuthenticationError()
+    error.stack = null!
+    throw error
+  }
 }
 
 export const useRedirectAuthenticated = (to: string) => {

--- a/test/integration/auth/pages/page-dot-authenticate-logout.tsx
+++ b/test/integration/auth/pages/page-dot-authenticate-logout.tsx
@@ -1,0 +1,36 @@
+import logout from "app/mutations/logout"
+import getAuthenticatedBasic from "app/queries/getAuthenticatedBasic"
+import {BlitzPage, useMutation, useQuery} from "blitz"
+import {Suspense} from "react"
+
+function Content() {
+  const [result] = useQuery(getAuthenticatedBasic, undefined)
+  const [logoutMutation] = useMutation(logout)
+  return (
+    <div>
+      <div id="content">{result}</div>
+      <button
+        id="logout"
+        onClick={async () => {
+          await logoutMutation()
+        }}
+      >
+        logout
+      </button>
+    </div>
+  )
+}
+
+const Page: BlitzPage = () => {
+  return (
+    <div id="page">
+      <Suspense fallback={"Loading..."}>
+        <Content />
+      </Suspense>
+    </div>
+  )
+}
+
+Page.authenticate = {redirectTo: "/login"}
+
+export default Page

--- a/test/integration/auth/pages/page-dot-authenticate.tsx
+++ b/test/integration/auth/pages/page-dot-authenticate.tsx
@@ -1,0 +1,39 @@
+import logout from "app/mutations/logout"
+import getAuthenticatedBasic from "app/queries/getAuthenticatedBasic"
+import {BlitzPage, useMutation, useQuery} from "blitz"
+import {Suspense} from "react"
+
+function Content() {
+  const [result] = useQuery(getAuthenticatedBasic, undefined)
+  const [logoutMutation] = useMutation(logout)
+  return (
+    <div>
+      <div id="content">{result}</div>
+      <button
+        id="logout"
+        onClick={async () => {
+          await logoutMutation()
+        }}
+      >
+        logout
+      </button>
+    </div>
+  )
+}
+
+const Page: BlitzPage = () => {
+  if (typeof window !== "undefined") {
+    throw new Error("This code should never run")
+  }
+  return (
+    <div id="page">
+      <Suspense fallback={"Loading..."}>
+        <Content />
+      </Suspense>
+    </div>
+  )
+}
+
+Page.authenticate = true
+
+export default Page

--- a/test/integration/auth/test/index.test.ts
+++ b/test/integration/auth/test/index.test.ts
@@ -29,6 +29,7 @@ describe("Auth", () => {
       "/login",
       "/noauth-query",
       "/authenticated-query",
+      "/page-dot-authenticate",
       "/api/queries/getNoauthBasic",
       "/api/queries/getAuthenticatedBasic",
       "/api/mutations/login",
@@ -50,6 +51,14 @@ describe("Auth", () => {
 
     it("should render error for protected query", async () => {
       const browser = await webdriver(context.appPort, "/authenticated-query")
+      await browser.waitForElementByCss("#error")
+      let text = await browser.elementByCss("#error").text()
+      expect(text).toMatch(/AuthenticationError/)
+      if (browser) await browser.close()
+    })
+
+    it("should render error for protected page", async () => {
+      const browser = await webdriver(context.appPort, "/page-dot-authenticate")
       await browser.waitForElementByCss("#error")
       let text = await browser.elementByCss("#error").text()
       expect(text).toMatch(/AuthenticationError/)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/blitz/issues/2337

### What are the changes and their implications?

fix pages to never render if `Page.authenticate=true` and logged out

## Bug Checklist

- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)