### PR TITLE
Update react-query.tsx

### DIFF
--- a/apps/web/pages/users.tsx
+++ b/apps/web/pages/users.tsx
@@ -7,7 +7,7 @@ function UsersPage() {
     <div>
       Users:
       <ul>
-        {users.map((user) => (
+        {users?.map((user) => (
           <li key={user.id}>
             {user.name} - {user.email}
           </li>

--- a/packages/blitz-rpc/src/data-client/react-query.tsx
+++ b/packages/blitz-rpc/src/data-client/react-query.tsx
@@ -45,7 +45,7 @@ export function useQuery<
   queryFn: T,
   params: FirstParam<T>,
   options?: UseQueryOptions<TResult, TError, TSelectedData> & QueryNonLazyOptions,
-): [TSelectedData, RestQueryResult<TSelectedData, TError>]
+): [TSelectedData | undefined, RestQueryResult<TSelectedData, TError>]
 export function useQuery<
   T extends AsyncFunc,
   TResult = PromiseReturnType<T>,


### PR DESCRIPTION
Getting runtime errors from attempting to read properties on undefined, this change should prevent that!

Context: During SSR useQuery returns undefined until the query resolves.