### PR TITLE
docs: fix broken link to PostgreSQL guide

### DIFF
--- a/examples/cypress/db/schema.prisma
+++ b/examples/cypress/db/schema.prisma
@@ -59,7 +59,7 @@ model Token {
 
 // NOTE: It's highly recommended to use an enum for the token type
 //       but enums only work in Postgres.
-//       See: https://blitzjs.com/docs/database-overview#switch-to-postgresql
+//       See: https://blitzjs.com/docs/database-overview#switch-to-postgre-sql
 // enum TokenType {
 //   RESET_PASSWORD
 // }

--- a/examples/i18n-next-rosetta/db/schema.prisma
+++ b/examples/i18n-next-rosetta/db/schema.prisma
@@ -59,7 +59,7 @@ model Token {
 
 // NOTE: It's highly recommended to use an enum for the token type
 //       but enums only work in Postgres.
-//       See: https://blitzjs.com/docs/database-overview#switch-to-postgresql
+//       See: https://blitzjs.com/docs/database-overview#switch-to-postgre-sql
 // enum TokenType {
 //   RESET_PASSWORD
 // }

--- a/packages/generator/templates/app/db/schema.prisma
+++ b/packages/generator/templates/app/db/schema.prisma
@@ -59,7 +59,7 @@ model Token {
 
 // NOTE: It's highly recommended to use an enum for the token type
 //       but enums only work in Postgres.
-//       See: https://blitzjs.com/docs/database-overview#switch-to-postgresql
+//       See: https://blitzjs.com/docs/database-overview#switch-to-postgre-sql
 // enum TokenType {
 //   RESET_PASSWORD
 // }


### PR DESCRIPTION
### What are the changes and their implications?

This PR fixes a link to a broken anchor ([correct anchor in docs](https://blitzjs.com/docs/database-overview#switch-to-postgre-sql)).

## Bug Checklist

N/A

## Feature Checklist

N/A