### PR TITLE
Add support for custom messages and icons in recipes

### DIFF
--- a/packages/installer/src/executors/executor.tsx
+++ b/packages/installer/src/executors/executor.tsx
@@ -3,6 +3,7 @@ import * as React from "react"
 import {Newline} from "../components/newline"
 
 export interface ExecutorConfig {
+  successIcon?: string
   stepId: string | number
   stepName: string
   stepType: string

--- a/packages/installer/src/executors/print-message-executor.tsx
+++ b/packages/installer/src/executors/print-message-executor.tsx
@@ -1,0 +1,36 @@
+import {Box, Text} from "ink"
+import * as React from "react"
+import {Newline} from "../components/newline"
+import {useEnterToContinue} from "../utils/use-enter-to-continue"
+import {Executor, executorArgument, ExecutorConfig, getExecutorArgument} from "./executor"
+
+export interface Config extends ExecutorConfig {
+  message: executorArgument<string>
+}
+
+export const type = "print-message"
+
+export const Commit: Executor["Commit"] = ({cliArgs, onChangeCommitted, step}) => {
+  const generatorArgs = React.useMemo(
+    () => ({
+      message: getExecutorArgument((step as Config).message, cliArgs),
+      stepName: getExecutorArgument((step as Config).stepName, cliArgs),
+    }),
+    [cliArgs, step],
+  )
+
+  const handleChangeCommitted = React.useCallback(() => {
+    onChangeCommitted(generatorArgs.stepName)
+  }, [onChangeCommitted, generatorArgs])
+
+  useEnterToContinue(handleChangeCommitted)
+
+  return (
+    <Box flexDirection="column">
+      {/* eslint-disable-next-line jsx-a11y/accessible-emoji */}
+      <Text>{generatorArgs.message}</Text>
+      <Newline />
+      <Text bold>Press ENTER to continue</Text>
+    </Box>
+  )
+}

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -4,6 +4,8 @@ export * from "./executors/executor"
 export {type as AddDependencyType} from "./executors/add-dependency-executor"
 export {type as FileTransformType} from "./executors/file-transform-executor"
 export {type as NewFileType} from "./executors/new-file-executor"
+export {type as PrintMessageType} from "./executors/print-message-executor"
+
 export * from "./utils/paths"
 export * from "./transforms"
 export {customTsParser} from "./utils/transform"

--- a/packages/installer/src/recipe-builder.ts
+++ b/packages/installer/src/recipe-builder.ts
@@ -1,12 +1,16 @@
 import * as AddDependencyExecutor from "./executors/add-dependency-executor"
 import * as TransformFileExecutor from "./executors/file-transform-executor"
 import * as NewFileExecutor from "./executors/new-file-executor"
+import * as PrintMessageExecutor from "./executors/print-message-executor"
 import {ExecutorConfigUnion, RecipeExecutor} from "./recipe-executor"
 import {RecipeMeta} from "./types"
 
 export interface IRecipeBuilder {
   setName(name: string): IRecipeBuilder
   setDescription(description: string): IRecipeBuilder
+  printMessage(
+    step: Omit<Omit<PrintMessageExecutor.Config, "stepType">, "explanation">,
+  ): IRecipeBuilder
   setOwner(owner: string): IRecipeBuilder
   setRepoLink(repoLink: string): IRecipeBuilder
   addAddDependenciesStep(step: Omit<AddDependencyExecutor.Config, "stepType">): IRecipeBuilder
@@ -26,6 +30,13 @@ export function RecipeBuilder(): IRecipeBuilder {
     },
     setDescription(description: string) {
       meta.description = description
+      return this
+    },
+    printMessage(step: Omit<PrintMessageExecutor.Config, "stepType">) {
+      steps.push({
+        stepType: PrintMessageExecutor.type,
+        ...step,
+      })
       return this
     },
     setOwner(owner: string) {

--- a/packages/installer/src/recipe-executor.tsx
+++ b/packages/installer/src/recipe-executor.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import * as AddDependencyExecutor from "./executors/add-dependency-executor"
 import * as FileTransformExecutor from "./executors/file-transform-executor"
 import * as NewFileExecutor from "./executors/new-file-executor"
+import * as PrintMessageExecutor from "./executors/print-message-executor"
 import {RecipeRenderer} from "./recipe-renderer"
 import {RecipeMeta} from "./types"
 // const debug = require('debug')("blitz:installer")
@@ -12,6 +13,7 @@ type ExecutorConfig =
   | AddDependencyExecutor.Config
   | FileTransformExecutor.Config
   | NewFileExecutor.Config
+  | PrintMessageExecutor.Config
 
 export type {ExecutorConfig as ExecutorConfigUnion}
 

--- a/packages/installer/src/recipe-renderer.tsx
+++ b/packages/installer/src/recipe-renderer.tsx
@@ -5,6 +5,7 @@ import * as AddDependencyExecutor from "./executors/add-dependency-executor"
 import {Executor, ExecutorConfig, Frontmatter} from "./executors/executor"
 import * as FileTransformExecutor from "./executors/file-transform-executor"
 import * as NewFileExecutor from "./executors/new-file-executor"
+import * as PrintMessageExecutor from "./executors/print-message-executor"
 import {RecipeMeta} from "./types"
 import {useEnterToContinue} from "./utils/use-enter-to-continue"
 
@@ -27,6 +28,7 @@ enum Status {
 const ExecutorMap: {[key: string]: Executor} = {
   [AddDependencyExecutor.type]: AddDependencyExecutor,
   [NewFileExecutor.type]: NewFileExecutor,
+  [PrintMessageExecutor.type]: PrintMessageExecutor,
   [FileTransformExecutor.type]: FileTransformExecutor,
 } as const
 
@@ -177,13 +179,14 @@ export function RecipeRenderer({cliArgs, steps, recipeMeta}: RecipeProps) {
     }
   })
 
-  const messages = state.steps.map((step) => step.successMsg).filter((s) => s)
-
+  const messages = state.steps
+    .map((step) => ({msg: step.successMsg, icon: step.executor.successIcon ?? "✅"}))
+    .filter((s) => s.msg)
   return (
     <DispatchContext.Provider value={dispatch}>
-      {messages.map((msg, index) => (
+      {messages.map(({msg, icon}, index) => (
         <Text key={msg + index} color="green">
-          {msg === "\n" ? "" : "✅"} {msg}
+          {msg === "\n" ? "" : icon} {msg}
         </Text>
       ))}
       {state.current === -1 ? <WelcomeMessage recipeMeta={recipeMeta} /> : null}

--- a/packages/installer/test/executors/__snapshots__/print-message-executor.test.tsx.snap
+++ b/packages/installer/test/executors/__snapshots__/print-message-executor.test.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Executor should render PrintMessageExecutor 1`] = `
+"My message
+
+Press ENTER to continue"
+`;

--- a/packages/installer/test/executors/print-message-executor.test.tsx
+++ b/packages/installer/test/executors/print-message-executor.test.tsx
@@ -1,0 +1,29 @@
+import {render} from "ink-testing-library"
+import React from "react"
+import stripAnsi from "strip-ansi"
+import {Commit as PrintMessageExecutor} from "../../src/executors/print-message-executor"
+
+describe("Executor", () => {
+  const executorConfig = {
+    stepId: "printMessage",
+    stepName: "Print message",
+    stepType: "print-message",
+    explanation: "Testing text for a print message",
+    message: "My message",
+  }
+  it("should render PrintMessageExecutor", () => {
+    const {lastFrame} = render(
+      <PrintMessageExecutor cliArgs={null} onChangeCommitted={() => {}} step={executorConfig} />,
+    )
+
+    expect(stripAnsi(lastFrame())).toMatchSnapshot()
+  })
+
+  it("should contain a step name and explanation", () => {
+    const {frames} = render(
+      <PrintMessageExecutor cliArgs={null} onChangeCommitted={() => {}} step={executorConfig} />,
+    )
+
+    expect(frames[0].includes("My message")).toBeTruthy()
+  })
+})


### PR DESCRIPTION
This is a feature nobody asked for (maybe?) but it's something that I think was missing in the recipes; writing a custom message step while installing a recipe. 
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: ?

### What are the changes and their implications?


Adds new step type `printMessage`

```typescript
  builder.printMessage({
    successIcon: "😭",
    stepId: "oops",
    stepName: "Im so sorry :(",
    message:
      "This recipe can't edit your blitz.config.ts (yet), you can add the Blitz Guard middleware following these two steps: https://ntgussoni.github.io/blitz-guard/docs/middleware",
  })
```

This prints the message in the following way
![image](https://user-images.githubusercontent.com/10161067/122650804-2807be00-d135-11eb-881c-aaccc97c51e6.png)
![image](https://user-images.githubusercontent.com/10161067/122650824-3eae1500-d135-11eb-9bde-405fc464ca5e.png)


The updated documentation can be found here: https://github.com/blitz-js/blitzjs.com/pull/508

## Bug Checklist

- [ x ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ x ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ x ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
