### PR TITLE
Fix RedirectError incorrectly failing Cypress tests

### DIFF
--- a/nextjs/packages/next/client/index.tsx
+++ b/nextjs/packages/next/client/index.tsx
@@ -116,6 +116,27 @@ if (process.env.NODE_ENV === 'development') {
     }
   }
   window.addEventListener('error', onUnhandledError)
+
+  if ('Cypress' in window) {
+    // Hide some errors from Cypress, so they don't fail Cypress tests
+    // https://github.com/cypress-io/cypress/issues/7196
+
+    const cypressOnErrorFun = window.onerror
+
+    window.onerror = (message, source, lineno, colno, err) => {
+      if (
+        cypressOnErrorFun &&
+        !(
+          err instanceof RedirectError ||
+          err instanceof AuthenticationError ||
+          err instanceof AuthorizationError ||
+          err instanceof NotFoundError
+        )
+      ) {
+        cypressOnErrorFun(message, source, lineno, colno, err)
+      }
+    }
+  }
 }
 
 if (process.env.__NEXT_I18N_SUPPORT) {


### PR DESCRIPTION
Closes #2633

### What are the changes and their implications?

In development, if Cypress is detected, the following errors will be hidden from Cypress, so they don't fail E2E tests: RedirectError, AuthenticationError, AuthorizationError, NotFoundError. For all other errors, the Cypress behavior is preserved.

## Bug Checklist

This can only be tested with Cypress (test if Cypress fails a test that, e.g., logs in to an app). The `auth` example app has a Cypress test that covers the RedirectError. Not sure how to proceed here. What do you think?
