### PR TITLE
(newapp) Fix image warning in index page

### DIFF
--- a/packages/generator/templates/app/app/pages/index.tsx
+++ b/packages/generator/templates/app/app/pages/index.tsx
@@ -1,8 +1,9 @@
 import { Suspense } from "react"
-import { Link, BlitzPage, useMutation, Routes } from "blitz"
+import { Image, Link, BlitzPage, useMutation, Routes } from "blitz"
 import Layout from "app/core/layouts/Layout"
 import { useCurrentUser } from "app/core/hooks/useCurrentUser"
 import logout from "app/auth/mutations/logout"
+import logo from "public/logo.png"
 
 /*
  * This file is just for a pleasant getting started page for your new app.
@@ -54,7 +55,7 @@ const Home: BlitzPage = () => {
     <div className="container">
       <main>
         <div className="logo">
-          <img src="/logo.png" alt="blitz.js" />
+          <Image src={logo} alt="blitzjs" />
         </div>
         <p>
           <strong>Congrats!</strong> Your app is ready, including user sign-up and log-in.


### PR DESCRIPTION
### What are the changes and their implications?

This PR replace `<img` element in the `index.ts` template with `<Image>` to solve the following warning message:

```
Do not use <img>. Use Image from 'next/image' instead. See https://nextjs.org/docs/messages/no-img-element.
``
