### PR TITLE
Fix blitz app dir

### DIFF
--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -158,6 +158,7 @@ export abstract class Generator<
         ? fs.existsSync(path.resolve("tsconfig.json"))
         : this.options.useTs
     if (!this.options.destinationRoot) this.options.destinationRoot = process.cwd()
+    process.env.BLITZ_APP_DIR = this.options.destinationRoot
   }
 
   abstract getTemplateValues(): Promise<any>

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -158,7 +158,7 @@ export abstract class Generator<
         ? fs.existsSync(path.resolve("tsconfig.json"))
         : this.options.useTs
     if (!this.options.destinationRoot) this.options.destinationRoot = process.cwd()
-    process.env.BLITZ_APP_DIR = this.options.destinationRoot
+    process.env.BLITZ_APP_DIR = process.cwd()
   }
 
   abstract getTemplateValues(): Promise<any>


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #2727 

### What are the changes and their implications?

Sets the BLITZ_APP_DIR env variable to process.cwd() to prevent `loadConfigProduction` from throwing an error.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
// TODO