### PR TITLE
Use alpha version for blitz dependency, fix package manager selection

### DIFF
--- a/packages/blitz/build.config.ts
+++ b/packages/blitz/build.config.ts
@@ -2,7 +2,7 @@ import {BuildConfig} from "unbuild"
 
 const config: BuildConfig = {
   entries: ["./src/index-browser", "./src/index-server", "./src/cli/index"],
-  externals: ["index-browser.cjs", "index-browser.mjs", "index.cjs", "zod", "@blitzjs/generator"],
+  externals: ["index-browser.cjs", "index-browser.mjs", "index.cjs", "zod"],
   declaration: true,
   rollup: {
     emitCJS: true,

--- a/packages/blitz/src/cli/commands/new.ts
+++ b/packages/blitz/src/cli/commands/new.ts
@@ -199,6 +199,7 @@ const determinePkgManagerToInstallDeps = async () => {
           {title: "skip"},
         ],
       })
+      projectPkgManger = res.pkgManager
 
       if (res.pkgManager === "skip") {
         shouldInstallDeps = false

--- a/packages/generator/src/generators/app-generator.ts
+++ b/packages/generator/src/generators/app-generator.ts
@@ -111,7 +111,7 @@ export class AppGenerator extends Generator<AppGeneratorOptions> {
     const [
       {value: newDependencies, isFallback: dependenciesUsedFallback},
       {value: newDevDependencies, isFallback: devDependenciesUsedFallback},
-      {value: blitzDependencyVersion, isFallback: blitzUsedFallback},
+      {value: blitzDependencyVersion},
     ] = await Promise.all([
       fetchLatestVersionsFor(pkg.dependencies),
       fetchLatestVersionsFor(pkg.devDependencies),
@@ -122,8 +122,7 @@ export class AppGenerator extends Generator<AppGeneratorOptions> {
     pkg.devDependencies = newDevDependencies
     pkg.dependencies.blitz = blitzDependencyVersion
 
-    const fallbackUsed =
-      dependenciesUsedFallback || devDependenciesUsedFallback || blitzUsedFallback
+    const fallbackUsed = dependenciesUsedFallback || devDependenciesUsedFallback
 
     await writeJson(pkgJsonLocation, pkg, {spaces: 2})
 

--- a/packages/generator/src/utils/fallbackable.ts
+++ b/packages/generator/src/utils/fallbackable.ts
@@ -1,4 +1,4 @@
 export interface Fallbackable<T> {
   value: T
-  isFallback: boolean
+  isFallback?: boolean
 }

--- a/packages/generator/src/utils/get-blitz-dependency-version.ts
+++ b/packages/generator/src/utils/get-blitz-dependency-version.ts
@@ -6,16 +6,16 @@ export const getBlitzDependencyVersion = async (
   cliVersion: string,
 ): Promise<Fallbackable<string>> => {
   try {
-    const {latest, canary} = await fetchDistTags("blitz")
+    const {alpha} = await fetchDistTags("blitz")
 
-    if (cliVersion.includes("canary")) {
-      return {value: canary, isFallback: false}
+    if (cliVersion.includes("alpha")) {
+      return {value: alpha}
     }
 
-    return {value: latest, isFallback: false}
+    logFailedVersionFetch("blitz")
+    return {value: ""}
   } catch (error) {
-    const fallback = "latest"
-    logFailedVersionFetch("blitz", fallback)
-    return {value: fallback, isFallback: true}
+    logFailedVersionFetch("blitz")
+    return {value: ""}
   }
 }

--- a/packages/generator/src/utils/get-latest-version.ts
+++ b/packages/generator/src/utils/get-latest-version.ts
@@ -2,12 +2,10 @@ import chalk from "chalk"
 import {Fallbackable} from "./fallbackable"
 import {fetchAllVersions, fetchLatestDistVersion} from "./npm-fetch"
 
-export const logFailedVersionFetch = (dependency: string, fallback: string) => {
-  // log.clearLine()
+export const logFailedVersionFetch = (dependency: string, fallback?: string) => {
   console.warn(
-    `Failed to fetch latest version of '${chalk.bold(dependency)}', falling back to '${chalk.bold(
-      fallback,
-    )}'.`,
+    `Failed to fetch latest version of '${chalk.bold(dependency)}'`,
+    fallback ? `Falling back to '${chalk.bold(fallback)}'` : "",
   )
 }
 

--- a/packages/generator/src/utils/npm-fetch.ts
+++ b/packages/generator/src/utils/npm-fetch.ts
@@ -12,7 +12,7 @@ export const fetchAllVersions = async (dependency: string) => {
   return Object.keys(res.versions)
 }
 
-type NpmDistTagsResponse = {latest: string; canary: string}
+type NpmDistTagsResponse = {latest: string; canary: string; alpha: string}
 
 export const fetchDistTags = async (dependency: string) => {
   const res = await got(`https://registry.npmjs.org/-/package/${dependency}/dist-tags`, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
       "@types/node": 17.0.16
       "@types/preview-email": 2.0.1
       "@types/react": 17.0.43
-      blitz: workspace:2.0.0-alpha.10
+      blitz: workspace:2.0.0-alpha.11
       eslint: 7.32.0
       husky: 7.0.4
       jest: 27.5.1
@@ -263,8 +263,8 @@ importers:
 
   packages/blitz:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-alpha.10
-      "@blitzjs/generator": 2.0.0-alpha.10
+      "@blitzjs/config": workspace:2.0.0-alpha.11
+      "@blitzjs/generator": 2.0.0-alpha.11
       "@types/cookie": 0.4.1
       "@types/cross-spawn": 6.0.2
       "@types/debug": 4.1.7
@@ -356,7 +356,7 @@ importers:
 
   packages/blitz-auth:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-alpha.10
+      "@blitzjs/config": workspace:2.0.0-alpha.11
       "@testing-library/react": 13.0.0
       "@testing-library/react-hooks": 7.0.2
       "@types/b64-lite": 1.3.0
@@ -368,7 +368,7 @@ importers:
       "@types/secure-password": 3.1.1
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-alpha.10
+      blitz: 2.0.0-alpha.11
       cookie: 0.4.1
       debug: 4.3.3
       http: 0.0.1-security
@@ -413,8 +413,8 @@ importers:
 
   packages/blitz-next:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-alpha.10
-      "@blitzjs/rpc": 2.0.0-alpha.10
+      "@blitzjs/config": workspace:2.0.0-alpha.11
+      "@blitzjs/rpc": 2.0.0-alpha.11
       "@testing-library/dom": 8.13.0
       "@testing-library/jest-dom": 5.16.3
       "@testing-library/react": 13.0.0
@@ -425,7 +425,7 @@ importers:
       "@types/react": 17.0.43
       "@types/react-dom": 17.0.14
       "@types/testing-library__react-hooks": 4.0.0
-      blitz: 2.0.0-alpha.10
+      blitz: 2.0.0-alpha.11
       cross-spawn: 7.0.3
       debug: 4.3.3
       find-up: 4.1.0
@@ -472,14 +472,14 @@ importers:
 
   packages/blitz-rpc:
     specifiers:
-      "@blitzjs/auth": 2.0.0-alpha.10
-      "@blitzjs/config": workspace:2.0.0-alpha.10
+      "@blitzjs/auth": 2.0.0-alpha.11
+      "@blitzjs/config": workspace:2.0.0-alpha.11
       "@types/debug": 4.1.7
       "@types/react": 17.0.43
       "@types/react-dom": 17.0.14
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-alpha.10
+      blitz: 2.0.0-alpha.11
       chalk: ^4.1.0
       debug: 4.3.3
       next: 12.1.1
@@ -534,7 +534,7 @@ importers:
       "@babel/plugin-transform-typescript": 7.12.1
       "@babel/preset-env": 7.12.10
       "@babel/types": 7.12.10
-      "@blitzjs/config": 2.0.0-alpha.10
+      "@blitzjs/config": 2.0.0-alpha.11
       "@juanm04/cpx": 2.0.1
       "@mrleebo/prisma-ast": 0.2.6
       "@types/babel__core": 7.1.19
@@ -625,7 +625,7 @@ importers:
 
   packages/pkg-template:
     specifiers:
-      "@blitzjs/config": 2.0.0-alpha.10
+      "@blitzjs/config": 2.0.0-alpha.11
       "@types/react": 17.0.43
       "@types/react-dom": 17.0.14
       "@typescript-eslint/eslint-plugin": 5.9.1


### PR DESCRIPTION
This is a temporary fix, we should refactor the code responsible for fetching versions and tags a little bit.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: ?

### What are the changes and their implications?

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
