### PR TITLE
fix passport adapter to work behind cloudfront

### DIFF
--- a/nextjs/packages/next/stdlib-server/middleware.ts
+++ b/nextjs/packages/next/stdlib-server/middleware.ts
@@ -149,10 +149,14 @@ function getProtocol(req: MiddlewareRequest) {
   if (req.connection.encrypted) {
     return 'https'
   }
+
+  if (!req.headers) return 'http'
+
   const forwardedProto =
-    req.headers &&
-    ((req.headers['forwarded'] as string)?.match(/(?<=proto=).+/g)?.[0] ||
-      (req.headers['x-forwarded-proto'] as string))
+    (req.headers['forwarded'] as string)?.match(/(?<=proto=).+/g)?.[0] ||
+    (req.headers['x-forwarded-proto'] as string) ||
+    (req.headers['CloudFront-Forwarded-Proto'] as string)
+
   if (forwardedProto) {
     return forwardedProto.split(/\s*,\s*/)[0]
   }


### PR DESCRIPTION


### What are the changes and their implications?

This fixes an issue where passport adapter does not work behind cloudfront
