### PR TITLE
Fix Internal Blitz Error: process.env.BLITZ_APP_DIR is not set (in canary release)

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -213,6 +213,8 @@ export class Generate extends Command {
     debug("args: ", args)
     debug("flags: ", flags)
 
+    process.env.BLITZ_APP_DIR = process.cwd()
+
     try {
       const {model, context} = this.getModelNameAndContext(args.model, flags.context)
       const singularRootContext = modelName(model)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/blitz/issues/2727

### What are the changes and their implications?

Fix Internal Blitz Error: process.env.BLITZ_APP_DIR is not set
