### PR TITLE
Fix validateZodSchema bug: undefined is not an object (evaluating 'e[n]._errors[0]')

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -26,7 +26,7 @@ export function recursiveFormatZodErrors(errors: any) {
       continue
     }
 
-    if (errors[key]._errors[0]) {
+    if (errors[key]?._errors?.[0]) {
       if (!isNaN(key as any) && !Array.isArray(formattedErrors)) {
         formattedErrors = []
       }


### PR DESCRIPTION


### What are the changes and their implications?

Fix validateZodSchema bug: undefined is not an object (evaluating 'e[n]._errors[0]')
