### PR TITLE
fix blitz logging to respect FORCE_COLOR=0

### DIFF
--- a/nextjs/packages/next/server/lib/logging.ts
+++ b/nextjs/packages/next/server/lib/logging.ts
@@ -62,6 +62,7 @@ export const baseLogger = (options?: ISettingsParam): Logger => {
       bigint: 'blue',
       boolean: 'blue',
     },
+    colorizePrettyLogs: process.env.FORCE_COLOR === '0' ? false : true,
     maskValuesOfKeys: ['password', 'passwordConfirmation'],
     exposeErrorCodeFrame: process.env.NODE_ENV !== 'production',
     ...options,


### PR DESCRIPTION

### What are the changes and their implications?

This fixes blitz logging to respect FORCE_COLOR=0. Most logging libraries use the supports-color package that handles this, but tslog is behind the times so we have to help it along.