### PR TITLE
Install latest stable Blitz version

### DIFF
--- a/packages/generator/templates/app/package.js.json
+++ b/packages/generator/templates/app/package.js.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@prisma/client": "3.x",
-    "blitz": "canary",
+    "blitz": "latest",
     "react-dom": "18.0.0-alpha-5ca4b0433-20211020",
     "react": "18.0.0-beta-149b420f6-20211119",
     "zod": "3.x"

--- a/packages/generator/templates/app/package.ts.json
+++ b/packages/generator/templates/app/package.ts.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@prisma/client": "3.x",
-    "blitz": "canary",
+    "blitz": "latest",
     "react-dom": "18.0.0-alpha-5ca4b0433-20211020",
     "react": "18.0.0-beta-149b420f6-20211119",
     "zod": "3.x"

--- a/packages/generator/templates/minimalapp/package.js.json
+++ b/packages/generator/templates/minimalapp/package.js.json
@@ -18,7 +18,7 @@
     "*.{js}": ["eslint --fix"]
   },
   "dependencies": {
-    "blitz": "canary",
+    "blitz": "latest",
     "react-dom": "18.0.0-alpha-5ca4b0433-20211020",
     "react": "18.0.0-beta-149b420f6-20211119"
   },

--- a/packages/generator/templates/minimalapp/package.ts.json
+++ b/packages/generator/templates/minimalapp/package.ts.json
@@ -20,7 +20,7 @@
     ]
   },
   "dependencies": {
-    "blitz": "canary",
+    "blitz": "latest",
     "react-dom": "18.0.0-alpha-5ca4b0433-20211020",
     "react": "18.0.0-beta-149b420f6-20211119"
   },


### PR DESCRIPTION
### What are the changes and their implications?

Install the latest stable Blitz version instead of the unstable canary one for new apps. (Also, `latest` points to v0.44.3 and `canary` points to v0.41.2-canary.5)
