### PR TITLE
(newapp) On login page, pass user to the onSuccess callback

### DIFF
--- a/packages/blitz/src/index.ts
+++ b/packages/blitz/src/index.ts
@@ -77,3 +77,4 @@ export type {
   RedirectAuthenticatedToFn,
   RouteUrlObject,
 } from "next/types"
+export type {PromiseReturnType} from "next/types/utils"

--- a/packages/generator/templates/app/app/auth/components/LoginForm.tsx
+++ b/packages/generator/templates/app/app/auth/components/LoginForm.tsx
@@ -1,11 +1,11 @@
-import { AuthenticationError, Link, useMutation, Routes } from "blitz"
-import { LabeledTextField } from "app/core/components/LabeledTextField"
-import { Form, FORM_ERROR } from "app/core/components/Form"
+import {AuthenticationError, Link, useMutation, Routes, PromiseReturnType} from "blitz"
+import {LabeledTextField} from "app/core/components/LabeledTextField"
+import {Form, FORM_ERROR} from "app/core/components/Form"
 import login from "app/auth/mutations/login"
-import { Login } from "app/auth/validations"
+import {Login} from "app/auth/validations"
 
 type LoginFormProps = {
-  onSuccess?: () => void
+  onSuccess?: (user: PromiseReturnType<typeof login>) => void
 }
 
 export const LoginForm = (props: LoginFormProps) => {
@@ -18,14 +18,14 @@ export const LoginForm = (props: LoginFormProps) => {
       <Form
         submitText="Login"
         schema={Login}
-        initialValues={{ email: "", password: "" }}
+        initialValues={{email: "", password: ""}}
         onSubmit={async (values) => {
           try {
-            await loginMutation(values)
-            props.onSuccess?.()
+            const user = await loginMutation(values)
+            props.onSuccess?.(user)
           } catch (error: any) {
             if (error instanceof AuthenticationError) {
-              return { [FORM_ERROR]: "Sorry, those credentials are invalid" }
+              return {[FORM_ERROR]: "Sorry, those credentials are invalid"}
             } else {
               return {
                 [FORM_ERROR]:
@@ -44,7 +44,7 @@ export const LoginForm = (props: LoginFormProps) => {
         </div>
       </Form>
 
-      <div style={{ marginTop: "1rem" }}>
+      <div style={{marginTop: "1rem"}}>
         Or <Link href={Routes.SignupPage()}>Sign Up</Link>
       </div>
     </div>

--- a/packages/generator/templates/app/app/auth/pages/login.tsx
+++ b/packages/generator/templates/app/app/auth/pages/login.tsx
@@ -1,6 +1,6 @@
-import { useRouter, BlitzPage } from "blitz"
+import {useRouter, BlitzPage} from "blitz"
 import Layout from "app/core/layouts/Layout"
-import { LoginForm } from "app/auth/components/LoginForm"
+import {LoginForm} from "app/auth/components/LoginForm"
 
 const LoginPage: BlitzPage = () => {
   const router = useRouter()
@@ -8,7 +8,7 @@ const LoginPage: BlitzPage = () => {
   return (
     <div>
       <LoginForm
-        onSuccess={() => {
+        onSuccess={(_user) => {
           const next = router.query.next ? decodeURIComponent(router.query.next as string) : "/"
           router.push(next)
         }}


### PR DESCRIPTION


### What are the changes and their implications?

It's a somewhat common case where after login you may want to redirect the user based on their user role. Adding this to the newapp template helps show new blitz users how they could do that.
