### PR TITLE
Fix inconsistent formatting in LoginForm and Login page 

### DIFF
--- a/packages/generator/templates/app/app/auth/components/LoginForm.tsx
+++ b/packages/generator/templates/app/app/auth/components/LoginForm.tsx
@@ -1,8 +1,8 @@
-import {AuthenticationError, Link, useMutation, Routes, PromiseReturnType} from "blitz"
-import {LabeledTextField} from "app/core/components/LabeledTextField"
-import {Form, FORM_ERROR} from "app/core/components/Form"
+import { AuthenticationError, Link, useMutation, Routes, PromiseReturnType } from "blitz"
+import { LabeledTextField } from "app/core/components/LabeledTextField"
+import { Form, FORM_ERROR } from "app/core/components/Form"
 import login from "app/auth/mutations/login"
-import {Login} from "app/auth/validations"
+import { Login } from "app/auth/validations"
 
 type LoginFormProps = {
   onSuccess?: (user: PromiseReturnType<typeof login>) => void
@@ -18,14 +18,14 @@ export const LoginForm = (props: LoginFormProps) => {
       <Form
         submitText="Login"
         schema={Login}
-        initialValues={{email: "", password: ""}}
+        initialValues={{ email: "", password: "" }}
         onSubmit={async (values) => {
           try {
             const user = await loginMutation(values)
             props.onSuccess?.(user)
           } catch (error: any) {
             if (error instanceof AuthenticationError) {
-              return {[FORM_ERROR]: "Sorry, those credentials are invalid"}
+              return { [FORM_ERROR]: "Sorry, those credentials are invalid" }
             } else {
               return {
                 [FORM_ERROR]:
@@ -44,7 +44,7 @@ export const LoginForm = (props: LoginFormProps) => {
         </div>
       </Form>
 
-      <div style={{marginTop: "1rem"}}>
+      <div style={{ marginTop: "1rem" }}>
         Or <Link href={Routes.SignupPage()}>Sign Up</Link>
       </div>
     </div>

--- a/packages/generator/templates/app/app/auth/pages/login.tsx
+++ b/packages/generator/templates/app/app/auth/pages/login.tsx
@@ -1,6 +1,6 @@
-import {useRouter, BlitzPage} from "blitz"
+import { useRouter, BlitzPage } from "blitz"
 import Layout from "app/core/layouts/Layout"
-import {LoginForm} from "app/auth/components/LoginForm"
+import { LoginForm } from "app/auth/components/LoginForm"
 
 const LoginPage: BlitzPage = () => {
   const router = useRouter()


### PR DESCRIPTION
This commit https://github.com/blitz-js/blitz/commit/4384ce0514557c2fe7905b0c022caa8b63afff83#diff-90f545371ea059291383a0ec101e86b455616c68fe05777f7554c69bb431c23f introduced inconsistent formatting for the login form and the login pages, which causes users of a brand new app to have unneeded "unstaged changes" after they format their files.

This is a quick fix that adds back the space inside the curly braces.