### PR TITLE
passportAuth — improve error message if req.query.auth is undefined

### DIFF
--- a/nextjs/packages/next/stdlib-server/passport-adapter.ts
+++ b/nextjs/packages/next/stdlib-server/passport-adapter.ts
@@ -101,6 +101,15 @@ export function passportAuth(config: BlitzPassportConfig): NextApiHandler {
       middleware.push(secureProxyMiddleware)
     }
 
+    assert(
+      req.query.auth,
+      'req.query.auth is not defined. Page must be named [...auth].ts/js. See more at https://blitzjs.com/docs/passportjs#1-add-the-passport-js-api-route'
+    )
+    assert(
+      Array.isArray(req.query.auth),
+      'req.query.auth must be an array. Page must be named [...auth].ts/js. See more at https://blitzjs.com/docs/passportjs#1-add-the-passport-js-api-route'
+    )
+
     if (!req.query.auth.length) {
       return res.status(404).end()
     }


### PR DESCRIPTION
Issue: #2717 
### What are the changes and their implications?

Added error messages if `req.query.auth` is undefined or it is not an array.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
