### PR TITLE
Add support for `Page.redirectAuthenticatedTo` to be a function with access to `session`

### DIFF
--- a/packages/core/src/blitz-app-root.tsx
+++ b/packages/core/src/blitz-app-root.tsx
@@ -46,17 +46,21 @@ const NoPageFlicker = () => {
 export function withBlitzInnerWrapper(Page: BlitzPage) {
   const BlitzInnerRoot = (props: ComponentPropsWithoutRef<BlitzPage>) => {
     // We call useSession so this will rerender anytime session changes
-    useSession({suspense: false})
+    const session = useSession({suspense: false})
 
     useAuthorizeIf(Page.authenticate === true)
 
     if (typeof window !== "undefined") {
+      const publicData = publicDataStore.getData()
       // We read directly from publicDataStore.getData().userId instead of useSession
       // so we can access userId on first render. useSession is always empty on first render
-      if (publicDataStore.getData().userId) {
+      if (publicData.userId) {
         clientDebug("[BlitzInnerRoot] logged in")
         let {redirectAuthenticatedTo} = Page
         if (redirectAuthenticatedTo) {
+          if (typeof redirectAuthenticatedTo === "function") {
+            redirectAuthenticatedTo = redirectAuthenticatedTo({publicData, session})
+          }
           if (typeof redirectAuthenticatedTo !== "string") {
             redirectAuthenticatedTo = formatWithValidation(redirectAuthenticatedTo)
           }

--- a/packages/core/src/blitz-app-root.tsx
+++ b/packages/core/src/blitz-app-root.tsx
@@ -56,17 +56,17 @@ export function withBlitzInnerWrapper(Page: BlitzPage) {
       // so we can access userId on first render. useSession is always empty on first render
       if (publicData.userId) {
         clientDebug("[BlitzInnerRoot] logged in")
-        let {redirectAuthenticatedTo} = Page
-        if (typeof redirectAuthenticatedTo === "function") {
-          redirectAuthenticatedTo = redirectAuthenticatedTo({session: publicData})
-          // redirectAuthenticatedTo is string/RouteUrlObject/false now
-        }
-        if (redirectAuthenticatedTo && typeof redirectAuthenticatedTo !== "string") {
-          redirectAuthenticatedTo = formatWithValidation(redirectAuthenticatedTo)
-        }
+        const redirectAuthenticatedTo =
+          typeof Page.redirectAuthenticatedTo === "function"
+            ? Page.redirectAuthenticatedTo({session: publicData})
+            : Page.redirectAuthenticatedTo
         if (redirectAuthenticatedTo) {
-          clientDebug("[BlitzInnerRoot] redirecting to", redirectAuthenticatedTo)
-          const error = new RedirectError(redirectAuthenticatedTo)
+          const redirectUrl =
+            typeof redirectAuthenticatedTo === "string"
+              ? redirectAuthenticatedTo
+              : formatWithValidation(redirectAuthenticatedTo)
+          clientDebug("[BlitzInnerRoot] redirecting to", redirectUrl)
+          const error = new RedirectError(redirectUrl)
           error.stack = null!
           throw error
         }

--- a/packages/core/src/blitz-app-root.tsx
+++ b/packages/core/src/blitz-app-root.tsx
@@ -51,15 +51,14 @@ export function withBlitzInnerWrapper(Page: BlitzPage) {
     useAuthorizeIf(Page.authenticate === true)
 
     if (typeof window !== "undefined") {
-      const publicData = publicDataStore.getData()
       // We read directly from publicDataStore.getData().userId instead of useSession
       // so we can access userId on first render. useSession is always empty on first render
-      if (publicData.userId) {
+      if (publicDataStore.getData().userId) {
         clientDebug("[BlitzInnerRoot] logged in")
         let {redirectAuthenticatedTo} = Page
         if (redirectAuthenticatedTo) {
           if (typeof redirectAuthenticatedTo === "function") {
-            redirectAuthenticatedTo = redirectAuthenticatedTo({publicData, session})
+            redirectAuthenticatedTo = redirectAuthenticatedTo({session})
           }
           if (typeof redirectAuthenticatedTo !== "string") {
             redirectAuthenticatedTo = formatWithValidation(redirectAuthenticatedTo)

--- a/packages/core/src/blitz-app-root.tsx
+++ b/packages/core/src/blitz-app-root.tsx
@@ -59,6 +59,7 @@ export function withBlitzInnerWrapper(Page: BlitzPage) {
         let {redirectAuthenticatedTo} = Page
         if (typeof redirectAuthenticatedTo === "function") {
           redirectAuthenticatedTo = redirectAuthenticatedTo({session: publicData})
+          // redirectAuthenticatedTo is string/RouteUrlObject/false now
         }
         if (redirectAuthenticatedTo && typeof redirectAuthenticatedTo !== "string") {
           redirectAuthenticatedTo = formatWithValidation(redirectAuthenticatedTo)

--- a/packages/core/src/blitz-app-root.tsx
+++ b/packages/core/src/blitz-app-root.tsx
@@ -56,14 +56,17 @@ export function withBlitzInnerWrapper(Page: BlitzPage) {
       if (publicDataStore.getData().userId) {
         clientDebug("[BlitzInnerRoot] logged in")
         let {redirectAuthenticatedTo} = Page
-        if (redirectAuthenticatedTo) {
-          if (typeof redirectAuthenticatedTo === "function") {
+        if (typeof redirectAuthenticatedTo === "function") {
+          if (session.isLoading) {
+            redirectAuthenticatedTo = undefined
+          } else {
             redirectAuthenticatedTo = redirectAuthenticatedTo({session})
           }
-          if (typeof redirectAuthenticatedTo !== "string") {
-            redirectAuthenticatedTo = formatWithValidation(redirectAuthenticatedTo)
-          }
-
+        }
+        if (redirectAuthenticatedTo && typeof redirectAuthenticatedTo !== "string") {
+          redirectAuthenticatedTo = formatWithValidation(redirectAuthenticatedTo)
+        }
+        if (redirectAuthenticatedTo) {
           clientDebug("[BlitzInnerRoot] redirecting to", redirectAuthenticatedTo)
           const error = new RedirectError(redirectAuthenticatedTo)
           error.stack = null!

--- a/packages/core/src/blitz-app-root.tsx
+++ b/packages/core/src/blitz-app-root.tsx
@@ -46,22 +46,19 @@ const NoPageFlicker = () => {
 export function withBlitzInnerWrapper(Page: BlitzPage) {
   const BlitzInnerRoot = (props: ComponentPropsWithoutRef<BlitzPage>) => {
     // We call useSession so this will rerender anytime session changes
-    const session = useSession({suspense: false})
+    useSession({suspense: false})
 
     useAuthorizeIf(Page.authenticate === true)
 
     if (typeof window !== "undefined") {
-      // We read directly from publicDataStore.getData().userId instead of useSession
+      const publicData = publicDataStore.getData()
+      // We read directly from publicData.userId instead of useSession
       // so we can access userId on first render. useSession is always empty on first render
-      if (publicDataStore.getData().userId) {
+      if (publicData.userId) {
         clientDebug("[BlitzInnerRoot] logged in")
         let {redirectAuthenticatedTo} = Page
         if (typeof redirectAuthenticatedTo === "function") {
-          if (session.isLoading) {
-            redirectAuthenticatedTo = undefined
-          } else {
-            redirectAuthenticatedTo = redirectAuthenticatedTo({session})
-          }
+          redirectAuthenticatedTo = redirectAuthenticatedTo({session: publicData})
         }
         if (redirectAuthenticatedTo && typeof redirectAuthenticatedTo !== "string") {
           redirectAuthenticatedTo = formatWithValidation(redirectAuthenticatedTo)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,7 +9,7 @@ import {
   NextPageContext,
 } from "next/types"
 import type {UrlObject} from "url"
-import {ClientSession, EmptyPublicData} from "./auth/auth-types"
+import {ClientSession} from "./auth/auth-types"
 import {BlitzRuntimeData} from "./blitz-data"
 
 export type {BlitzConfig} from "@blitzjs/config"
@@ -40,7 +40,6 @@ export interface AppProps<P = {}> extends NextAppProps<P> {
 }
 
 export type RedirectAuthenticatedToFnCtx = {
-  publicData: EmptyPublicData
   session: ClientSession
 }
 export type RedirectAuthenticatedToFn = (

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,6 +9,7 @@ import {
   NextPageContext,
 } from "next/types"
 import type {UrlObject} from "url"
+import {ClientSession, EmptyPublicData} from "./auth/auth-types"
 import {BlitzRuntimeData} from "./blitz-data"
 
 export type {BlitzConfig} from "@blitzjs/config"
@@ -37,11 +38,20 @@ export type BlitzComponentType<C = NextPageContext, IP = {}, P = {}> = NextCompo
 export interface AppProps<P = {}> extends NextAppProps<P> {
   Component: BlitzComponentType<NextPageContext, any, P> & BlitzPage
 }
+
+export type RedirectAuthenticatedToFnCtx = {
+  publicData: EmptyPublicData
+  session: ClientSession
+}
+export type RedirectAuthenticatedToFn = (
+  args: RedirectAuthenticatedToFnCtx,
+) => string | RouteUrlObject
+
 export type BlitzPage<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (component: JSX.Element) => JSX.Element
   authenticate?: boolean | {redirectTo?: string | RouteUrlObject}
   suppressFirstRenderFlicker?: boolean
-  redirectAuthenticatedTo?: string | RouteUrlObject
+  redirectAuthenticatedTo?: string | RouteUrlObject | RedirectAuthenticatedToFn
 }
 
 export interface RouteUrlObject extends Pick<UrlObject, "pathname" | "query"> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,7 +9,7 @@ import {
   NextPageContext,
 } from "next/types"
 import type {UrlObject} from "url"
-import {ClientSession} from "./auth/auth-types"
+import {PublicData} from "./auth/auth-types"
 import {BlitzRuntimeData} from "./blitz-data"
 
 export type {BlitzConfig} from "@blitzjs/config"
@@ -39,18 +39,19 @@ export interface AppProps<P = {}> extends NextAppProps<P> {
   Component: BlitzComponentType<NextPageContext, any, P> & BlitzPage
 }
 
+export type RedirectAuthenticatedTo = string | RouteUrlObject | false
 export type RedirectAuthenticatedToFnCtx = {
-  session: ClientSession
+  session: PublicData
 }
 export type RedirectAuthenticatedToFn = (
   args: RedirectAuthenticatedToFnCtx,
-) => string | RouteUrlObject
+) => RedirectAuthenticatedTo
 
 export type BlitzPage<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (component: JSX.Element) => JSX.Element
   authenticate?: boolean | {redirectTo?: string | RouteUrlObject}
   suppressFirstRenderFlicker?: boolean
-  redirectAuthenticatedTo?: string | RouteUrlObject | RedirectAuthenticatedToFn
+  redirectAuthenticatedTo?: RedirectAuthenticatedTo | RedirectAuthenticatedToFn
 }
 
 export interface RouteUrlObject extends Pick<UrlObject, "pathname" | "query"> {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Hello ^-^
This PR closes #2575
redirectAuthenticatedTo can now be also a function. It accepts a context, which includes
```typescript
type RedirectAuthenticatedToFnCtx = {
  publicData: EmptyPublicData
  session: ClientSession
}
```
i added a publicData because in my use case i need access to some user metadata on the first render, when session is empty.

### What are the changes and their implications?

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [x] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
