### PR TITLE
fix missing `BlitzConfig` type

### DIFF
--- a/nextjs/packages/next/server/config-shared.ts
+++ b/nextjs/packages/next/server/config-shared.ts
@@ -176,6 +176,8 @@ export type NextConfig = { [key: string]: any } & {
   }
 }
 
+export type BlitzConfig = NextConfig
+
 export const defaultConfig: NextConfig = {
   env: {},
   webpack: null,

--- a/nextjs/packages/next/server/config.ts
+++ b/nextjs/packages/next/server/config.ts
@@ -18,7 +18,12 @@ import { loadEnvConfig } from '@next/env'
 import { hasNextSupport } from '../telemetry/ci-info'
 const debug = require('debug')('blitz:config')
 
-export { DomainLocale, NextConfig, normalizeConfig } from './config-shared'
+export {
+  DomainLocale,
+  NextConfig,
+  BlitzConfig,
+  normalizeConfig,
+} from './config-shared'
 
 const targets = ['server', 'serverless', 'experimental-serverless-trace']
 


### PR DESCRIPTION


### What are the changes and their implications?

`BlitzConfig` was exported but the type was `any`. This fixes that.
