### PR TITLE
Fix browser error when using `prisma.$use()`

### DIFF
--- a/packages/core/src/prisma-utils.ts
+++ b/packages/core/src/prisma-utils.ts
@@ -20,9 +20,9 @@ export const enhancePrisma = <TPrismaClientCtor extends Constructor>(
   return new Proxy(client as EnhancedPrismaClientConstructor<TPrismaClientCtor>, {
     construct(target, args) {
       if (typeof window !== "undefined" && process.env.JEST_WORKER_ID === undefined) {
-        // Return empty object if in the browser
+        // Return object with $use method if in the browser
         // Skip in Jest tests because window is defined in Jest tests
-        return {}
+        return {$use: () => {}}
       }
 
       if (!global._blitz_prismaClient) {


### PR DESCRIPTION
Closes: #2493 

### What are the changes and their implications?
Return object with $use method if in the browser

