### PR TITLE
Fix ssr with auth pages failing on Vercel on canary release

### DIFF
--- a/nextjs/packages/next/build/webpack/loaders/next-serverless-loader/page-handler.ts
+++ b/nextjs/packages/next/build/webpack/loaders/next-serverless-loader/page-handler.ts
@@ -12,6 +12,7 @@ import { getRedirectStatus } from '../../../../lib/load-custom-routes'
 import getRouteNoAssetPath from '../../../../shared/lib/router/utils/get-route-from-asset-path'
 import { PERMANENT_REDIRECT_STATUS } from '../../../../shared/lib/constants'
 import { resultToChunks } from '../../../../server/utils'
+import { loadConfigAtRuntime } from '../../../../server/config-shared'
 
 export function getPageHandler(ctx: ServerlessHandlerCtx) {
   const {
@@ -55,6 +56,9 @@ export function getPageHandler(ctx: ServerlessHandlerCtx) {
     normalizeDynamicRouteParams,
     normalizeVercelUrl,
   } = getUtils(ctx)
+
+  // Required for session middleware https://github.com/blitz-js/blitz/issues/2772
+  loadConfigAtRuntime()
 
   async function renderReqToHTML(
     req: IncomingMessage,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/blitz/issues/2772

### What are the changes and their implications?

Fix ssr with auth pages failing on Vercel on canary release
