### PR TITLE
Fix `blitz generate` /new page does not use `Routes`

### DIFF
--- a/examples/auth/app/pages/projects/new.tsx
+++ b/examples/auth/app/pages/projects/new.tsx
@@ -23,7 +23,7 @@ const NewProjectPage: BlitzPage = () => {
         onSubmit={async (values) => {
           try {
             const project = await createProjectMutation(values)
-            router.push(`/projects/${project.id}`)
+            router.push(Routes.ShowProjectPage({projectId: project.id}))
           } catch (error) {
             console.error(error)
             return {

--- a/packages/generator/templates/page/new.tsx
+++ b/packages/generator/templates/page/new.tsx
@@ -34,8 +34,8 @@ const New__ModelName__Page: BlitzPage = () => {
             )
             router.push(
               process.env.parentModel
-                ? `/__parentModels__/${__parentModelId__}/__modelNames__/${__modelName__.id}`
-                : `/__modelNames__/${__modelName__.id}`,
+                ? Routes.Show__ModelName__Page({ __parentModelId__: __parentModelId__!, __modelId__: __modelName__.id })
+                : Routes.Show__ModelName__Page({ __modelId__: __modelName__.id }),
             )
           } catch (error) {
             console.error(error)


### PR DESCRIPTION
### What are the changes and their implications?

The `new.tsx` generated page calls `Router.push` but used a string literal for the path instead of the `Routes` object.
