### PR TITLE
Fix Yarn Berry gitignore for new apps

### DIFF
--- a/packages/generator/templates/app/.prettierignore
+++ b/packages/generator/templates/app/.prettierignore
@@ -5,3 +5,5 @@
 db/migrations
 .next
 .blitz
+.yarn
+.pnp*

--- a/packages/generator/templates/app/gitignore
+++ b/packages/generator/templates/app/gitignore
@@ -1,8 +1,11 @@
 # dependencies
 node_modules
-.yarn/cache
-.yarn/unplugged
-.yarn/build-state.yml
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
 .pnp.*
 .npm
 web_modules/


### PR DESCRIPTION
Now, it commits, for example, `install-state.gz`. This gitignore was taken from the [Yarn berry documentation](https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored).

Also, Prettier will ignore `.pnp*` and the Yarn folder
