### PR TITLE
Fix edit page generated by `blitz generate` to not have buggy behavior

### DIFF
--- a/examples/auth/app/pages/projects/[projectId]/edit.tsx
+++ b/examples/auth/app/pages/projects/[projectId]/edit.tsx
@@ -10,7 +10,14 @@ import {Routes} from ".blitz"
 export const EditProject = () => {
   const router = useRouter()
   const projectId = useParam("projectId", "number")
-  const [project, {setQueryData}] = useQuery(getProject, {id: projectId})
+  const [project, {setQueryData}] = useQuery(
+    getProject,
+    {id: projectId},
+    {
+      // This ensures the query never refreshes and overwrites the form data while the user is editing.
+      staleTime: Infinity,
+    },
+  )
   const [updateProjectMutation] = useMutation(updateProject)
 
   return (

--- a/packages/generator/templates/page/__modelIdParam__/edit.tsx
+++ b/packages/generator/templates/page/__modelIdParam__/edit.tsx
@@ -13,7 +13,7 @@ export const Edit__ModelName__ = () => {
   }
   const [__modelName__, {setQueryData}] = useQuery(
     get__ModelName__,
-    { id: __modelId__ },
+    {id: __modelId__},
     { 
       // This ensures the query never refreshes and overwrites the form data while the user is editing.
       staleTime: Infinity 

--- a/packages/generator/templates/page/__modelIdParam__/edit.tsx
+++ b/packages/generator/templates/page/__modelIdParam__/edit.tsx
@@ -11,7 +11,14 @@ export const Edit__ModelName__ = () => {
   if (process.env.parentModel) {
     const __parentModelId__ = useParam("__parentModelId__", "number")
   }
-  const [__modelName__, {setQueryData}] = useQuery(get__ModelName__, {id: __modelId__})
+  const [__modelName__, {setQueryData}] = useQuery(
+    get__ModelName__,
+    { id: __modelId__ },
+    { 
+      // This ensures the query never refreshes and overwrites the form data while the user is editing.
+      staleTime: Infinity 
+    }
+  )
   const [update__ModelName__Mutation] = useMutation(update__ModelName__)
 
   return (


### PR DESCRIPTION
Closes: #2481

### What are the changes and their implications?

The generated Edit Page now has `{ staleTime: Infinity }`, so that the query never refreshes and resets the form (which would lose user edited changes).

## Bug Checklist

- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

This is just a change to the template, so I don't think any tests are required. 
