### PR TITLE
Add missing cmd aliases and display aliases with `help` cmd

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,6 +69,7 @@
   "oclif": {
     "commands": "./lib/src/commands",
     "bin": "blitz",
+    "helpClass": "./lib/src/help",
     "plugins": [
       "@oclif/plugin-help",
       "@oclif/plugin-not-found",

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -3,7 +3,6 @@ import Help from "@oclif/plugin-help"
 
 export class HelpCommand extends Command {
   static description = "Display help for <%= config.bin %>"
-
   static aliases = ["h"]
 
   static flags = {

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -52,6 +52,7 @@ const templates: {[key in Template]: AppGeneratorOptions["template"]} = {
 
 export class New extends Command {
   static description = "Create a new Blitz project"
+  static aliases: string[] = ["n"]
 
   static args = [
     {

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -52,7 +52,7 @@ const templates: {[key in Template]: AppGeneratorOptions["template"]} = {
 
 export class New extends Command {
   static description = "Create a new Blitz project"
-  static aliases: string[] = ["n"]
+  static aliases = ["n"]
 
   static args = [
     {

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -1,0 +1,23 @@
+import {Command} from "@oclif/config"
+import Help from "@oclif/plugin-help"
+import chalk from "chalk"
+import {indent} from "./utils/indent"
+
+// eslint-disable-next-line import/no-default-export
+export default class BlitzHelp extends Help {
+  protected formatCommands(commands: Command[]): string {
+    const body = commands
+      .map((command) => {
+        let output = ""
+        output += command.id
+        const joinedAliases = command.aliases.join(", ")
+        if (joinedAliases) output += `, ${joinedAliases}`
+        output = output.padEnd(15, " ")
+        if (command.description) output += command.description.split("\n")[0]
+        return output
+      })
+      .join("\n")
+
+    return [chalk.bold("COMMANDS"), indent(body, 2)].join("\n")
+  }
+}

--- a/packages/cli/src/utils/indent.ts
+++ b/packages/cli/src/utils/indent.ts
@@ -1,0 +1,7 @@
+export function indent(arg: string, level: number) {
+  const padding = "".padStart(level, " ")
+  return arg
+    .split("\n")
+    .map((part) => `${padding}${part}`)
+    .join("\n")
+}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: ##3347

### What are the changes and their implications?

- Added an alias for the `new` command
- Added a custom `Help` class that shows command aliases while printing the command list.
