### PR TITLE
Remove nullish coalescing from post-install script

### DIFF
--- a/packages/blitz/scripts/postinstall.js
+++ b/packages/blitz/scripts/postinstall.js
@@ -29,7 +29,7 @@ async function findNodeModulesRoot(src) {
     const nextPkgLocation = path.dirname(
       (await findUp("package.json", {
         cwd: resolveFrom(src, "next"),
-      })) ?? "",
+      })) || "",
     )
     if (!nextPkgLocation) {
       throw new Error("Internal Blitz Error: unable to find 'next' package location")
@@ -41,7 +41,7 @@ async function findNodeModulesRoot(src) {
     const blitzPkgLocation = path.dirname(
       (await findUp("package.json", {
         cwd: resolveFrom(src, "blitz"),
-      })) ?? "",
+      })) || "",
     )
     if (!blitzPkgLocation) {
       throw new Error("Internal Blitz Error: unable to find 'blitz' package location")
@@ -49,7 +49,7 @@ async function findNodeModulesRoot(src) {
     const nextPkgLocation = path.dirname(
       (await findUp("package.json", {
         cwd: resolveFrom(blitzPkgLocation, "next"),
-      })) ?? "",
+      })) || "",
     )
     if (!nextPkgLocation) {
       throw new Error("Internal Blitz Error: unable to find 'next' package location")


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/blitz/issues/3023

### What are the changes and their implications?

`findUp` returns `undefined` or string, and we check for falsy values. Hence replacing `??` with `||`.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
