### PR TITLE
add err when model name not passed to cli generate

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -203,6 +203,13 @@ export class Generate extends Command {
       }
     }
 
+    if (modelName.includes(":")) {
+      console.warn(
+        "Model name has not been passed. Use blitz generate [type] [modelName] [field:type]...",
+      )
+      this.exit(0)
+    }
+
     return {
       model: modelName,
     }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #2800

### What are the changes and their implications?

Blitz-cli generate options will check if model name contains `:`. If it does, it will throw an error. Usually this happens when someone forget to pass model name e.g. `blitz generate all name:string`

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo](https://github.com/blitz-js/blitzjs.com))
