### PR TITLE
fix build TypeError: Cannot read property 'children' of undefined

### DIFF
--- a/nextjs/packages/next/stdlib/blitz-app-root.tsx
+++ b/nextjs/packages/next/stdlib/blitz-app-root.tsx
@@ -99,8 +99,8 @@ export function getAuthValues(
           break
         }
 
-        if (currentElement.props.children) {
-          currentElement = currentElement.props.children
+        if (currentElement.props?.children) {
+          currentElement = currentElement.props?.children
         } else {
           break
         }


### PR DESCRIPTION

### What are the changes and their implications?

fix build TypeError: Cannot read property 'children' of undefined