### PR TITLE
Replace keyof check

### DIFF
--- a/packages/core/src/auth/auth-types.ts
+++ b/packages/core/src/auth/auth-types.ts
@@ -14,7 +14,7 @@ declare global {
   }
 }
 
-export type PublicData = "PublicData" extends keyof Session
+export type PublicData = Session extends {PublicData: unknown}
   ? Session["PublicData"]
   : {userId: unknown}
 
@@ -22,7 +22,7 @@ export interface EmptyPublicData extends Partial<Omit<PublicData, "userId">> {
   userId: PublicData["userId"] | null
 }
 
-export type IsAuthorizedArgs = "isAuthorized" extends keyof Session
+export type IsAuthorizedArgs = Session extends {isAuthorized: (...args: any) => any}
   ? "args" extends keyof Parameters<Session["isAuthorized"]>[0]
     ? Parameters<Session["isAuthorized"]>[0]["args"]
     : unknown[]

--- a/packages/core/src/server/resolver.ts
+++ b/packages/core/src/server/resolver.ts
@@ -1,4 +1,4 @@
-import {infer as zInfer, ZodSchema} from "zod"
+import {input as zInput, output as zOutput, ZodSchema} from "zod"
 import {AuthenticatedSessionContext, SessionContext, SessionContextBase} from "../auth/auth-types"
 import {Await, Ctx, EnsurePromise} from "../types"
 
@@ -292,8 +292,10 @@ const authorize: ResolverAuthorize = (...args) => {
 
 export const resolver = {
   pipe,
-  zod<Schema extends ZodSchema<any, any>, Type = zInfer<Schema>>(schema: Schema) {
-    return (input: Type): Type => schema.parse(input)
+  zod<Schema extends ZodSchema<any, any>, InputType = zInput<Schema>, OutputType = zOutput<Schema>>(
+    schema: Schema,
+  ) {
+    return (input: InputType): OutputType => schema.parse(input)
   },
   authorize,
 }

--- a/packages/core/src/server/resolver.ts
+++ b/packages/core/src/server/resolver.ts
@@ -1,4 +1,4 @@
-import {input as zInput, output as zOutput, ZodSchema} from "zod"
+import {infer as zInfer, ZodSchema} from "zod"
 import {AuthenticatedSessionContext, SessionContext, SessionContextBase} from "../auth/auth-types"
 import {Await, Ctx, EnsurePromise} from "../types"
 
@@ -292,10 +292,8 @@ const authorize: ResolverAuthorize = (...args) => {
 
 export const resolver = {
   pipe,
-  zod<Schema extends ZodSchema<any, any>, InputType = zInput<Schema>, OutputType = zOutput<Schema>>(
-    schema: Schema,
-  ) {
-    return (input: InputType): OutputType => schema.parse(input)
+  zod<Schema extends ZodSchema<any, any>, Type = zInfer<Schema>>(schema: Schema) {
+    return (input: Type): Type => schema.parse(input)
   },
   authorize,
 }


### PR DESCRIPTION
I replaced `"X" extends of keyof Y` with `Y extends of {X: unknown}` to solve `Type "X" cannot be used as an index type.`. Why? Turns out TypeScript 4.3 doesn't narrow the types of an object after a keyof check.


<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: —

### What are the changes and their implications?

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
