### PR TITLE
Fix CSRF error when using `session.$setPublicData`

### DIFF
--- a/packages/core/src/server/auth/passport-adapter.ts
+++ b/packages/core/src/server/auth/passport-adapter.ts
@@ -99,21 +99,11 @@ export function passportAuth(config: BlitzPassportConfig): BlitzApiHandler {
             try {
               let error = err
 
-              if (!error) {
-                if (result === false) {
-                  log.warning(
-                    `Login via ${strategyName} failed - usually this means the user did not authenticate properly with the provider`,
-                  )
-                  error = `Login failed`
-                }
-                assert(
-                  typeof result === "object" && result !== null,
-                  `Your '${strategyName}' passport verify callback returned empty data. Ensure you call 'done(null, {publicData: {userId: 1}})' along with any other publicData fields you need)`,
+              if (!error && result === false) {
+                log.warning(
+                  `Login via ${strategyName} failed - usually this means the user did not authenticate properly with the provider`,
                 )
-                assert(
-                  (result as any).publicData,
-                  `'publicData' is missing from your '${strategyName}' passport verify callback. Ensure you call 'done(null, {publicData: {userId: 1}})' along with any other publicData fields you need)`,
-                )
+                error = `Login failed`
               }
 
               const redirectUrlFromVerifyResult =
@@ -132,6 +122,14 @@ export function passportAuth(config: BlitzPassportConfig): BlitzApiHandler {
                 return
               }
 
+              assert(
+                typeof result === "object" && result !== null,
+                `Your '${strategyName}' passport verify callback returned empty data. Ensure you call 'done(null, {publicData: {userId: 1}})' along with any other publicData fields you need)`,
+              )
+              assert(
+                (result as any).publicData,
+                `'publicData' is missing from your '${strategyName}' passport verify callback. Ensure you call 'done(null, {publicData: {userId: 1}})' along with any other publicData fields you need)`,
+              )
               assert(isVerifyCallbackResult(result), "Passport verify callback is invalid")
 
               delete (result.publicData as any)[INTERNAL_REDIRECT_URL_KEY]

--- a/packages/core/src/server/auth/sessions.ts
+++ b/packages/core/src/server/auth/sessions.ts
@@ -551,6 +551,7 @@ export const setCSRFCookie = (
   expiresAt: Date,
 ) => {
   debug("setCSRFCookie", antiCSRFToken)
+  assert(Boolean(antiCSRFToken), "Internal error: antiCSRFToken is being set to undefined")
   setCookie(
     res,
     cookie.serialize(COOKIE_CSRF_TOKEN(), antiCSRFToken, {
@@ -726,8 +727,8 @@ export async function getSessionKernel(
     return {
       handle: payload.handle,
       publicData: payload.publicData,
+      antiCSRFToken: payload.antiCSRFToken,
       jwtPayload: payload,
-      antiCSRFToken,
       anonymousSessionToken,
     }
   }

--- a/packages/core/src/server/auth/sessions.ts
+++ b/packages/core/src/server/auth/sessions.ts
@@ -551,7 +551,7 @@ export const setCSRFCookie = (
   expiresAt: Date,
 ) => {
   debug("setCSRFCookie", antiCSRFToken)
-  assert(Boolean(antiCSRFToken), "Internal error: antiCSRFToken is being set to undefined")
+  assert(antiCSRFToken !== undefined, "Internal error: antiCSRFToken is being set to undefined")
   setCookie(
     res,
     cookie.serialize(COOKIE_CSRF_TOKEN(), antiCSRFToken, {

--- a/test/integration/auth/pages/gssp-setpublicdata.tsx
+++ b/test/integration/auth/pages/gssp-setpublicdata.tsx
@@ -1,0 +1,31 @@
+import {GetServerSideProps, getSession} from "blitz"
+import {Suspense} from "react"
+
+export const getServerSideProps: GetServerSideProps = async ({req, res}) => {
+  const session = await getSession(req, res)
+  await session.$setPublicData({role: "user"})
+
+  return {
+    props: {},
+  }
+}
+
+function Content() {
+  return (
+    <div>
+      <div id="content">it works</div>
+    </div>
+  )
+}
+
+function Page() {
+  return (
+    <div id="page">
+      <Suspense fallback={"Loading..."}>
+        <Content />
+      </Suspense>
+    </div>
+  )
+}
+
+export default Page

--- a/test/integration/auth/pages/login.tsx
+++ b/test/integration/auth/pages/login.tsx
@@ -22,7 +22,7 @@ function Content() {
             try {
               await logoutMutation()
             } catch (error) {
-              setError(error)
+              setError(error.toString())
             }
           }}
         >

--- a/test/integration/auth/test/index.test.ts
+++ b/test/integration/auth/test/index.test.ts
@@ -147,6 +147,25 @@ const runTests = (mode: string) => {
         if (browser) await browser.close()
       })
     })
+
+    describe("setPublicData", () => {
+      it("it should not throw CSRF error", async () => {
+        // https://github.com/blitz-js/blitz/issues/2448
+        const browser = await webdriver(appPort, "/login")
+
+        // ensure logged out
+        let text = await browser.elementByCss("#content").text()
+        if (text.match(/logged-in/)) {
+          await browser.elementByCss("#logout").click()
+        }
+
+        await browser.eval(`window.location = "/gssp-setpublicdata"`)
+        await browser.waitForElementByCss("#content")
+        text = await browser.elementByCss("#content").text()
+        expect(text).toMatch(/it works/)
+        if (browser) await browser.close()
+      })
+    })
   })
 }
 
@@ -167,6 +186,7 @@ describe("dev mode", () => {
       "/api/queries/getAuthenticatedBasic",
       "/api/mutations/login",
       "/api/mutations/logout",
+      "/gssp-setpublicdata",
     ]
     await Promise.all(prerender.map((route) => renderViaHTTP(appPort, route)))
   })


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/2448
Closes: https://github.com/blitz-js/blitz/issues/2096
Related: https://github.com/blitz-js/blitz/issues/2534

### What are the changes and their implications?

Fix CSRF error when using `session.$setPublicData`. Issue was that the csrf cookie would get set to `undefined`

## Bug Checklist

- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)