### PR TITLE
Fix redirectAuthenticatedTo does not call queries when redirecting fr…

### DIFF
--- a/packages/core/src/blitz-app-root.tsx
+++ b/packages/core/src/blitz-app-root.tsx
@@ -6,6 +6,7 @@ import {AppProps, BlitzPage} from "next/types"
 import React, {ComponentPropsWithoutRef, useEffect} from "react"
 import SuperJSON from "superjson"
 import {Head} from "./head"
+import {useRouter} from "./router"
 import {clientDebug} from "./utils"
 
 const customCSS = `
@@ -44,12 +45,13 @@ const NoPageFlicker = () => {
 
 export function withBlitzInnerWrapper(Page: BlitzPage) {
   const BlitzInnerRoot = (props: ComponentPropsWithoutRef<BlitzPage>) => {
+    const isRouterReady = useRouter().isReady
     // We call useSession so this will rerender anytime session changes
     useSession({suspense: false})
 
     useAuthorizeIf(Page.authenticate === true)
 
-    if (typeof window !== "undefined") {
+    if (typeof window !== "undefined" && isRouterReady) {
       const publicData = getPublicDataStore().getData()
       // We read directly from publicData.userId instead of useSession
       // so we can access userId on first render. useSession is always empty on first render


### PR DESCRIPTION
…om a dynamic route

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #2527, #2636 

The evil raises [here](https://github.com/blitz-js/blitz/blob/canary/nextjs/packages/next/data-client/react-query.tsx#L129). react-query throws a promise... and that's the end of the story. all because the router isReady state is forever false, since the moment of redirect...
on [this line](https://github.com/blitz-js/blitz/blob/canary/nextjs/packages/next/shared/lib/router/router.ts#L649) next seeds the initial isReady state of the router. there are many flags that i don't understand, but autoExportDynamic looked like our patient. 
[this](https://github.com/blitz-js/blitz/blob/canary/nextjs/packages/next/shared/lib/router/router.ts#L839) is the only place where isReady can potentially become true later(as far as i understand). 
[here](https://github.com/blitz-js/blitz/blob/canary/nextjs/packages/next/client/index.tsx#L221) next container could possibly set isReady to true, but only if isSsr prop of the router was true on componentDidMount. the problem is - when redirect happens before this hook,  isSsr becomes false on didMount, so [this one](https://github.com/blitz-js/blitz/blob/canary/nextjs/packages/next/client/index.tsx#L245) never gets called...

[the first solution](https://github.com/blitz-js/blitz/compare/canary...s-r-x:canary#diff-543a24f6b2c2a2b3a5be806641dfbd3699f73409da4cb56551bb59b4abcb3a45) is a bit hacky. i'm not quite familiar with next.js internals so here may be some edge cases that i don't know about.
[the second one](https://github.com/blitz-js/blitz/compare/canary...s-r-x:canary#diff-f2e285ca72ba6ef0d8da9f6e7928f79da842b7296f1d20b5a3c8f33f3a5cde10) is a clean one, and also fixes server/client markup mismatch error on redirects. the downside is that the user will see the initial page for a moment, but i guess it can be fixed in the same manner as suppressFirstRenderFlicker... and also additional rerenders on router state change


### What are the changes and their implications?

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
