### PR TITLE
Migrate react-query unit test to blitz-rpc

### DIFF
--- a/packages/blitz-rpc/test/blitz-test-utils.ts
+++ b/packages/blitz-rpc/test/blitz-test-utils.ts
@@ -1,0 +1,20 @@
+// This enhance fn does what buildRpcFunction does during build time
+export function buildQueryRpc(fn: any) {
+  const newFn = (...args: any) => {
+    const [data, ...rest] = args
+    return fn(data, ...rest)
+  }
+  newFn._isRpcClient = true
+  newFn._resolverType = "query"
+  newFn._routePath = "/api/test/url/" + Math.random()
+  return newFn
+}
+
+// This enhance fn does what buildRpcFunction does during build time
+export function buildMutationRpc(fn: any) {
+  const newFn = (...args: any) => fn(...args)
+  newFn._isRpcClient = true
+  newFn._resolverType = "mutation"
+  newFn._routePath = "/api/test/url"
+  return newFn
+}

--- a/packages/blitz-rpc/test/unit/react-query-utils.unit.test.ts
+++ b/packages/blitz-rpc/test/unit/react-query-utils.unit.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment jsdom
+ */
+import {assert, expect, test, beforeEach, describe, spyOn, it} from "vitest"
+
+import {queryClient, invalidateQuery, setQueryData} from "../../src/data-client"
+
+import {getQueryCacheFunctions} from "../../src/data-client/react-query-utils"
+import {buildQueryRpc} from "../blitz-test-utils"
+
+// eslint-disable-next-line require-await
+const isEmpty = async (arg: string): Promise<boolean> => {
+  return Boolean(arg)
+}
+
+describe("getQueryCacheFunctions", () => {
+  const spyRefetchQueries = spyOn(queryClient, "invalidateQueries")
+
+  beforeEach(() => {
+    spyRefetchQueries.mockReset()
+  })
+
+  it("returns a setQueryData function with working options", async () => {
+    window.requestIdleCallback = undefined as any
+
+    const {setQueryData} = getQueryCacheFunctions(buildQueryRpc(isEmpty), "a")
+    expect(setQueryData).toBeTruthy()
+    await setQueryData(true)
+    expect(spyRefetchQueries).toBeCalledTimes(1)
+    await setQueryData(true, {refetch: false})
+    expect(spyRefetchQueries).toBeCalledTimes(1)
+    await setQueryData(true, {refetch: true})
+    expect(spyRefetchQueries).toBeCalledTimes(2)
+  })
+
+  it("works even when requestIdleCallback is undefined", async () => {
+    window.requestIdleCallback = undefined as any
+    const {setQueryData} = getQueryCacheFunctions(buildQueryRpc(isEmpty), "a")
+    expect(setQueryData).toBeTruthy()
+    await setQueryData(true)
+    expect(spyRefetchQueries).toBeCalledTimes(1)
+    await setQueryData(true, {refetch: false})
+    expect(spyRefetchQueries).toBeCalledTimes(1)
+    await setQueryData(true, {refetch: true})
+    expect(spyRefetchQueries).toBeCalledTimes(2)
+  })
+})
+
+describe("invalidateQuery", () => {
+  const spyRefetchQueries = spyOn(queryClient, "invalidateQueries")
+
+  beforeEach(() => {
+    spyRefetchQueries.mockReset()
+  })
+
+  it("invalidates a query given resolver and params", async () => {
+    await invalidateQuery(buildQueryRpc(isEmpty), "a")
+    expect(spyRefetchQueries).toBeCalledTimes(1)
+    const calledWith = spyRefetchQueries.mock.calls[0][0] as any
+    // json of the queryKey is "a"
+    expect(calledWith[1].json).toEqual("a")
+  })
+})
+
+describe("setQueryData", () => {
+  const spyRefetchQueries = spyOn(queryClient, "invalidateQueries")
+  const spySetQueryData = spyOn(queryClient, "setQueryData")
+
+  beforeEach(() => {
+    spyRefetchQueries.mockReset()
+    spySetQueryData.mockReset()
+  })
+
+  it("without refetch will not invalidate queries", async () => {
+    await setQueryData(buildQueryRpc(isEmpty), "params", "newValue", {
+      refetch: false,
+    })
+    expect(spyRefetchQueries).toBeCalledTimes(0)
+    expect(spySetQueryData).toBeCalledTimes(1)
+
+    const calledWith = spySetQueryData.mock.calls[0] as Array<any>
+    expect(calledWith[0][1].json).toEqual("params")
+    expect(calledWith[1]).toEqual("newValue")
+  })
+
+  it("will invalidate queries by default", async () => {
+    await setQueryData(buildQueryRpc(isEmpty), "params", "newValue")
+    expect(spyRefetchQueries).toBeCalledTimes(1)
+    expect(spySetQueryData).toBeCalledTimes(1)
+
+    const invalidateCalledWith = spyRefetchQueries.mock.calls[0][0] as any
+    expect(invalidateCalledWith[1].json).toEqual("params")
+
+    const calledWith = spySetQueryData.mock.calls[0] as Array<any>
+    expect(calledWith[0][1].json).toEqual("params")
+    expect(calledWith[1]).toEqual("newValue")
+  })
+})


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #3295 

### What are the changes and their implications?

Adds a unit test to react query implementation in blitz-RPC.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
