### PR TITLE
Add ability to access `req` and `res` objects in blitz passport implementation

### DIFF
--- a/examples/auth/app/api/auth/[...auth].ts
+++ b/examples/auth/app/api/auth/[...auth].ts
@@ -22,7 +22,7 @@ assert(process.env.AUTH0_DOMAIN, "You must provide the AUTH0_DOMAIN env variable
 assert(process.env.AUTH0_CLIENT_ID, "You must provide the AUTH0_CLIENT_ID env variable")
 assert(process.env.AUTH0_CLIENT_SECRET, "You must provide the AUTH0_CLIENT_SECRET env variable")
 
-export default passportAuth(({blitzCtx, req, res}) => ({
+export default passportAuth(({ctx, req, res}) => ({
   successRedirectUrl: "/",
   strategies: [
     {
@@ -44,7 +44,7 @@ export default passportAuth(({blitzCtx, req, res}) => ({
             return done(new Error("Twitter OAuth response doesn't have email."))
           }
 
-          console.log(blitzCtx.session.userId)
+          console.log(ctx.session.userId)
 
           const user = await db.user.upsert({
             where: {email},

--- a/examples/auth/app/api/auth/[...auth].ts
+++ b/examples/auth/app/api/auth/[...auth].ts
@@ -22,7 +22,7 @@ assert(process.env.AUTH0_DOMAIN, "You must provide the AUTH0_DOMAIN env variable
 assert(process.env.AUTH0_CLIENT_ID, "You must provide the AUTH0_CLIENT_ID env variable")
 assert(process.env.AUTH0_CLIENT_SECRET, "You must provide the AUTH0_CLIENT_SECRET env variable")
 
-export default passportAuth((ctx) => ({
+export default passportAuth(({blitzCtx, req, res}) => ({
   successRedirectUrl: "/",
   strategies: [
     {
@@ -44,7 +44,7 @@ export default passportAuth((ctx) => ({
             return done(new Error("Twitter OAuth response doesn't have email."))
           }
 
-          console.log(ctx.session.userId)
+          console.log(blitzCtx.session.userId)
 
           const user = await db.user.upsert({
             where: {email},

--- a/packages/core/src/auth/auth-types.ts
+++ b/packages/core/src/auth/auth-types.ts
@@ -1,5 +1,5 @@
 import type {AuthenticateOptions, Strategy} from "passport"
-import {Ctx} from "../../types"
+import {BlitzApiRequest, BlitzApiResponse, Ctx} from "../../types"
 
 export interface Session {
   // isAuthorize can be injected here
@@ -86,7 +86,17 @@ export interface AuthenticatedClientSession extends PublicData {
   isLoading: boolean
 }
 
-export type BlitzPassportConfigCallback = (blitzCtx: Ctx) => BlitzPassportConfigObject
+export interface BlitzPassportConfigCallbackParams {
+  ctx: Ctx
+  req: BlitzApiRequest
+  res: BlitzApiResponse
+}
+
+export type BlitzPassportConfigCallback = ({
+  ctx,
+  req,
+  res,
+}: BlitzPassportConfigCallbackParams) => BlitzPassportConfigObject
 
 export type BlitzPassportConfig = BlitzPassportConfigObject | BlitzPassportConfigCallback
 

--- a/packages/core/src/server/auth/passport-adapter.ts
+++ b/packages/core/src/server/auth/passport-adapter.ts
@@ -36,7 +36,7 @@ export function passportAuth(config: BlitzPassportConfig): BlitzApiHandler {
     await handleRequestWithMiddleware(req, res, globalMiddleware)
 
     const configObject: BlitzPassportConfigObject = isFunction(config)
-      ? config((res as any).blitzCtx as Ctx)
+      ? config({ctx: (res as any).blitzCtx as Ctx, req, res})
       : config
 
     const cookieSessionMiddleware = cookieSession({


### PR DESCRIPTION
Closes: #2329 

### What are the changes and their implications?

Request and response objects are now available when using a callback for `passportAuth` adapter. Using the request object we can have access to the query and its parameters to customize our passport strategies (e.g., invitation codes, referal codes).

A test hasn't been provided as no previous test is available for passport-adapter. I'd try to think how to implement one in a different issue.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [X] Documentation updated (PR  [blitz-js/blitzjs.com/pull/523](blitz-js/blitzjs.com/pull/523))