### PR TITLE
Add typings for PrismaStorage

### DIFF
--- a/packages/blitz-auth/src/shared/types.ts
+++ b/packages/blitz-auth/src/shared/types.ts
@@ -39,7 +39,18 @@ export interface SessionModel extends Record<any, any> {
   privateData?: string | null
 }
 
-export type SessionConfig = {
+export interface SessionConfigMethods {
+  getSession: (handle: string) => Promise<SessionModel | null>
+  getSessions: (userId: PublicData["userId"]) => Promise<SessionModel[]>
+  createSession: (session: SessionModel) => Promise<SessionModel>
+  updateSession: (
+    handle: string,
+    session: Partial<SessionModel>,
+  ) => Promise<SessionModel | undefined>
+  deleteSession: (handle: string) => Promise<SessionModel>
+}
+
+export interface SessionConfig extends SessionConfigMethods {
   cookiePrefix?: string
   sessionExpiryMinutes?: number
   method?: "essential" | "advanced"
@@ -47,11 +58,6 @@ export type SessionConfig = {
   secureCookies?: boolean
   domain?: string
   publicDataKeysToSyncAcrossSessions?: string[]
-  getSession: (handle: string) => Promise<SessionModel | null>
-  getSessions: (userId: PublicData["userId"]) => Promise<SessionModel[]>
-  createSession: (session: SessionModel) => Promise<SessionModel>
-  updateSession: (handle: string, session: Partial<SessionModel>) => Promise<SessionModel>
-  deleteSession: (handle: string) => Promise<SessionModel>
   isAuthorized: (data: {ctx: BlitzCtx; args: any}) => boolean
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #3204

### What are the changes and their implications?
Adds minimal typing requirement for the `db` param in the `PrismaStorage` function

## Bug Checklist

- ~~[ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)~~

## Feature Checklist

- ~~[ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)~~
- ~~[ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))~~
