### PR TITLE
Fix passport adapter `secureProxy` to always work regardless of request headers

### DIFF
--- a/nextjs/packages/next/stdlib-server/middleware.ts
+++ b/nextjs/packages/next/stdlib-server/middleware.ts
@@ -139,7 +139,7 @@ export const secureProxyMiddleware: Middleware = function (
   _res: MiddlewareResponse,
   next: (error?: Error) => void
 ) {
-  req.protocol = getProtocol(req)
+  req.protocol = 'https' // getProtocol(req)
   next()
 }
 

--- a/nextjs/packages/next/stdlib-server/middleware.ts
+++ b/nextjs/packages/next/stdlib-server/middleware.ts
@@ -139,26 +139,6 @@ export const secureProxyMiddleware: Middleware = function (
   _res: MiddlewareResponse,
   next: (error?: Error) => void
 ) {
-  req.protocol = 'https' // getProtocol(req)
+  req.protocol = 'https'
   next()
-}
-
-function getProtocol(req: MiddlewareRequest) {
-  // @ts-ignore
-  // For some reason there is no encrypted on socket while it is expected
-  if (req.connection.encrypted) {
-    return 'https'
-  }
-
-  if (!req.headers) return 'http'
-
-  const forwardedProto =
-    (req.headers['forwarded'] as string)?.match(/(?<=proto=).+/g)?.[0] ||
-    (req.headers['x-forwarded-proto'] as string) ||
-    (req.headers['CloudFront-Forwarded-Proto'] as string)
-
-  if (forwardedProto) {
-    return forwardedProto.split(/\s*,\s*/)[0]
-  }
-  return 'http'
 }


### PR DESCRIPTION
This fixes an issue where passport adapter would fail even with `secureProxy: true`. With this change, secureProxy will always override the request protocol to be `https` regardless of request headers. 