### PR TITLE
Fix APP_ENV loading to not load all `.env` files

### DIFF
--- a/nextjs/packages/next-env/index.ts
+++ b/nextjs/packages/next-env/index.ts
@@ -77,18 +77,21 @@ export function loadEnvConfig(
   // environment values e.g. \$ENV_FILE_KEY
   if (combinedEnv) return { combinedEnv, loadedEnvFiles: cachedLoadedEnvFiles }
 
-  const isTest = process.env.NODE_ENV === 'test'
-  const mode = isTest ? 'test' : dev ? 'development' : 'production'
-  const appEnv = process.env.APP_ENV
+  const appEnv =
+    process.env.APP_ENV ||
+    (process.env.NODE_ENV === 'test'
+      ? 'test'
+      : dev
+      ? 'development'
+      : 'production')
+
   let dotenvFiles = [
-    `.env.${mode}.local`,
-    appEnv && `.env.${appEnv}.local`,
-    appEnv && `.env.${appEnv}`,
+    `.env.${appEnv}.local`,
+    `.env.${appEnv}`,
     // Don't include `.env.local` for `test` environment
     // since normally you expect tests to produce the same
     // results for everyone
-    mode !== 'test' && `.env.local`,
-    `.env.${mode}`,
+    appEnv !== 'test' && `.env.local`,
     '.env',
   ].filter(Boolean) as string[]
 

--- a/nextjs/test/integration/env-config-app-env/test/index.test.js
+++ b/nextjs/test/integration/env-config-app-env/test/index.test.js
@@ -29,14 +29,10 @@ const getEnvFromHtml = async (path) => {
   return env
 }
 
-const runTests = (mode = 'dev') => {
-  const isDevOnly = mode === 'dev'
-
+const runTests = (mode = 'dev', appEnv) => {
   const checkEnvData = (data) => {
     expect(data.ENV_FILE_KEY).toBe('env')
-    expect(data.PRODUCTION_ENV_FILE_KEY).toBe(
-      isDevOnly ? undefined : 'production'
-    )
+    expect(data.PRODUCTION_ENV_FILE_KEY).toBe(undefined)
     expect(data.ENV_FILE_DEVELOPMENT_OVERRIDE_TEST).toEqual('staginglocal')
 
     expect(data.nextConfigEnv).toBe('hello from staging app')
@@ -86,7 +82,7 @@ describe('Env Config', () => {
     })
     afterAll(() => killApp(app))
 
-    runTests('dev')
+    runTests('dev', 'staging')
   })
 
   describe('server mode', () => {
@@ -107,7 +103,7 @@ describe('Env Config', () => {
     })
     afterAll(() => killApp(app))
 
-    runTests('server')
+    runTests('server', 'staging')
   })
 
   describe('serverless mode', () => {
@@ -158,6 +154,6 @@ describe('Env Config', () => {
       await killApp(app)
     })
 
-    runTests('serverless')
+    runTests('serverless', 'staging')
   })
 })

--- a/nextjs/test/integration/image-component/custom-resolver/test/index.test.js
+++ b/nextjs/test/integration/image-component/custom-resolver/test/index.test.js
@@ -4,7 +4,7 @@ import { join } from 'path'
 import { killApp, findPort, nextStart, nextBuild } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
-jest.setTimeout(1000 * 30)
+jest.setTimeout(1000 * 45)
 
 const appDir = join(__dirname, '../')
 let appPort

--- a/nextjs/test/integration/image-component/custom-resolver/test/index.test.js
+++ b/nextjs/test/integration/image-component/custom-resolver/test/index.test.js
@@ -4,7 +4,7 @@ import { join } from 'path'
 import { killApp, findPort, nextStart, nextBuild } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
-jest.setTimeout(1000 * 45)
+jest.setTimeout(1000 * 60)
 
 const appDir = join(__dirname, '../')
 let appPort

--- a/nextjs/test/integration/next-dynamic-css/test/index.test.js
+++ b/nextjs/test/integration/next-dynamic-css/test/index.test.js
@@ -8,6 +8,7 @@ import {
   killApp,
   nextBuild,
   nextStart,
+  waitFor,
 } from 'next-test-utils'
 
 jest.setTimeout(1000 * 60 * 2)
@@ -19,6 +20,8 @@ const appDir = join(__dirname, '../')
 function runTests() {
   it('should load page correctly', async () => {
     const browser = await webdriver(appPort, '/')
+
+    waitFor(500)
 
     expect(
       await browser

--- a/nextjs/test/integration/ssr-prepass/test/index.test.js
+++ b/nextjs/test/integration/ssr-prepass/test/index.test.js
@@ -9,7 +9,7 @@ import {
   renderViaHTTP,
 } from 'next-test-utils'
 
-jest.setTimeout(1000 * 30)
+jest.setTimeout(1000 * 60)
 
 const appDir = join(__dirname, '../')
 let appPort


### PR DESCRIPTION
### What are the changes and their implications?

Changes the behavior of `blitz --env`. Right now, if I run `blitz start --env staging` it will load both `.env.production*` and `.env.staging*`.

With these changes, only the env files declared with `--env` will be loaded. Also, now you can pass multiple environments:

``` bash
blitz start
# .env.production.local
# .env.production
# .env.local
# .env

blitz start --env staging
# .env.staging.local
# .env.staging
# .env.local
# .env

blitz start --env staging,production
# .env.staging.local
# .env.staging
# .env.production.local
# .env.production
# .env.local
# .env
```

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
