### PR TITLE
[legacy-framework] fix broken route manifest in 0.41.2-canary.2

### DIFF
--- a/nextjs/packages/next/build/routes.ts
+++ b/nextjs/packages/next/build/routes.ts
@@ -187,18 +187,18 @@ async function findNodeModulesRoot(src: string) {
         "Internal Blitz Error: unable to find 'blitz' package location"
       )
     }
-    const blitzCorePkgLocation = dirname(
+    const nextPkgLocation = dirname(
       (await findUp('package.json', {
         cwd: resolveFrom(blitzPkgLocation, 'next'),
       })) ?? ''
     )
-    manifestDebug('blitzCorePkgLocation ' + blitzCorePkgLocation)
-    if (!blitzCorePkgLocation) {
+    manifestDebug('nextPkgLocation ' + nextPkgLocation)
+    if (!nextPkgLocation) {
       throw new Error(
         "Internal Blitz Error: unable to find 'next' package location"
       )
     }
-    root = join(blitzCorePkgLocation, '../../')
+    root = join(nextPkgLocation, '../')
   }
   manifestDebug('root ' + root)
   return root

--- a/nextjs/packages/next/client/router.ts
+++ b/nextjs/packages/next/client/router.ts
@@ -134,6 +134,12 @@ export default singletonRouter as SingletonRouter
 // Reexport the withRoute HOC
 export { default as withRouter } from './with-router'
 
+/**
+ * `useRouter` is a React hook used to access `router` object within components
+ *
+ * @returns `router` object
+ * @see Docs {@link https://blitzjs.com/docs/router#router-object | router}
+ */
 export function useRouter(): NextRouter {
   return React.useContext(RouterContext)
 }

--- a/nextjs/packages/next/client/with-router.tsx
+++ b/nextjs/packages/next/client/with-router.tsx
@@ -11,6 +11,25 @@ export type ExcludeRouterProps<P> = Pick<
   Exclude<keyof P, keyof WithRouterProps>
 >
 
+/**
+ * `withRouter` is a higher-order component that takes a component and returns a new one
+ * with an additional `router` prop.
+ *
+ * @example
+ * ```
+ * import {withRouter} from "blitz"
+ *
+ * function Page({router}) {
+ *  return <p>{router.pathname}</p>
+ * }
+ *
+ * export default withRouter(Page)
+ * ```
+ *
+ * @param WrappedComponent - a React component that needs `router` object in props
+ * @returns A component with a `router` object in props
+ * @see Docs {@link https://blitzjs.com/docs/router#router-object | router}
+ */
 export default function withRouter<
   P extends WithRouterProps,
   C = NextPageContext


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/legacy-framework/issues/222

### What are the changes and their implications?

fix broken route manifest in 0.41.2-canary.2
