### PR TITLE
fix `validateZodSchema()` to pass if schema undefined

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -43,6 +43,7 @@ export function recursiveFormatZodErrors(errors: any) {
 }
 
 export const validateZodSchema = (schema: any) => (values: any): any => {
+  if (!schema) return {}
   try {
     schema.parse(values)
     return {}


### PR DESCRIPTION

### What are the changes and their implications?

fix `validateZodSchema()` to pass if schema undefined

In the meantime, here's a workaround to make in Form.tsx

```diff
-      validate={validateZodSchema(schema)}
+      validate={schema ? validateZodSchema(schema) : () => ({})}
```
