### PR TITLE
Fix `<Link>` not working correctly with i18n and basepath

### DIFF
--- a/nextjs/packages/next/client/link.tsx
+++ b/nextjs/packages/next/client/link.tsx
@@ -106,7 +106,7 @@ function linkClicked(
   })
 }
 
-function Link(props: React.PropsWithChildren<LinkProps>) {
+export function Link(props: React.PropsWithChildren<LinkProps>) {
   if (process.env.NODE_ENV !== 'production') {
     function createPropError(args: {
       key: string

--- a/packages/babel-preset/src/rewrite-imports.test.ts
+++ b/packages/babel-preset/src/rewrite-imports.test.ts
@@ -16,14 +16,14 @@ pluginTester({
     {
       code: `import {Image, Link} from 'blitz';`,
       output: `
-        import { Link } from '@blitzjs/core';
+        import { Link } from 'next/link';
         import { Image } from 'next/image';
       `,
     },
     {
       code: `import {Image as BlitzImage, Link} from 'blitz';`,
       output: `
-        import { Link } from '@blitzjs/core';
+        import { Link } from 'next/link';
         import { Image as BlitzImage } from 'next/image';
       `,
     },

--- a/packages/babel-preset/src/rewrite-imports.ts
+++ b/packages/babel-preset/src/rewrite-imports.ts
@@ -8,6 +8,7 @@ import { BabelType } from 'babel-plugin-tester';
 const defaultImportSource = '@blitzjs/core';
 
 const specialImports: Record<string, string> = {
+  Link: 'next/link',
   Image: 'next/image',
   Script: 'next/script',
 

--- a/packages/blitz/src/index.ts
+++ b/packages/blitz/src/index.ts
@@ -13,8 +13,12 @@ export * from "@blitzjs/core/server"
  */
 export {default as Image} from "next/image"
 export type {ImageProps, ImageLoader, ImageLoaderProps} from "next/image"
+
+export * from "next/link"
+
 export {Script} from "next/script"
 export type {Props as ScriptProps} from "next/script"
+
 export * from "next/stdlib"
 export * from "next/stdlib-server"
 export * from "next/data-client"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,5 @@
 export * from "./types"
 export * from "./router"
-export * from "./link"
 export * from "./error"
 export * from "./error-boundary"
 export {withBlitzAppRoot} from "./blitz-app-root"

--- a/packages/core/src/link.ts
+++ b/packages/core/src/link.ts
@@ -1,7 +1,0 @@
-/*
- * IF YOU CHANGE THIS FILE
- *    You also need to update the rewrite map in
- *    packages/babel-preset/src/rewrite-imports.ts
- */
-export {default as Link} from "next/link"
-export type {LinkProps} from "next/link"


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/blitz/issues/2469
Closes: https://github.com/blitz-js/blitz/issues/2610

### What are the changes and their implications?

Fixes `<Link>` not working with i18n and with basepath.