### PR TITLE
fix lint warning, unused `path` in generated api routes (patch)

### DIFF
--- a/packages/server/src/stages/rpc/index.ts
+++ b/packages/server/src/stages/rpc/index.ts
@@ -62,7 +62,6 @@ const apiHandlerTemplate = (originalPath: string, useTypes: boolean, useDb: bool
 import enhancedResolver from '${originalPath}'
 import {getAllMiddlewareForModule} from '@blitzjs/core/server'
 import {rpcApiHandler} from '@blitzjs/core/server'
-import path from 'path'
 
 let db${useTypes ? ": any" : ""}
 let connect${useTypes ? ": any" : ""}


### PR DESCRIPTION


### What are the changes and their implications?


fix lint warning, unused `path` in generated api routes (patch)