### PR TITLE
[legacy-framework] fix route manifest for mdx pages

### DIFF
--- a/nextjs/test/integration/plugin-mdx/pages/docs/two-words.mdx
+++ b/nextjs/test/integration/plugin-mdx/pages/docs/two-words.mdx
@@ -1,0 +1,7 @@
+import Button from '../components/button.js'
+
+# MDX + Next.js
+
+Two word slug
+
+<Button>👋 Hello</Button>

--- a/nextjs/test/integration/plugin-mdx/test/index.test.js
+++ b/nextjs/test/integration/plugin-mdx/test/index.test.js
@@ -25,5 +25,14 @@ describe('Configuration', () => {
         /Look, a button!/
       )
     })
+
+    it('should generate correct route manifest', async () => {
+      const { Routes } = require('.blitz')
+      expect(Object.keys(Routes)).toStrictEqual([
+        'Button',
+        'DocsTwoWords',
+        'Index',
+      ])
+    })
   })
 })


### PR DESCRIPTION


### What are the changes and their implications?

Fix a bug where mdx files caused the route manifest generation to fail the build. 

Now the route manifest for mdx files is a PascalCase version of the route path instead of trying to parse a default export name.
```
mdx routes:
/               -> Routes.Index()
/home           -> Routes.Home()
/docs/two-words -> Routes.DocsTwoWords()
```

## Bug Checklist

- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

