### PR TITLE
update "Read the Documentation" link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 <h1 align="center">The Fullstack React Framework</h1>
 
 <h5 align="center">"Zero-API" Data Layer — Built on Next.js — Inspired by Ruby on Rails</h3>
-<h3 align="center"><a href="https://blitzjs.com" target="_blank">Read the Documentation</a></h3>
+<h3 align="center"><a href="https://blitzjs.com/docs/get-started" target="_blank">Read the Documentation</a></h3>
 <br>
 
 “Zero-API” data layer **lets you import server code directly into your React components** instead of having to manually add API endpoints and do client-side fetching and caching.


### PR DESCRIPTION
Closes: N/A

### What are the changes and their implications?

The logo and other links are already pointing to blitzjs.com, so "Read the Doc" should point to the doc.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
