### PR TITLE
display an error if loading a module fails in blitz console

### DIFF
--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@blitzjs/config": "0.40.0",
+    "@blitzjs/display": "0.40.0",
     "chokidar": "3.5.1",
     "globby": "11.0.2",
     "pkg-dir": "^5.0.0",

--- a/packages/repl/src/utils/load-blitz.ts
+++ b/packages/repl/src/utils/load-blitz.ts
@@ -55,7 +55,7 @@ export const loadBlitz = async () => {
           [name]: contextObj,
         }
       } catch (error) {
-        log.error(`Failed loading ${modulePath}: ${error}`)
+        log.error(`Failed to load ${modulePath}: ${error}`)
         debug("Failed to load module", error)
         return {}
       }

--- a/packages/repl/src/utils/load-blitz.ts
+++ b/packages/repl/src/utils/load-blitz.ts
@@ -1,4 +1,5 @@
 import {getProjectRoot} from "@blitzjs/config"
+import {log} from "@blitzjs/display"
 import globby from "globby"
 import path from "path"
 import ProgressBar from "progress"
@@ -54,6 +55,7 @@ export const loadBlitz = async () => {
           [name]: contextObj,
         }
       } catch (error) {
+        log.error(`Failed loading ${modulePath}: ${error}`)
         debug("Failed to load module", error)
         return {}
       }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #2751 

### What are the changes and their implications?

I decided to simply log the error that appears at the loading of the module.
I initially thought about a verbose mode, but I finally think this error should always be displayed.
If expert users need more details they can still enable additional logging using the DEBUG env var.

I'll check if there is some documentation about the DEBUG scopes, if not I'll be glad to create it.

Edit : I created it here : https://github.com/blitz-js/blitzjs.com/pull/560

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
