### PR TITLE
jest-preset: handle static assets for next/image

### DIFF
--- a/packages/blitz/jest-preset.js
+++ b/packages/blitz/jest-preset.js
@@ -32,10 +32,11 @@ const common = {
       (tsConfig && tsConfig.compilerOptions && tsConfig.compilerOptions.paths) || {},
     ),
     "\\.(css|less|sass|scss)$": path.resolve(__dirname, "./jest-preset/identity-obj-proxy.js"),
-    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": path.resolve(
+    "\\.(eot|otf|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": path.resolve(
       __dirname,
       "./jest-preset/file-mock.js",
     ),
+    "\\.(jpg|jpeg|png|gif|webp|ico)$": path.resolve(__dirname, "./jest-preset/image-mock.js"),
   },
   watchPlugins: ["jest-watch-typeahead/filename", "jest-watch-typeahead/testname"],
   // Coverage output

--- a/packages/blitz/jest-preset/mock-image.js
+++ b/packages/blitz/jest-preset/mock-image.js
@@ -1,0 +1,5 @@
+module.exports = {
+  src: "/public/test.png",
+  width: 100,
+  height: 100,
+}


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/2758

### What are the changes and their implications?

Previously, when unit testing a component that uses `next/image`, we'd get an error that mocked `test-file-stub` string is not a valid argument — we were handing all types of static assets by replacing the import with `test-file-stub`. This PR handles files with extensions supported by `next/image` differently. Though, it's still possible to do manual mocks, and/or test real images. More context in the issue. 

Open for feedback and alternative solutions.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
