### PR TITLE
Fix CSRFTokenMismatchError on logout

### DIFF
--- a/nextjs/packages/next/stdlib-server/auth-sessions.ts
+++ b/nextjs/packages/next/stdlib-server/auth-sessions.ts
@@ -347,18 +347,13 @@ export class SessionContextClass implements SessionContext {
     })
   }
 
-  $revoke() {
-    return revokeSession(this._req, this._res, this.$handle)
+  async $revoke() {
+    this._kernel = await revokeSession(this._req, this._res, this.$handle)
   }
 
   async $revokeAll() {
-    if (!this.$publicData.userId) {
-      throw new Error(
-        'session.revokeAll() cannot be used with anonymous sessions'
-      )
-    }
     // revoke the current session which uses req/res
-    await revokeSession(this._req, this._res, this.$handle)
+    await this.$revoke()
     // revoke other sessions for which there is no req/res object
     await revokeAllSessionsForUser(this.$publicData.userId)
     return
@@ -1063,7 +1058,7 @@ async function revokeSession(
   res: ServerResponse,
   handle: string,
   anonymous: boolean = false
-): Promise<void> {
+) {
   debug('Revoking session', handle)
   if (!anonymous) {
     try {
@@ -1075,10 +1070,11 @@ async function revokeSession(
   // This is used on the frontend to clear localstorage
   setHeader(res, HEADER_SESSION_REVOKED, 'true')
 
-  // Clear all cookies
-  setSessionCookie(req, res, '', new Date(0))
-  setAnonymousSessionCookie(req, res, '', new Date(0))
-  setCSRFCookie(req, res, '', new Date(0))
+  // Go ahead and create a new anon session. This
+  // This fixes race condition where all client side queries get refreshed
+  // in parallel and each creates a new anon session
+  // https://github.com/blitz-js/blitz/issues/2746
+  return createAnonymousSession(req, res)
 }
 
 async function revokeAllSessionsForUser(userId: PublicData['userId']) {
@@ -1088,7 +1084,11 @@ async function revokeAllSessionsForUser(userId: PublicData['userId']) {
 
   let revoked: string[] = []
   for (const handle of sessionHandles) {
-    await global.sessionConfig.deleteSession(handle)
+    try {
+      await global.sessionConfig.deleteSession(handle)
+    } catch (error) {
+      // Ignore any errors, like if session doesn't exist in DB
+    }
     revoked.push(handle)
   }
   return revoked


### PR DESCRIPTION

Closes: https://github.com/blitz-js/blitz/issues/2746

### What are the changes and their implications?

Fix CSRFTokenMismatchError on logout

We now create a new anonymous session on logout, which prevents race conditions when queries refresh right after logout. So end result is the same, but now one anon session is created ahead of time.