### PR TITLE
Fix next_stdlib__WEBPACK_IMPORTED_MODULE_1__.connectMiddleware is not a function

### DIFF
--- a/nextjs/packages/next/build/babel/plugins/rewrite-imports.ts
+++ b/nextjs/packages/next/build/babel/plugins/rewrite-imports.ts
@@ -45,6 +45,7 @@ const specialImports: Record<string, string> = {
   hash256: 'next/stdlib-server',
   generateToken: 'next/stdlib-server',
   resolver: 'next/stdlib-server',
+  connectMiddleware: 'next/stdlib-server',
 
   getAntiCSRFToken: 'next/data-client',
   useSession: 'next/data-client',


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #3015 

### What are the changes and their implications?
Added a babel import rewrite rule for connectMiddleware.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
