### PR TITLE
[legacy-framework] fix missing `BlitzScript.getInlineScriptSource` in canary release

### DIFF
--- a/nextjs/packages/next/pages/_document.tsx
+++ b/nextjs/packages/next/pages/_document.tsx
@@ -159,7 +159,7 @@ function getScripts(
  * `Document` component handles the initial `document` markup and renders only on the server side.
  * Commonly used for implementing server side rendering for `css-in-js` libraries.
  */
-export default class Document<P = {}> extends Component<DocumentProps & P> {
+export class Document<P = {}> extends Component<DocumentProps & P> {
   /**
    * `getInitialProps` hook returns the context object with the addition of `renderPage`.
    * `renderPage` callback executes `React` rendering logic synchronously to support server-rendering wrappers
@@ -199,6 +199,7 @@ export default class Document<P = {}> extends Component<DocumentProps & P> {
     )
   }
 }
+export default Document
 
 export function Html(
   props: React.DetailedHTMLProps<
@@ -499,14 +500,14 @@ export class Head extends Component<
         if (!isReactHelmet) {
           if (child?.type === 'title') {
             console.warn(
-              "Warning: <title> should not be used in _document.js's <Head>. https://nextjs.org/docs/messages/no-document-title"
+              "Warning: <title> should not be used in _document.js's <DocumentHead>. https://nextjs.org/docs/messages/no-document-title"
             )
           } else if (
             child?.type === 'meta' &&
             child?.props?.name === 'viewport'
           ) {
             console.warn(
-              "Warning: viewport meta tags should not be used in _document.js's <Head>. https://nextjs.org/docs/messages/no-document-viewport-meta"
+              "Warning: viewport meta tags should not be used in _document.js's <DocumentHead>. https://nextjs.org/docs/messages/no-document-viewport-meta"
             )
           }
         }
@@ -514,7 +515,7 @@ export class Head extends Component<
       })
       if (this.props.crossOrigin)
         console.warn(
-          'Warning: `Head` attribute `crossOrigin` is deprecated. https://nextjs.org/docs/messages/doc-crossorigin-deprecated'
+          'Warning: `DocumentHead` attribute `crossOrigin` is deprecated. https://nextjs.org/docs/messages/doc-crossorigin-deprecated'
         )
     }
 
@@ -736,6 +737,7 @@ export class Head extends Component<
     )
   }
 }
+export class DocumentHead extends Head {}
 
 export function Main() {
   const { inAmpMode, html, docComponentsRendered } = useContext(
@@ -900,6 +902,7 @@ export class NextScript extends Component<OriginProps> {
     )
   }
 }
+export class BlitzScript extends NextScript {}
 
 function getAmpPath(ampPath: string, asPath: string): string {
   return ampPath || `${asPath}${asPath.includes('?') ? '&' : '?'}amp=1`

--- a/nextjs/test/integration/document-head-warnings/test/index.test.js
+++ b/nextjs/test/integration/document-head-warnings/test/index.test.js
@@ -24,19 +24,19 @@ describe('Custom Document Head Warnings', () => {
   describe('development mode', () => {
     it('warns when using a <title> in document/head', () => {
       expect(output).toMatch(
-        /.*Warning: <title> should not be used in _document.js's <Head>\..*/
+        /.*Warning: <title> should not be used in _document.js's <DocumentHead>\..*/
       )
     })
 
     it('warns when using viewport meta tags in document/head', () => {
       expect(output).toMatch(
-        /.*Warning: viewport meta tags should not be used in _document.js's <Head>\..*/
+        /.*Warning: viewport meta tags should not be used in _document.js's <DocumentHead>\..*/
       )
     })
 
     it('warns when using a crossOrigin attribute on document/head', () => {
       expect(output).toMatch(
-        /.*Warning: `Head` attribute `crossOrigin` is deprecated\..*/
+        /.*Warning: `DocumentHead` attribute `crossOrigin` is deprecated\..*/
       )
     })
   })

--- a/packages/babel-preset/src/rewrite-imports.test.ts
+++ b/packages/babel-preset/src/rewrite-imports.test.ts
@@ -30,11 +30,11 @@ pluginTester({
     {
       code: `import {Document, Html, DocumentHead, Main, BlitzScript} from "blitz";`,
       output: `
-        import { BlitzScript } from '@blitzjs/core/document';
-        import { Main } from '@blitzjs/core/document';
-        import { DocumentHead } from '@blitzjs/core/document';
-        import { Html } from '@blitzjs/core/document';
-        import { Document } from '@blitzjs/core/document';
+        import { BlitzScript } from 'next/document';
+        import { Main } from 'next/document';
+        import { DocumentHead } from 'next/document';
+        import { Html } from 'next/document';
+        import { Document } from 'next/document';
       `,
     },
   ],

--- a/packages/babel-preset/src/rewrite-imports.ts
+++ b/packages/babel-preset/src/rewrite-imports.ts
@@ -12,6 +12,12 @@ const specialImports: Record<string, string> = {
   Image: 'next/image',
   Script: 'next/script',
 
+  Document: 'next/document',
+  DocumentHead: 'next/document',
+  Html: 'next/document',
+  Main: 'next/document',
+  BlitzScript: 'next/document',
+
   AuthenticationError: 'next/stdlib',
   AuthorizationError: 'next/stdlib',
   CSRFTokenMismatchError: 'next/stdlib',
@@ -58,12 +64,6 @@ const specialImports: Record<string, string> = {
 
   getConfig: '@blitzjs/core/config',
   setConfig: '@blitzjs/core/config',
-
-  Document: '@blitzjs/core/document',
-  DocumentHead: '@blitzjs/core/document',
-  Html: '@blitzjs/core/document',
-  Main: '@blitzjs/core/document',
-  BlitzScript: '@blitzjs/core/document',
 
   resolver: '@blitzjs/core/server',
 };

--- a/packages/blitz/src/index.ts
+++ b/packages/blitz/src/index.ts
@@ -1,6 +1,5 @@
 export * from "@blitzjs/core/app"
 export * from "@blitzjs/core/config"
-export * from "@blitzjs/core/document"
 export * from "@blitzjs/core/dynamic"
 export * from "@blitzjs/core/head"
 export * from "@blitzjs/core"
@@ -15,6 +14,8 @@ export {default as Image} from "next/image"
 export type {ImageProps, ImageLoader, ImageLoaderProps} from "next/image"
 
 export * from "next/link"
+export {Document, DocumentHead, Html, Main, BlitzScript} from "next/document"
+export type {DocumentProps, DocumentContext, DocumentInitialProps} from "next/document"
 
 export {Script} from "next/script"
 export type {Props as ScriptProps} from "next/script"

--- a/packages/core/document/package.json
+++ b/packages/core/document/package.json
@@ -1,5 +1,0 @@
-{
-  "main": "dist/blitzjs-core-document.cjs.js",
-  "module": "dist/blitzjs-core-document.esm.js",
-  "types": "dist/blitzjs-core-document.cjs.d.ts"
-}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,6 @@
     "entrypoints": [
       "app.ts",
       "config.ts",
-      "document.ts",
       "dynamic.ts",
       "head.ts",
       "index.ts",
@@ -25,7 +24,6 @@
     "dist",
     "app",
     "config",
-    "document",
     "dynamic",
     "head",
     "server"

--- a/packages/core/src/blitz-script.tsx
+++ b/packages/core/src/blitz-script.tsx
@@ -1,8 +1,0 @@
-import {NextScript} from "next/document"
-import React, {ComponentPropsWithoutRef} from "react"
-
-export type BlitzScriptProps = ComponentPropsWithoutRef<typeof NextScript>
-
-export function BlitzScript(props: BlitzScriptProps) {
-  return <NextScript {...props} />
-}

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -1,8 +1,0 @@
-/*
- * IF YOU CHANGE THIS FILE
- *    You also need to update the rewrite map in
- *    packages/babel-preset/src/rewrite-imports.ts
- */
-export {default as Document, Head as DocumentHead, Html, Main} from "next/document"
-export type {DocumentProps, DocumentContext, DocumentInitialProps} from "next/document"
-export {BlitzScript} from "./blitz-script"


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/legacy-framework/issues/319

### What are the changes and their implications?

Fix missing `BlitzScript.getInlineScriptSource` in canary release