### PR TITLE
Fix `blitz generate` to preserve quotes in string defaults

### DIFF
--- a/packages/generator/src/prisma/field.ts
+++ b/packages/generator/src/prisma/field.ts
@@ -37,7 +37,7 @@ const fallbackIfUndef = <T extends any>(defaultValue: T, input?: T) => {
   return input
 }
 
-const defaultValueTest = /=([\w]+)$/
+const defaultValueTest = /=([\w"]+)$/
 const builtInGenerators = ["autoincrement", "now", "uuid", "cuid"]
 
 class MissingFieldNameError extends Error {}

--- a/packages/generator/test/prisma/field.test.ts
+++ b/packages/generator/test/prisma/field.test.ts
@@ -22,6 +22,11 @@ describe("Field", () => {
     expect(field.default).toBe("true")
   })
 
+  it("handles default string attribute with double quoted value", () => {
+    const [field] = Field.parse('name:string:default="user"')
+    expect(field.default).toBe('"user"')
+  })
+
   it("handles default uuid attribute", () => {
     const [field] = Field.parse("id:string:default=uuid")
     expect(field.default).toMatchObject({name: "uuid"})


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #2863

### What are the changes and their implications?

Added keeping quotes when generating Prisma model with a string default using `blitz generate`.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
