### PR TITLE
Add default values to `public-hoist-pattern`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,6 @@
 save-exact=true
 public-hoist-pattern[]=secure-password
+public-hoist-pattern[]=*types*
+public-hoist-pattern[]=*eslint*
+public-hoist-pattern[]=@prettier/plugin-*
+public-hoist-pattern[]=*prettier-plugin-*

--- a/packages/config/eslint.js
+++ b/packages/config/eslint.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["next", "prettier"],
+  extends: ["eslint-config-next", "prettier"],
   ignorePatterns: ["*.d.ts"],
   settings: {
     next: {


### PR DESCRIPTION
Setting `public-hoist-pattern[]=secure-password` overrode the default values and broke eslint. This PR add the defaults.

### What are the changes and their implications?

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
