### PR TITLE
Fix `RedirectError` not redirecting on the client #3098

### DIFF
--- a/nextjs/packages/next/stdlib/errors.ts
+++ b/nextjs/packages/next/stdlib/errors.ts
@@ -1,7 +1,7 @@
 import SuperJson from 'superjson'
 import type { UrlObject } from 'url'
 
-const errorProps = ['name', 'message', 'code', 'statusCode', 'meta']
+const errorProps = ['name', 'message', 'code', 'statusCode', 'meta', 'url']
 if (process.env.JEST_WORKER_ID === undefined) {
   SuperJson.allowErrorProps(...errorProps)
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #3098 

### What are the changes and their implications?
Added `url` to the list of allowedErrorProps for SuperJson.
This will propagate the url parameter to the frontend. The frontend can then handle the redirection to url (as `string` or `UrlObject` with `pathname` and optionally `href` properties). Earlier, since `url` property was not serialized, such redirection could not be correctly handled by the frontend.

On https://blitzjs.com/docs/error-handling#built-in-errors the documentation mentions 
```
You can throw this error from a render function if you want to redirect the user ...
```
which is a bit confusing since it makes one believe that `RedirectError` can be thrown only on the frontend because of the `render function` bit. That documentation can be updated too with correct language. However, I am not the best person to suggest what the final wordings there should be, so I am not submitting a corresponding documentation PR.

Also, I could not find any integration / unit tests for `nextjs/packages/stdlib/errors.ts`, so I have not added the corresponding tests.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
