### PR TITLE
(patch) Fix bug when no dependencies are defined in app package.json

### DIFF
--- a/packages/server/src/next-utils.ts
+++ b/packages/server/src/next-utils.ts
@@ -256,8 +256,8 @@ const getEsbuildOptions = (): esbuild.BuildOptions => {
       "blitz",
       "next",
       ...Object.keys(require("blitz/package").dependencies),
-      ...Object.keys(pkg.dependencies),
-      ...Object.keys(pkg.devDependencies),
+      ...Object.keys(pkg?.dependencies ?? {}),
+      ...Object.keys(pkg?.devDependencies ?? {}),
     ],
   }
 }


### PR DESCRIPTION
Closes: ?

### What are the changes and their implications?

Allow a custom server to start even without dependencies defined in the app package.json

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
