### PR TITLE
Fix internal middleware to use `forwarded` header to set protocol

### DIFF
--- a/nextjs/packages/next/stdlib-server/middleware.ts
+++ b/nextjs/packages/next/stdlib-server/middleware.ts
@@ -150,7 +150,9 @@ function getProtocol(req: MiddlewareRequest) {
     return 'https'
   }
   const forwardedProto =
-    req.headers && (req.headers['x-forwarded-proto'] as string)
+    req.headers &&
+    ((req.headers['forwarded'] as string)?.match(/(?<=proto=).+/g)?.[0] ||
+      (req.headers['x-forwarded-proto'] as string))
   if (forwardedProto) {
     return forwardedProto.split(/\s*,\s*/)[0]
   }

--- a/nextjs/test/unit/middleware.unit.test.ts
+++ b/nextjs/test/unit/middleware.unit.test.ts
@@ -33,6 +33,24 @@ describe('secure proxy middleware', () => {
     method: 'GET',
     url: '/stuff?q=thing',
   }
+  // @ts-ignore
+  let reqForwardSecure: Request = {
+    connection: new Socket(),
+    method: 'GET',
+    url: '/stuff?q=thing',
+    headers: {
+      forwarded: 'by=unknown;for=unknown;host=localhost;proto=https',
+    },
+  }
+  // @ts-ignore
+  let reqForwardHttp: Request = {
+    connection: new Socket(),
+    method: 'GET',
+    url: '/stuff?q=thing',
+    headers: {
+      forwarded: 'by=unknown;for=unknown;host=localhost;proto=http',
+    },
+  }
 
   const res = {}
   it('should set https protocol if X-Forwarded-Proto is https', () => {
@@ -41,16 +59,28 @@ describe('secure proxy middleware', () => {
     expect(reqSecure.protocol).toEqual('https')
   })
 
-  it('should set http protocol if X-Forwarded-Proto is absent', () => {
-    // @ts-ignore
-    void secureProxyMiddleware(reqNoHeader, res, () => null)
-    expect(reqNoHeader.protocol).toEqual('http')
-  })
-
   it('should set http protocol if X-Forwarded-Proto is http', () => {
     // @ts-ignore
     void secureProxyMiddleware(reqHttp, res, () => null)
     expect(reqHttp.protocol).toEqual('http')
+  })
+
+  it('should set https protocol if Forwarded is proto=https', () => {
+    // @ts-ignore
+    void secureProxyMiddleware(reqForwardSecure, res, () => null)
+    expect(reqForwardSecure.protocol).toEqual('https')
+  })
+
+  it('should set http protocol if Forwarded is proto=http', () => {
+    // @ts-ignore
+    void secureProxyMiddleware(reqForwardHttp, res, () => null)
+    expect(reqForwardHttp.protocol).toEqual('http')
+  })
+
+  it('should set http protocol if X-Forwarded-Proto and Forwarded are absent', () => {
+    // @ts-ignore
+    void secureProxyMiddleware(reqNoHeader, res, () => null)
+    expect(reqNoHeader.protocol).toEqual('http')
   })
 })
 


### PR DESCRIPTION
Would close #966, but already closed.

### What are the changes and their implications?
The middleware now takes the protocol from the more standard [`Forwarded`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded) header.
I've also added 2 unit tests. 

## Feature Checklist

- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed): N/A (unit test added)
- [x] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com)): blitz-js/blitzjs.com#547

