### PR TITLE
Fix duplicate react-query clients

### DIFF
--- a/apps/toolkit-app/app/blitz-client.ts
+++ b/apps/toolkit-app/app/blitz-client.ts
@@ -2,7 +2,7 @@ import { AuthClientPlugin } from "@blitzjs/auth"
 import { setupBlitzClient } from "@blitzjs/next"
 import { BlitzRpcPlugin } from "@blitzjs/rpc"
 
-export const { withBlitz, queryClient } = setupBlitzClient({
+export const { withBlitz } = setupBlitzClient({
   plugins: [
     AuthClientPlugin({
       cookiePrefix: "web-cookie-prefix",

--- a/apps/web/app/blitz-client.ts
+++ b/apps/web/app/blitz-client.ts
@@ -2,7 +2,7 @@ import {AuthClientPlugin} from "@blitzjs/auth"
 import {setupBlitzClient} from "@blitzjs/next"
 import {BlitzRpcPlugin} from "@blitzjs/rpc"
 
-const {withBlitz, queryClient} = setupBlitzClient({
+const {withBlitz} = setupBlitzClient({
   plugins: [
     AuthClientPlugin({
       cookiePrefix: "webapp-cookie-prefix",
@@ -17,4 +17,4 @@ const {withBlitz, queryClient} = setupBlitzClient({
   ],
 })
 
-export {withBlitz, queryClient}
+export {withBlitz}

--- a/packages/blitz-rpc/src/data-client/index.ts
+++ b/packages/blitz-rpc/src/data-client/index.ts
@@ -6,7 +6,7 @@ export {
   getInfiniteQueryKey,
   invalidateQuery,
   setQueryData,
-  queryClient,
+  getQueryClient,
 } from "./react-query-utils"
 export {useQueryErrorResetBoundary, QueryClient} from "react-query"
 export {dehydrate} from "react-query/hydration"

--- a/packages/blitz-rpc/src/data-client/react-query-utils.ts
+++ b/packages/blitz-rpc/src/data-client/react-query-utils.ts
@@ -54,8 +54,8 @@ export const initializeQueryClient = () => {
   })
 }
 
-// Create internal QueryClient instance
-export const queryClient = initializeQueryClient()
+// Query client is initialised in `BlitzRpcPlugin`, and can only be used with BlitzRpcPlugin right now
+export const getQueryClient = () => globalThis.queryClient
 
 function isRpcClient(f: any): f is RpcClient<any, any> {
   return !!f._isRpcClient
@@ -176,7 +176,7 @@ export function invalidateQuery<TInput, TResult, T extends AsyncFunc>(
     // Params not provided, only use first query key item (url)
     queryKey = fullQueryKey[0]
   }
-  return queryClient.invalidateQueries(queryKey)
+  return getQueryClient().invalidateQueries(queryKey)
 }
 
 export function setQueryData<TInput, TResult, T extends AsyncFunc>(
@@ -184,15 +184,15 @@ export function setQueryData<TInput, TResult, T extends AsyncFunc>(
   params: TInput,
   newData: TResult | ((oldData: TResult | undefined) => TResult),
   opts: MutateOptions = {refetch: true},
-): Promise<void | ReturnType<typeof queryClient.invalidateQueries>> {
+): Promise<void | ReturnType<ReturnType<typeof getQueryClient>["invalidateQueries"]>> {
   if (typeof resolver === "undefined") {
     throw new Error("setQueryData is missing the first argument - it must be a resolver function")
   }
   const queryKey = getQueryKey(resolver, params)
 
   return new Promise((res) => {
-    queryClient.setQueryData(queryKey, newData)
-    let result: void | ReturnType<typeof queryClient.invalidateQueries>
+    getQueryClient().setQueryData(queryKey, newData)
+    let result: void | ReturnType<ReturnType<typeof getQueryClient>["invalidateQueries"]>
     if (opts.refetch) {
       result = invalidateQuery(resolver, params)
     }

--- a/packages/blitz-rpc/src/data-client/rpc.ts
+++ b/packages/blitz-rpc/src/data-client/rpc.ts
@@ -3,7 +3,7 @@ import {addBasePath} from "next/dist/shared/lib/router/router"
 import {deserialize, serialize} from "superjson"
 import {SuperJSONResult} from "superjson/dist/types"
 import {CSRFTokenMismatchError, isServer} from "blitz"
-import {getQueryKeyFromUrlAndParams, queryClient} from "./react-query-utils"
+import {getQueryKeyFromUrlAndParams, getQueryClient} from "./react-query-utils"
 import {
   getAntiCSRFToken,
   getPublicDataStore,
@@ -123,9 +123,9 @@ export function __internal_buildRpcClient({
             setTimeout(async () => {
               // Do these in the next tick to prevent various bugs like https://github.com/blitz-js/blitz/issues/2207
               debug("Invalidating react-query cache...")
-              await queryClient.cancelQueries()
-              await queryClient.resetQueries()
-              queryClient.getMutationCache().clear()
+              await getQueryClient().cancelQueries()
+              await getQueryClient().resetQueries()
+              getQueryClient().getMutationCache().clear()
               // We have a 100ms delay here to prevent unnecessary stale queries from running
               // This prevents the case where you logout on a page with
               // Page.authenticate = {redirectTo: '/login'}
@@ -184,7 +184,7 @@ export function __internal_buildRpcClient({
 
             if (!opts.fromQueryHook) {
               const queryKey = getQueryKeyFromUrlAndParams(routePath, params)
-              queryClient.setQueryData(queryKey, data)
+              getQueryClient().setQueryData(queryKey, data)
             }
             return data
           }

--- a/packages/blitz-rpc/test/unit/react-query-utils.unit.test.ts
+++ b/packages/blitz-rpc/test/unit/react-query-utils.unit.test.ts
@@ -3,13 +3,14 @@
  */
 import {assert, expect, test, beforeEach, describe, spyOn, it} from "vitest"
 
-import {queryClient, invalidateQuery, setQueryData} from "../../src/data-client"
+import {getQueryClient, invalidateQuery, setQueryData} from "../../src/data-client"
 
 import {
   getQueryCacheFunctions,
   initializeQueryClient,
 } from "../../src/data-client/react-query-utils"
 import {buildQueryRpc} from "../blitz-test-utils"
+globalThis.queryClient = initializeQueryClient()
 
 // eslint-disable-next-line require-await
 const isEmpty = async (arg: string): Promise<boolean> => {
@@ -17,7 +18,7 @@ const isEmpty = async (arg: string): Promise<boolean> => {
 }
 
 describe("getQueryCacheFunctions", () => {
-  const spyRefetchQueries = spyOn(queryClient, "invalidateQueries")
+  const spyRefetchQueries = spyOn(getQueryClient(), "invalidateQueries")
 
   beforeEach(() => {
     spyRefetchQueries.mockReset()
@@ -50,7 +51,7 @@ describe("getQueryCacheFunctions", () => {
 })
 
 describe("invalidateQuery", () => {
-  const spyRefetchQueries = spyOn(queryClient, "invalidateQueries")
+  const spyRefetchQueries = spyOn(getQueryClient(), "invalidateQueries")
 
   beforeEach(() => {
     spyRefetchQueries.mockReset()
@@ -59,15 +60,15 @@ describe("invalidateQuery", () => {
   it("invalidates a query given resolver and params", async () => {
     await invalidateQuery(buildQueryRpc(isEmpty), "a")
     expect(spyRefetchQueries).toBeCalledTimes(1)
-    const calledWith = spyRefetchQueries.mock.calls[0][0] as any
+    const calledWith = spyRefetchQueries.mock.calls[0]![0] as any
     // json of the queryKey is "a"
     expect(calledWith[1].json).toEqual("a")
   })
 })
 
 describe("setQueryData", () => {
-  const spyRefetchQueries = spyOn(queryClient, "invalidateQueries")
-  const spySetQueryData = spyOn(queryClient, "setQueryData")
+  const spyRefetchQueries = spyOn(getQueryClient(), "invalidateQueries")
+  const spySetQueryData = spyOn(getQueryClient(), "setQueryData")
 
   beforeEach(() => {
     spyRefetchQueries.mockReset()
@@ -91,7 +92,7 @@ describe("setQueryData", () => {
     expect(spyRefetchQueries).toBeCalledTimes(1)
     expect(spySetQueryData).toBeCalledTimes(1)
 
-    const invalidateCalledWith = spyRefetchQueries.mock.calls[0][0] as any
+    const invalidateCalledWith = spyRefetchQueries.mock.calls[0]![0] as any
     expect(invalidateCalledWith[1].json).toEqual("params")
 
     const calledWith = spySetQueryData.mock.calls[0] as Array<any>

--- a/packages/generator/templates/app/app/blitz-client.ts
+++ b/packages/generator/templates/app/app/blitz-client.ts
@@ -2,7 +2,7 @@ import { AuthClientPlugin } from "@blitzjs/auth"
 import { setupBlitzClient } from "@blitzjs/next"
 import { BlitzRpcPlugin } from "@blitzjs/rpc"
 
-export const { withBlitz, queryClient } = setupBlitzClient({
+export const { withBlitz } = setupBlitzClient({
   plugins: [
     AuthClientPlugin({
       cookiePrefix: "__safeNameSlug__-cookie-prefix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2716,10 +2716,10 @@ packages:
       semver: 5.7.1
     dev: false
 
-  /@changesets/assemble-release-plan/5.1.2:
+  /@changesets/assemble-release-plan/5.1.3:
     resolution:
       {
-        integrity: sha512-nOFyDw4APSkY/vh5WNwGEtThPgEjVShp03PKVdId6wZTJALVcAALCSLmDRfeqjE2z9EsGJb7hZdDlziKlnqZgw==,
+        integrity: sha512-I+TTkUoqvxBEuDLoJfJYKDXIJ+nyiTbVJ8KGhpXEsLq4N/ms/AStSbouJwF2d/p3cB+RCPr5+gXh31GSN4kA7w==,
       }
     dependencies:
       "@babel/runtime": 7.18.3
@@ -2748,12 +2748,12 @@ packages:
     dependencies:
       "@babel/runtime": 7.18.3
       "@changesets/apply-release-plan": 6.0.0
-      "@changesets/assemble-release-plan": 5.1.2
+      "@changesets/assemble-release-plan": 5.1.3
       "@changesets/changelog-git": 0.1.11
       "@changesets/config": 2.0.0
       "@changesets/errors": 0.1.4
       "@changesets/get-dependents-graph": 1.3.2
-      "@changesets/get-release-plan": 3.0.8
+      "@changesets/get-release-plan": 3.0.9
       "@changesets/git": 1.3.2
       "@changesets/logger": 0.0.5
       "@changesets/pre": 1.0.11
@@ -2817,14 +2817,14 @@ packages:
       semver: 5.7.1
     dev: false
 
-  /@changesets/get-release-plan/3.0.8:
+  /@changesets/get-release-plan/3.0.9:
     resolution:
       {
-        integrity: sha512-TJYiWNuP0Lzu2dL/KHuk75w7TkiE5HqoYirrXF7SJIxkhlgH9toQf2C7IapiFTObtuF1qDN8HJAX1CuIOwXldg==,
+        integrity: sha512-5C1r4DcOjVxcCvPmXpymeyT6mdSTLCNiB2L+5uf19BRkDKndJdIQorH5Fe2XBR2nHUcZQFT+2TXDzCepat969w==,
       }
     dependencies:
       "@babel/runtime": 7.18.3
-      "@changesets/assemble-release-plan": 5.1.2
+      "@changesets/assemble-release-plan": 5.1.3
       "@changesets/config": 2.0.0
       "@changesets/pre": 1.0.11
       "@changesets/read": 0.5.5
@@ -3935,28 +3935,28 @@ packages:
       }
     engines: {node: ">= 10"}
 
-  /@tsconfig/node10/1.0.8:
+  /@tsconfig/node10/1.0.9:
     resolution:
       {
-        integrity: sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==,
+        integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==,
       }
 
-  /@tsconfig/node12/1.0.9:
+  /@tsconfig/node12/1.0.10:
     resolution:
       {
-        integrity: sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==,
+        integrity: sha512-N+srakvPaYMGkwjNDx3ASx65Zl3QG8dJgVtIB+YMOkucU+zctlv/hdP5250VKdDHSDoW9PFZoCqbqNcAPjCjXA==,
       }
 
-  /@tsconfig/node14/1.0.1:
+  /@tsconfig/node14/1.0.2:
     resolution:
       {
-        integrity: sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==,
+        integrity: sha512-YwrUA5ysDXHFYfL0Xed9x3sNS4P+aKlCOnnbqUa2E5HdQshHFleCJVrj1PlGTb4GgFUCDyte1v3JWLy2sz8Oqg==,
       }
 
-  /@tsconfig/node16/1.0.2:
+  /@tsconfig/node16/1.0.3:
     resolution:
       {
-        integrity: sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==,
+        integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==,
       }
 
   /@types/aria-query/4.2.2:
@@ -15848,10 +15848,10 @@ packages:
     engines: {node: ">=14.0.0"}
     dev: false
 
-  /tinyspy/0.3.2:
+  /tinyspy/0.3.3:
     resolution:
       {
-        integrity: sha512-2+40EP4D3sFYy42UkgkFFB+kiX2Tg3URG/lVvAZFfLxgGpnWl5qQJuBw1gaLttq8UOS+2p3C0WrhJnQigLTT2Q==,
+        integrity: sha512-gRiUR8fuhUf0W9lzojPf1N1euJYA30ISebSfgca8z76FOvXtVXqd5ojEIaKLWbDQhAaC3ibxZIjqbyi4ybjcTw==,
       }
     engines: {node: ">=14.0.0"}
     dev: false
@@ -16066,10 +16066,10 @@ packages:
         optional: true
     dependencies:
       "@cspotcode/source-map-support": 0.7.0
-      "@tsconfig/node10": 1.0.8
-      "@tsconfig/node12": 1.0.9
-      "@tsconfig/node14": 1.0.1
-      "@tsconfig/node16": 1.0.2
+      "@tsconfig/node10": 1.0.9
+      "@tsconfig/node12": 1.0.10
+      "@tsconfig/node14": 1.0.2
+      "@tsconfig/node16": 1.0.3
       "@types/node": 17.0.16
       acorn: 8.7.1
       acorn-walk: 8.2.0
@@ -16099,10 +16099,10 @@ packages:
         optional: true
     dependencies:
       "@cspotcode/source-map-support": 0.7.0
-      "@tsconfig/node10": 1.0.8
-      "@tsconfig/node12": 1.0.9
-      "@tsconfig/node14": 1.0.1
-      "@tsconfig/node16": 1.0.2
+      "@tsconfig/node10": 1.0.9
+      "@tsconfig/node12": 1.0.10
+      "@tsconfig/node14": 1.0.2
+      "@tsconfig/node16": 1.0.3
       acorn: 8.7.1
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -16349,7 +16349,10 @@ packages:
     dev: false
 
   /type-check/0.3.2:
-    resolution: {integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=}
+    resolution:
+      {
+        integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==,
+      }
     engines: {node: ">= 0.8.0"}
     dependencies:
       prelude-ls: 1.1.2
@@ -16559,12 +16562,18 @@ packages:
       detect-node: 2.1.0
 
   /unpipe/1.0.0:
-    resolution: {integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=}
+    resolution:
+      {
+        integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==,
+      }
     engines: {node: ">= 0.8"}
     dev: true
 
   /unset-value/1.0.0:
-    resolution: {integrity: sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=}
+    resolution:
+      {
+        integrity: sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==,
+      }
     engines: {node: ">=0.10.0"}
     dependencies:
       has-value: 0.3.1
@@ -16587,12 +16596,18 @@ packages:
       punycode: 2.1.1
 
   /urix/0.1.0:
-    resolution: {integrity: sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=}
+    resolution:
+      {
+        integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==,
+      }
     deprecated: Please see https://github.com/lydell/urix#deprecated
     dev: false
 
   /url-parse-lax/3.0.0:
-    resolution: {integrity: sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=}
+    resolution:
+      {
+        integrity: sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==,
+      }
     engines: {node: ">=4"}
     dependencies:
       prepend-http: 2.0.0
@@ -16625,7 +16640,10 @@ packages:
     dev: false
 
   /util-deprecate/1.0.2:
-    resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
+    resolution:
+      {
+        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
+      }
 
   /util/0.10.4:
     resolution:
@@ -16637,7 +16655,10 @@ packages:
     dev: false
 
   /utils-merge/1.0.1:
-    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
+    resolution:
+      {
+        integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==,
+      }
     engines: {node: ">= 0.4.0"}
 
   /uuid/8.3.2:
@@ -16682,18 +16703,27 @@ packages:
     dev: false
 
   /validate-npm-package-name/3.0.0:
-    resolution: {integrity: sha1-X6kS2B630MdK/BQN5zF/DKffQ34=}
+    resolution:
+      {
+        integrity: sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==,
+      }
     dependencies:
       builtins: 1.0.3
     dev: false
 
   /vary/1.1.2:
-    resolution: {integrity: sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=}
+    resolution:
+      {
+        integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==,
+      }
     engines: {node: ">= 0.8"}
     dev: true
 
   /vinyl-file/3.0.0:
-    resolution: {integrity: sha1-sQTZ5ECf+jJfqt1SBkLQo7SIs2U=}
+    resolution:
+      {
+        integrity: sha512-BoJDj+ca3D9xOuPEM6RWVtWQtvEPQiQYn82LvdxhLWplfQsBzBqtgK0yhCP0s1BNTi6dH9BO+dzybvyQIacifg==,
+      }
     engines: {node: ">=4"}
     dependencies:
       graceful-fs: 4.2.10
@@ -16773,7 +16803,7 @@ packages:
       jsdom: 19.0.0
       local-pkg: 0.4.1
       tinypool: 0.1.3
-      tinyspy: 0.3.2
+      tinyspy: 0.3.3
       vite: 2.9.12
     transitivePeerDependencies:
       - less
@@ -16782,7 +16812,10 @@ packages:
     dev: false
 
   /void-elements/3.1.0:
-    resolution: {integrity: sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=}
+    resolution:
+      {
+        integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==,
+      }
     engines: {node: ">=0.10.0"}
     dev: true
 
@@ -16858,7 +16891,10 @@ packages:
     dev: false
 
   /wcwidth/1.0.1:
-    resolution: {integrity: sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=}
+    resolution:
+      {
+        integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==,
+      }
     dependencies:
       defaults: 1.0.3
     dev: false
@@ -16988,7 +17024,10 @@ packages:
       is-symbol: 1.0.4
 
   /which-module/2.0.0:
-    resolution: {integrity: sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=}
+    resolution:
+      {
+        integrity: sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==,
+      }
     dev: false
 
   /which-pm-runs/1.1.0:
@@ -17093,7 +17132,10 @@ packages:
       strip-ansi: 6.0.1
 
   /wrappy/1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution:
+      {
+        integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
+      }
 
   /write-file-atomic/2.4.3:
     resolution:
@@ -17176,7 +17218,10 @@ packages:
     dev: false
 
   /xtraverse/0.1.0:
-    resolution: {integrity: sha1-t0G60BjveNip0ug63gB7P3lZxzI=}
+    resolution:
+      {
+        integrity: sha512-MANQdlG2hl1nQobxz1Rv8hsS1RuBS0C1N6qTOupv+9vmfrReePdxhmB2ecYjvsp4stJ80HD7erjkoF1Hd/FK9A==,
+      }
     engines: {node: ">= 0.4.0"}
     dependencies:
       xmldom: 0.1.31
@@ -17197,7 +17242,10 @@ packages:
     engines: {node: ">=10"}
 
   /yallist/2.1.2:
-    resolution: {integrity: sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=}
+    resolution:
+      {
+        integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==,
+      }
     dev: false
 
   /yallist/4.0.0:
@@ -17267,7 +17315,10 @@ packages:
       yargs-parser: 20.2.9
 
   /yauzl/2.10.0:
-    resolution: {integrity: sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=}
+    resolution:
+      {
+        integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==,
+      }
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0


### PR DESCRIPTION
### Closes

Currently, the Blitz internal `queryClient` & external RQ utilities (e.g. `invalidateQueries`) don't work as they use a different client to that which is used in `QueryClientProvider`.

Two react query clients are being created:
- one which is used by some internal Blitz function & those exported externally (e.g. invalidateQueries), and,
- one which is initialised within `BlitzRpcPlugin` to allow the user to specify custom options to `QueryClient`

### What are the changes and their implications?

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [x] Add a codemod to replace imports & usages of `queryClient` from `blitz` to `getQueryClient` (and add a step to the [manual migration steps](https://alpha.blitzjs.com/docs/upgrading-from-framework#manual-upgrade-steps))
