### PR TITLE
(newapp) Remove `<Suspense>` from _app.js because it causes buggy redirect behavior

### DIFF
--- a/packages/generator/templates/app/app/pages/_app.tsx
+++ b/packages/generator/templates/app/app/pages/_app.tsx
@@ -8,20 +8,17 @@ import {
   useQueryErrorResetBoundary,
 } from "blitz"
 import LoginForm from "app/auth/components/LoginForm"
-import { Suspense } from "react"
 
 export default function App({ Component, pageProps }: AppProps) {
   const getLayout = Component.getLayout || ((page) => page)
 
   return (
-    <Suspense fallback="Loading...">
-      <ErrorBoundary
-        FallbackComponent={RootErrorFallback}
-        onReset={useQueryErrorResetBoundary().reset}
-      >
-        {getLayout(<Component {...pageProps} />)}
-      </ErrorBoundary>
-    </Suspense>
+    <ErrorBoundary
+      FallbackComponent={RootErrorFallback}
+      onReset={useQueryErrorResetBoundary().reset}
+    >
+      {getLayout(<Component {...pageProps} />)}
+    </ErrorBoundary>
   )
 }
 


### PR DESCRIPTION
Related: https://github.com/blitz-js/blitz/issues/2527, https://github.com/blitz-js/blitz/discussions/2533

### What are the changes and their implications?


Remove `<Suspense>` from _app.js because it causes buggy redirect behavior