### PR TITLE
update react-query to 3.21.1 (and fix an infinite loop bug)

### DIFF
--- a/nextjs/packages/next/package.json
+++ b/nextjs/packages/next/package.json
@@ -119,7 +119,7 @@
     "querystring-es3": "0.2.1",
     "raw-body": "2.4.1",
     "react-is": "17.0.2",
-    "react-query": "3.16.0",
+    "react-query": "3.21.1",
     "react-refresh": "0.8.3",
     "resolve-from": "^5.0.0",
     "secure-password": "4.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,6 @@
     "lodash.frompairs": "4.0.1",
     "next": "0.40.0-canary.7",
     "npm-which": "^3.0.1",
-    "react-query": "3.16.0",
     "superjson": "1.7.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19598,6 +19598,15 @@ react-query@3.16.0:
     broadcast-channel "^3.4.1"
     match-sorter "^6.0.2"
 
+react-query@3.21.1:
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.21.1.tgz#8fe4df90bf6c6a93e0552ea9baff211d1b28f6e0"
+  integrity sha512-aKFLfNJc/m21JBXJk7sR9tDUYPjotWA4EHAKvbZ++GgxaY+eI0tqBxXmGBuJo0Pisis1W4pZWlZgoRv9yE8yjA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-reconciler@^0.24.0:
   version "0.24.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.24.0.tgz#5a396b2c2f5efe8554134a5935f49f546723f2dd"


### PR DESCRIPTION

### What are the changes and their implications?

update react-query to 3.21.1

Closes: https://github.com/blitz-js/blitz/issues/2538
