### PR TITLE
Fix serialization of RedirectError

### DIFF
--- a/nextjs/packages/next/stdlib/errors.ts
+++ b/nextjs/packages/next/stdlib/errors.ts
@@ -98,7 +98,7 @@ export class RedirectError extends Error {
   }
 }
 if (process.env.JEST_WORKER_ID === undefined) {
-  SuperJson.registerClass(NotFoundError, {
+  SuperJson.registerClass(RedirectError, {
     identifier: 'BlitzRedirectError',
     allowProps: errorProps,
   })


### PR DESCRIPTION
Closes: -

### What are the changes and their implications?

RedirectError is registered incorrectly with SuperJson. It is probably a copy+paste oversight. This commit fixes that. 

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

This probably doesn't require a test. If it does, please let me know and I will add one.
