### PR TITLE
Fix indentation of json on `blitz generate` edit pages

### DIFF
--- a/packages/generator/templates/page/__modelIdParam__/edit.tsx
+++ b/packages/generator/templates/page/__modelIdParam__/edit.tsx
@@ -29,7 +29,7 @@ export const Edit__ModelName__ = () => {
 
       <div>
         <h1>Edit __ModelName__ {__modelName__.id}</h1>
-        <pre>{JSON.stringify(__modelName__)}</pre>
+        <pre>{JSON.stringify(__modelName__, null, 2)}</pre>
 
         <__ModelName__Form
           submitText="Update __ModelName__"


### PR DESCRIPTION
Currently, the generated Edit pages show one large line of json instead of indented json [as done on this line](https://github.com/blitz-js/blitz/blob/canary/packages/generator/templates/page/__modelIdParam__.tsx#L24). 

This PR makes the generated Edit pages look identical to the View pages.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->
