### PR TITLE
fix so that blitz config `env` config values can be type `string | undefined`

### DIFF
--- a/nextjs/packages/next/server/config-shared.ts
+++ b/nextjs/packages/next/server/config-shared.ts
@@ -89,7 +89,7 @@ export type NextConfig = { [key: string]: any } & {
   excludeDefaultMomentLocales?: boolean
 
   trailingSlash?: boolean
-  env?: { [key: string]: string }
+  env?: { [key: string]: string | undefined }
   distDir?: string
   cleanDistDir?: boolean
   assetPrefix?: string


### PR DESCRIPTION

### What are the changes and their implications?


Fix so that blitz config `env` config values can be type `string | undefined`.

Prevent things like this:

```ts
info  - Checking validity of types...
Failed to compile.

./blitz.config.ts:7:5
Type error: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.

   5 | const config: BlitzConfig = {
   6 |   env: {
>  7 |     APP_ENV: process.env.APP_ENV,
     |     ^
   8 |     STRIPE_KEY: process.env.STRIPE_KEY,
   9 |     SENTRY_DSN: process.env.SENTRY_DSN,
  10 |   },
Error: Process completed with exit code 1.
```