### PR TITLE
Add email verification

### DIFF
--- a/packages/generator/templates/app/app/auth/mutations/confirmEmail.ts
+++ b/packages/generator/templates/app/app/auth/mutations/confirmEmail.ts
@@ -1,0 +1,41 @@
+import { resolver, SecurePassword, hash256 } from "blitz"
+import db from "db"
+import login from "./login"
+
+import { ConfirmEmail } from "../validations"
+
+export class ResetPasswordError extends Error {
+  name = "ConfirmEmailError"
+  message = "Email confirmation link is invalid or it has expired."
+}
+
+export default resolver.pipe(resolver.zod(ConfirmEmail), async ({ token }, ctx) => {
+  // 1. Try to find this token in the database
+  const hashedToken = hash256(token)
+  const possibleToken = await db.token.findFirst({
+    where: { hashedToken, type: "CONFIRM_EMAIL" },
+    include: { user: true },
+  })
+
+  // 2. If token not found, error
+  if (!possibleToken) {
+    throw new ResetPasswordError()
+  }
+  const savedToken = possibleToken
+
+  // 3. Delete token so it can't be used again
+  await db.token.delete({ where: { id: savedToken.id } })
+
+  // 4. If token has expired, error
+  if (savedToken.expiresAt < new Date()) {
+    throw new ResetPasswordError()
+  }
+
+  // 5. Since token is valid, we can verify the user
+  await db.user.update({
+    where: { id: savedToken.userId },
+    data: { verified: true },
+  })
+
+  return true
+})

--- a/packages/generator/templates/app/app/auth/mutations/confirmEmail.ts
+++ b/packages/generator/templates/app/app/auth/mutations/confirmEmail.ts
@@ -1,20 +1,20 @@
-import { resolver, SecurePassword, hash256 } from "blitz"
+import {resolver, SecurePassword, hash256} from "blitz"
 import db from "db"
 import login from "./login"
 
-import { ConfirmEmail } from "../validations"
+import {ConfirmEmail} from "../validations"
 
 export class ResetPasswordError extends Error {
   name = "ConfirmEmailError"
   message = "Email confirmation link is invalid or it has expired."
 }
 
-export default resolver.pipe(resolver.zod(ConfirmEmail), async ({ token }, ctx) => {
+export default resolver.pipe(resolver.zod(ConfirmEmail), resolver.authorize(), async ({token}) => {
   // 1. Try to find this token in the database
   const hashedToken = hash256(token)
   const possibleToken = await db.token.findFirst({
-    where: { hashedToken, type: "CONFIRM_EMAIL" },
-    include: { user: true },
+    where: {hashedToken, type: "CONFIRM_EMAIL"},
+    include: {user: true},
   })
 
   // 2. If token not found, error
@@ -24,7 +24,7 @@ export default resolver.pipe(resolver.zod(ConfirmEmail), async ({ token }, ctx) 
   const savedToken = possibleToken
 
   // 3. Delete token so it can't be used again
-  await db.token.delete({ where: { id: savedToken.id } })
+  await db.token.delete({where: {id: savedToken.id}})
 
   // 4. If token has expired, error
   if (savedToken.expiresAt < new Date()) {
@@ -33,8 +33,8 @@ export default resolver.pipe(resolver.zod(ConfirmEmail), async ({ token }, ctx) 
 
   // 5. Since token is valid, we can verify the user
   await db.user.update({
-    where: { id: savedToken.userId },
-    data: { verified: true },
+    where: {id: savedToken.userId},
+    data: {verified: true},
   })
 
   return true

--- a/packages/generator/templates/app/app/auth/mutations/sendConfirmationEmail.ts
+++ b/packages/generator/templates/app/app/auth/mutations/sendConfirmationEmail.ts
@@ -1,0 +1,42 @@
+import { resolver, generateToken, hash256, Ctx } from "blitz"
+import db from "db"
+import { confirmEmailMailer } from "mailers/confirmEmailMailer"
+
+const CONFIRM_EMAIL_TOKEN_EXPIRATION_IN_HOURS = 24
+
+export default resolver.pipe(async ({ ...data }, ctx: Ctx) => {
+  ctx.session.$authorize()
+
+  // 1. Get the user
+  const user = await db.user.findFirst({ where: { id: ctx.session.userId } })
+
+  // 2. Generate the token and expiration date.
+  const token = generateToken()
+  const hashedToken = hash256(token)
+  const expiresAt = new Date()
+  expiresAt.setHours(expiresAt.getHours() + CONFIRM_EMAIL_TOKEN_EXPIRATION_IN_HOURS)
+
+  // 3. If user with this email was found
+  if (user) {
+    // 4. Delete any existing email confirmation tokens
+    await db.token.deleteMany({ where: { type: "CONFIRM_EMAIL", userId: user.id } })
+    // 5. Save this new token in the database.
+    await db.token.create({
+      data: {
+        userId: user.id,
+        type: "CONFIRM_EMAIL",
+        expiresAt,
+        hashedToken,
+        sentTo: user.email,
+      },
+    })
+    // 6. Send the email
+    await confirmEmailMailer({ to: user.email, token }).send()
+  } else {
+    // 7. If no user found wait the same time so attackers can't tell the difference
+    await new Promise((resolve) => setTimeout(resolve, 750))
+  }
+
+  // 8. Return the same result whether a email reset email was sent or not
+  return
+})

--- a/packages/generator/templates/app/app/auth/pages/confirm-email.tsx
+++ b/packages/generator/templates/app/app/auth/pages/confirm-email.tsx
@@ -1,0 +1,57 @@
+import { BlitzPage, useRouterQuery, Link, useMutation, Routes, useRouter } from "blitz"
+import Layout from "app/core/layouts/Layout"
+import confirmEmail from "app/auth/mutations/confirmEmail"
+import { useState } from "react"
+import { useCurrentUser } from "app/core/hooks/useCurrentUser"
+
+const ConfirmPassswordPage: BlitzPage = () => {
+  const query = useRouterQuery()
+  const router = useRouter()
+  const user = useCurrentUser()
+  const [error, setError] = useState<string | null>(null)
+  const [resetPasswordMutation, { isSuccess }] = useMutation(confirmEmail)
+
+  if (user && user.verified) {
+    router.push("/")
+    return <>Loading...</>
+  }
+
+  return (
+    <div>
+      <h1>Confirm your email</h1>
+      {error && !isSuccess && <p>{error}</p>}
+      {isSuccess ? (
+        <div>
+          <h2>Email confirmed successfully</h2>
+          <p>
+            Go to the <Link href={Routes.Home()}>homepage</Link>
+          </p>
+        </div>
+      ) : (
+        <button
+          onClick={async () => {
+            try {
+              await resetPasswordMutation({ token: query.token as string })
+            } catch (error: any) {
+              if (error.name === "ResetPasswordError") {
+                setError(error.message)
+              } else {
+                setError("An unexpected error occurred")
+              }
+            }
+          }}
+        >
+          Confirm Email
+        </button>
+      )}
+    </div>
+  )
+}
+
+ConfirmPassswordPage.getLayout = (page) => (
+  <Layout title="Reset Your Password" noVerification>
+    {page}
+  </Layout>
+)
+
+export default ConfirmPassswordPage

--- a/packages/generator/templates/app/app/auth/pages/confirm-email.tsx
+++ b/packages/generator/templates/app/app/auth/pages/confirm-email.tsx
@@ -49,7 +49,7 @@ const ConfirmPassswordPage: BlitzPage = () => {
 }
 
 ConfirmPassswordPage.getLayout = (page) => (
-  <Layout title="Reset Your Password" noVerification>
+  <Layout title="Confirm your email" noVerification>
     {page}
   </Layout>
 )

--- a/packages/generator/templates/app/app/auth/pages/forgot-password.tsx
+++ b/packages/generator/templates/app/app/auth/pages/forgot-password.tsx
@@ -43,6 +43,6 @@ const ForgotPasswordPage: BlitzPage = () => {
 }
 
 ForgotPasswordPage.redirectAuthenticatedTo = "/"
-ForgotPasswordPage.getLayout = (page) => <Layout title="Forgot Your Password?">{page}</Layout>
+ForgotPasswordPage.getLayout = (page) => <Layout title="Forgot Your Password?" noVerification>{page}</Layout>
 
 export default ForgotPasswordPage

--- a/packages/generator/templates/app/app/auth/pages/login.tsx
+++ b/packages/generator/templates/app/app/auth/pages/login.tsx
@@ -18,6 +18,6 @@ const LoginPage: BlitzPage = () => {
 }
 
 LoginPage.redirectAuthenticatedTo = "/"
-LoginPage.getLayout = (page) => <Layout title="Log In">{page}</Layout>
+LoginPage.getLayout = (page) => <Layout title="Log In" noVerification>{page}</Layout>
 
 export default LoginPage

--- a/packages/generator/templates/app/app/auth/pages/reset-password.tsx
+++ b/packages/generator/templates/app/app/auth/pages/reset-password.tsx
@@ -54,6 +54,6 @@ const ResetPasswordPage: BlitzPage = () => {
 }
 
 ResetPasswordPage.redirectAuthenticatedTo = "/"
-ResetPasswordPage.getLayout = (page) => <Layout title="Reset Your Password">{page}</Layout>
+ResetPasswordPage.getLayout = (page) => <Layout title="Reset Your Password" noVerification>{page}</Layout>
 
 export default ResetPasswordPage

--- a/packages/generator/templates/app/app/auth/pages/signup.tsx
+++ b/packages/generator/templates/app/app/auth/pages/signup.tsx
@@ -13,6 +13,6 @@ const SignupPage: BlitzPage = () => {
 }
 
 SignupPage.redirectAuthenticatedTo = "/"
-SignupPage.getLayout = (page) => <Layout title="Sign Up">{page}</Layout>
+SignupPage.getLayout = (page) => <Layout title="Sign Up" noVerification>{page}</Layout>
 
 export default SignupPage

--- a/packages/generator/templates/app/app/auth/validations.ts
+++ b/packages/generator/templates/app/app/auth/validations.ts
@@ -40,3 +40,11 @@ export const ChangePassword = z.object({
   currentPassword: z.string(),
   newPassword: password,
 })
+
+export const SendConfirmationEmail = z.object({
+  email,
+})
+
+export const ConfirmEmail = z.object({
+  token: z.string(),
+})

--- a/packages/generator/templates/app/app/core/layouts/Layout.tsx
+++ b/packages/generator/templates/app/app/core/layouts/Layout.tsx
@@ -1,6 +1,29 @@
-import { Head, BlitzLayout } from "blitz"
+import {Head, BlitzLayout, useMutation} from "blitz"
+import {useCurrentUser} from "app/core/hooks/useCurrentUser"
+import sendConfirmationEmail from "app/auth/mutations/sendConfirmationEmail"
 
-const Layout: BlitzLayout<{title?: string}> = ({ title, children }) => {
+const Layout: BlitzLayout<{title?: string}> = ({title, noVerification, children}) => {
+  const [sendConfirmationEmailMutation] = useMutation(sendConfirmationEmail)
+  const user = useCurrentUser()
+
+  if (user && !user.verified && !noVerification) {
+    return (
+      <div>
+        You need to verify your email.{" "}
+        <button
+          onClick={() => {
+            ;(async () => {
+              await sendConfirmationEmailMutation()
+            })()
+          }}
+        >
+          Click here
+        </button>{" "}
+        to resend the email
+      </div>
+    )
+  }
+
   return (
     <>
       <Head>

--- a/packages/generator/templates/app/db/schema.prisma
+++ b/packages/generator/templates/app/db/schema.prisma
@@ -18,6 +18,7 @@ model User {
   updatedAt      DateTime @updatedAt
   name           String?
   email          String   @unique
+  verified       Boolean  @default(false)
   hashedPassword String?
   role           String   @default("USER")
 
@@ -62,4 +63,5 @@ model Token {
 //       See: https://blitzjs.com/docs/database-overview#switch-to-postgre-sql
 // enum TokenType {
 //   RESET_PASSWORD
+//   CONFIRM_PASSWORD
 // }

--- a/packages/generator/templates/app/mailers/confirmEmailMailer.ts
+++ b/packages/generator/templates/app/mailers/confirmEmailMailer.ts
@@ -1,0 +1,39 @@
+import previewEmail from "preview-email"
+
+type ResetPasswordMailer = {
+  to: string
+  token: string
+}
+
+export function confirmEmailMailer({to, token}: ResetPasswordMailer) {
+  // In production, set APP_ORIGIN to your production server origin
+  const origin = process.env.APP_ORIGIN || process.env.BLITZ_DEV_SERVER_ORIGIN
+  const resetUrl = `${origin}/confirm-email?token=${token}`
+
+  const msg = {
+    from: "TODO@example.com",
+    to,
+    subject: "Confirm your email address",
+    html: `
+      h1>Confirm Your Password</h1>
+      <h3>NOTE: You must set up a production email integration in mailers/forgotPasswordMailer.ts</h3>
+
+      <a href="${resetUrl}">
+        Click here to confirm your email
+      </a>
+    `,
+  }
+
+  return {
+    async send() {
+      if (process.env.NODE_ENV === "production") {
+        // TODO - send the production email, like this:
+        // await postmark.sendEmail(msg)
+        throw new Error("No production email implementation in mailers/forgotPasswordMailer")
+      } else {
+        // Preview email in the browser
+        await previewEmail(msg)
+      }
+    },
+  }
+}


### PR DESCRIPTION
Features:
- Adds email verification, using tokens
- Prevents users from seeing content without verifying their emails

The method for implementation is as follows
- A new field in the user model in the database, called `verified` this defaults to false and isn't provided when users sign up
- When a user signs up, a token(generated the same way as a reset password token) is sent to their email(uses previewMail)
- The user clicks on the link from their email, it opens a link
- The link is `/confirm-email?token=[token]`, the user then clicks on a button on the page
- This triggers a mutation called `confirmEmail`, which verifies the token
- If the token is valid, and the user is logged in(they are allowed to log in even if their email isn't verified), they are successfully verified
- They can now view the whole site
- View to the site is blocked by changes in they layout(prevents the user from seeing the content, if they aren't verified or a noVerification prop is passed)