### PR TITLE
Fix `blitz generate` to regenerate the Routes manifest

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -208,14 +208,6 @@ export class Generate extends Command {
     }
   }
 
-  async codegen() {
-    const {generate} = await import("@blitzjs/server")
-    await generate({
-      rootFolder: process.cwd(),
-      env: "dev",
-    })
-  }
-
   async run() {
     const {args, argv, flags}: {args: Args; argv: string[]; flags: Flags} = this.parse(Generate)
     debug("args: ", args)
@@ -246,8 +238,6 @@ export class Generate extends Command {
         })
         await generator.run()
       }
-
-      await this.codegen()
 
       console.log(" ") // new line
     } catch (err) {

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -208,6 +208,14 @@ export class Generate extends Command {
     }
   }
 
+  async codegen() {
+    const {generate} = await import("@blitzjs/server")
+    await generate({
+      rootFolder: process.cwd(),
+      env: "dev",
+    })
+  }
+
   async run() {
     const {args, argv, flags}: {args: Args; argv: string[]; flags: Flags} = this.parse(Generate)
     debug("args: ", args)
@@ -238,6 +246,8 @@ export class Generate extends Command {
         })
         await generator.run()
       }
+
+      await this.codegen()
 
       console.log(" ") // new line
     } catch (err) {

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -34,6 +34,7 @@
     "@babel/core": "7.12.10",
     "@babel/plugin-transform-typescript": "7.12.1",
     "@blitzjs/display": "0.38.0",
+    "@blitzjs/server": "0.38.0",
     "@mrleebo/prisma-ast": "^0.2.4",
     "@types/jscodeshift": "0.7.2",
     "chalk": "^4.1.0",

--- a/packages/generator/src/generators/page-generator.ts
+++ b/packages/generator/src/generators/page-generator.ts
@@ -60,4 +60,13 @@ export class PageGenerator extends Generator<PageGeneratorOptions> {
       : ""
     return `app/pages/${parent}${kebabCaseModelName}`
   }
+
+  async postWrite() {
+    // After pages have been generated, run `codegen` so the Routes definition is updated
+    const {generate} = await import("@blitzjs/server")
+    await generate({
+      rootFolder: process.cwd(),
+      env: "dev",
+    })
+  }
 }


### PR DESCRIPTION
### What are the changes and their implications?

`blitz generate` can create new page files. Right now, the user has to run `blitz codegen` manually after a `blitz generate` to get the `Routes` data updated. This change runs the codegen phase automatically after generate.