### PR TITLE
Fix typo: "serialiazable" should be "serializable"

### DIFF
--- a/nextjs/docs/api-routes/response-helpers.md
+++ b/nextjs/docs/api-routes/response-helpers.md
@@ -23,7 +23,7 @@ export default function handler(req, res) {
 The included helpers are:
 
 - `res.status(code)` - A function to set the status code. `code` must be a valid [HTTP status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
-- `res.json(body)` - Sends a JSON response. `body` must be a [serialiazable object](https://developer.mozilla.org/en-US/docs/Glossary/Serialization)
+- `res.json(body)` - Sends a JSON response. `body` must be a [serializable object](https://developer.mozilla.org/en-US/docs/Glossary/Serialization)
 - `res.send(body)` - Sends the HTTP response. `body` can be a `string`, an `object` or a `Buffer`
 - `res.redirect([status,] path)` - Redirects to a specified path or URL. `status` must be a valid [HTTP status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes). If not specified, `status` defaults to "307" "Temporary redirect".
 


### PR DESCRIPTION
This is just a simple spelling fix: the documentation has a non-word in it, serialiazable