### PR TITLE
Replace spinner 2793

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "@types/get-port": "4.2.0",
     "@types/gulp-if": "0.0.33",
     "@types/htmlescape": "^1.1.1",
-    "@types/ink-spinner": "3.0.0",
     "@types/jest": "26.0.20",
     "@types/jsonwebtoken": "8.5.0",
     "@types/lodash": "4.14.149",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -42,7 +42,6 @@
     "fs-extra": "^9.1.0",
     "globby": "11.0.2",
     "ink": "3.0.8",
-    "ink-spinner": "4.0.1",
     "ink-testing-library": "2.1.0",
     "jscodeshift": "0.11.0",
     "recast": "0.20.4"

--- a/packages/installer/src/executors/add-dependency-executor.tsx
+++ b/packages/installer/src/executors/add-dependency-executor.tsx
@@ -1,7 +1,7 @@
+import {log} from "@blitzjs/display"
 import {spawn} from "cross-spawn"
 import * as fs from "fs-extra"
 import {Box, Text} from "ink"
-import Spinner from "ink-spinner"
 import * as path from "path"
 import * as React from "react"
 import {Newline} from "../components/newline"
@@ -27,10 +27,12 @@ export function isAddDependencyExecutor(executor: ExecutorConfig): executor is C
 export const type = "add-dependency"
 
 function Package({pkg, loading}: {pkg: NpmPackage; loading: boolean}) {
+  const spinner = log.spinner("Loading").start()
+
   return (
     <Text>
       {`   `}
-      {loading ? <Spinner /> : "📦"}
+      {loading ? spinner : "📦"}
       {` ${pkg.name}@${pkg.version}`}
     </Text>
   )

--- a/packages/installer/src/executors/file-transform-executor.tsx
+++ b/packages/installer/src/executors/file-transform-executor.tsx
@@ -1,7 +1,7 @@
+import {log} from "@blitzjs/display"
 import {createPatch} from "diff"
 import * as fs from "fs-extra"
 import {Box, Text} from "ink"
-import Spinner from "ink-spinner"
 import * as React from "react"
 import {Newline} from "../components/newline"
 import {
@@ -60,12 +60,10 @@ export const Propose: Executor["Propose"] = ({cliArgs, onProposalAccepted, step}
   if (error) throw error
 
   if (!diff) {
+    const diffSpinner = log.spinner("Generating file diff...").start()
     return (
       <Box>
-        <Text>
-          <Spinner />
-          Generating file diff...
-        </Text>
+        <Text>{diffSpinner}</Text>
       </Box>
     )
   }
@@ -115,12 +113,8 @@ export const Commit: Executor["Commit"] = ({onChangeCommitted, proposalData: fil
   }, [filePath, step])
 
   if (loading) {
-    return (
-      <Box>
-        <Spinner />
-        <Text>Applying file changes</Text>
-      </Box>
-    )
+    const loadingSpinner = log.spinner("Applying file changes").start()
+    return <Box>{loadingSpinner}</Box>
   }
 
   onChangeCommitted(`Modified file: ${filePath}`)


### PR DESCRIPTION
Closes: #2793

### What are the changes and their implications?
- Removed `ink-spinner` dependencies
- Replaced `ink-spinner` with `log.spinner` from `@blitzjs`

NOTE: I don't know how to test a recipe locally, so this hasn't been tested. I did run the test scripts however.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
