### PR TITLE
implement logger factory config

### DIFF
--- a/nextjs/packages/next/server/config-shared.ts
+++ b/nextjs/packages/next/server/config-shared.ts
@@ -9,10 +9,16 @@ import { CONFIG_FILE, PHASE_PRODUCTION_SERVER } from '../shared/lib/constants'
 import { copy, remove } from 'fs-extra'
 import { Middleware } from '../shared/lib/utils'
 import { isInternalBlitzMonorepoDevelopment } from './utils'
+import { ISettingsParam, Logger } from 'tslog'
 const debug = require('debug')('blitz:config')
 
 export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
 export type LogType = 'json' | 'pretty' | 'hidden'
+export interface LoggerFactoryParams {
+  settings: ISettingsParam
+  logger: Logger
+}
+export type LoggerFactory = (params: LoggerFactoryParams) => Logger
 
 export function loadConfigAtRuntime() {
   if (!process.env.BLITZ_APP_DIR) {
@@ -133,6 +139,7 @@ export type NextConfig = { [key: string]: any } & {
   log?: {
     level?: LogLevel
     type?: LogType
+    loggerFactory?: LoggerFactory
   }
   middleware?: Middleware[]
   customServer?: {


### PR DESCRIPTION
Closes: #3074 

### What are the changes and their implications?

Allows the blitz logger to be fully customized in `blitz.config.ts` by providing a function that returns `tslog.Logger` to the `log.loggerFactory` config option.

This enables developers to do anything compatible with tslog's API, including adding transports. This also allows the developer to override any of Blitz's default logging settings. Unfortunately, this results in the `log.type` and `log.level` configuration options becoming redundant; however, they are still a nice way to easily configure the most common logging options without dealing with the factory. This positions `log.loggerFactory` as the full escape hatch for all logging customization needs.

**Confession** I did _not_ add any testing. In this case, I believe the types themselves provide the necessary level of assurance that things will work as intended. I've also been running this configuration via patch-package in production and things are working as intended.

**Documentation** See https://github.com/blitz-js/blitzjs.com/pull/649

#### Example of attaching additional transport:
```ts
import { BlitzConfig } from "blitz";
import { ILogObject } from "tslog";

/*
  This example is from tslog documentation:
  https://tslog.js.org/#/?id=transports
  Consult their documentation for more information about custom transports
*/
const transportLogs: ILogObject[] = [];
function logToTransport(logObject: ILogObject) {
  transportLogs.push(logObject);
}

const config: BlitzConfig = {
  log: {
    loggerFactory: ({ logger }) => {
      logger.attachTransport(
        {
          silly: logToTransport,
          debug: logToTransport,
          trace: logToTransport,
          info: logToTransport,
          warn: logToTransport,
          error: logToTransport,
          fatal: logToTransport,
        },
        "debug"
      );
      return logger;
    },
  },
};

module.exports = config;
```

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [x] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
