### PR TITLE
[legacy-framework] (recipe) removed unused htmlescape import in `secureheaders` recipe

### DIFF
--- a/recipes/secureheaders/templates/core/secureheaders.ts
+++ b/recipes/secureheaders/templates/core/secureheaders.ts
@@ -1,5 +1,4 @@
 import {BlitzScript, DocumentProps} from "blitz"
-import htmlescape from "htmlescape"
 import crypto from "crypto"
 
 export const cspHashOf = (text: string) => {


### PR DESCRIPTION

Closes: N/A

### What are the changes and their implications?

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
