### PR TITLE
add project language prompt for `blitz new` command

### DIFF
--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -247,8 +247,7 @@ export class New extends Command {
   }
 
   private async determineLanguage(flags: Flags): Promise<void> {
-    const isJavaScriptSpecified = flags.js
-    if (isJavaScriptSpecified) {
+    if (flags.js) {
       this.useTs = false
     } else {
       const {language} = (await this.enquirer.prompt({


### PR DESCRIPTION
Added a language prompt (TypeScript or JavaScript) for the `blitz new` command. 
TS is the default option, and it's still possible to pass the `--js` flag (it won't show the prompt is a user passed this flag).

### What are the changes and their implications?

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
