### PR TITLE
Chakra-UI recipe updates the `LabeledTextField` with Chakra's native components

### DIFF
--- a/recipes/chakra-ui/index.ts
+++ b/recipes/chakra-ui/index.ts
@@ -1,6 +1,6 @@
 import {addImport, paths, RecipeBuilder} from "@blitzjs/installer"
 import {NodePath} from "ast-types/lib/node-path"
-import j from "jscodeshift"
+import j, {JSXIdentifier} from "jscodeshift"
 import {Collection} from "jscodeshift/src/Collection"
 
 // Copied from https://github.com/blitz-js/blitz/pull/805, let's add this to the @blitzjs/installer
@@ -22,6 +22,110 @@ function wrapComponentWithChakraProvider(program: Collection<j.Program>) {
         ),
       )
     })
+  return program
+}
+
+function updateLabeledTextFieldWithInputComponent(program: Collection<j.Program>) {
+  program
+    .find(j.TSInterfaceDeclaration)
+    .find(j.TSExpressionWithTypeArguments)
+    .forEach((path: j.ASTPath<j.TSExpressionWithTypeArguments>) => {
+      path.replace(
+        j.tsExpressionWithTypeArguments(
+          j.identifier("ComponentPropsWithoutRef"),
+          j.tsTypeParameterInstantiation([j.tsTypeQuery(j.identifier("Input"))]),
+        ),
+      )
+    })
+
+  return program
+}
+
+function replaceOuterDivWithFormControl(program: Collection<j.Program>) {
+  program
+    .find(j.JSXElement)
+    .filter((path) => {
+      const {node} = path
+      const openingElementNameNode = node?.openingElement?.name as JSXIdentifier
+
+      // This will not include JSX elements within curly braces
+      const countOfChildrenJSXElements = path.node.children.filter(
+        (childNode) => childNode.type === "JSXElement",
+      ).length
+
+      return (
+        openingElementNameNode?.name === "div" &&
+        node?.openingElement?.selfClosing === false &&
+        countOfChildrenJSXElements === 1
+      )
+    })
+    .forEach((path) => {
+      path.node.openingElement = j.jsxOpeningElement(
+        j.jsxIdentifier("FormControl"),
+        path.node.openingElement.attributes,
+      )
+      path.node.closingElement = j.jsxClosingElement(j.jsxIdentifier("FormControl"))
+    })
+
+  return program
+}
+
+function replaceInputWithChakraInput(program: Collection<j.Program>) {
+  program
+    .find(j.JSXElement)
+    .filter((path) => {
+      const {node} = path
+      const openingElementNameNode = node?.openingElement?.name as JSXIdentifier
+
+      return openingElementNameNode?.name === "input" && node?.openingElement?.selfClosing === true
+    })
+    .forEach((path) => {
+      const {node} = path
+      node.openingElement = j.jsxOpeningElement(
+        j.jsxIdentifier("Input"),
+        node.openingElement.attributes,
+        node?.openingElement?.selfClosing,
+      )
+    })
+
+  return program
+}
+
+function replaceLabelWithChakraLabel(program: Collection<j.Program>) {
+  program
+    .find(j.JSXElement)
+    .filter((path) => {
+      const {node} = path
+      const openingElementNameNode = node?.openingElement?.name as JSXIdentifier
+
+      return openingElementNameNode?.name === "label" && node?.openingElement?.selfClosing === false
+    })
+    .forEach((path) => {
+      path.node.openingElement = j.jsxOpeningElement(
+        j.jsxIdentifier("FormLabel"),
+        path.node.openingElement.attributes,
+      )
+      path.node.closingElement = j.jsxClosingElement(j.jsxIdentifier("FormLabel"))
+    })
+
+  return program
+}
+
+function removeDefaultStyleElement(program: Collection<j.Program>) {
+  program
+    .find(j.JSXElement)
+    .filter((path) => {
+      const {node} = path
+      const openingElementNameNode = node?.openingElement?.name as JSXIdentifier
+
+      // Assumes there's one style element at the point the user runs the recipe.
+      return openingElementNameNode?.name === "style" && node?.openingElement?.selfClosing === false
+    })
+    .forEach((path) => {
+      // Removes the node.
+      path.replace()
+    })
+
   return program
 }
 
@@ -54,6 +158,56 @@ export default RecipeBuilder()
 
       addImport(program, stylesImport)
       return wrapComponentWithChakraProvider(program)
+    },
+  })
+  .addTransformFilesStep({
+    stepId: "updateLabeledTextField",
+    stepName: "Update the `LabeledTextField` with Chakra UI's `Input` component",
+    explanation: `The LabeledTextField component uses Chakra UI's input component`,
+    singleFileSearch: "app/core/components/LabeledTextField.tsx",
+    transform(program: Collection<j.Program>) {
+      // Add ComponentPropsWithoutRef import
+      program
+        .find(j.ImportDeclaration)
+        .filter((importDeclaration) => importDeclaration.node.loc?.start.line === 1)
+        .forEach((path) => {
+          path.node.specifiers.push(j.importSpecifier(j.identifier("ComponentPropsWithoutRef")))
+        })
+
+      const componentPropsWithoutRefImport = j.importDeclaration(
+        [j.importSpecifier(j.identifier("Input"))],
+        j.literal("@chakra-ui/input"),
+      )
+
+      const chakraReactImport = j.importDeclaration(
+        [
+          j.importSpecifier(j.identifier("FormControl")),
+          j.importSpecifier(j.identifier("FormLabel")),
+        ],
+        j.literal("@chakra-ui/form-control"),
+      )
+
+      addImport(program, componentPropsWithoutRefImport)
+      addImport(program, chakraReactImport)
+
+      // Imperative steps to describe transformations
+
+      // 1. Update the type of `LabeledTextField`
+      updateLabeledTextFieldWithInputComponent(program)
+
+      // 2. Remove the default <style jsx> styling
+      removeDefaultStyleElement(program)
+
+      // 3. Replace outer div with `FormControl`
+      replaceOuterDivWithFormControl(program)
+
+      // 4. Replace `input` with `ChakraInput`
+      replaceInputWithChakraInput(program)
+
+      // 5. Replace `label` with `ChakraLabel`
+      replaceLabelWithChakraLabel(program)
+
+      return program
     },
   })
   .build()


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #2550

### What are the changes and their implications?
Updates the `LabeledTextField` component to 
- be a Chakra UI `Input` component
- use native Chakra UI components, where appropriate, such as `FormLabel`, `Input`, and `FormControl`.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
