### PR TITLE
Hook up onError function for rpc server and next

### DIFF
--- a/.changeset/late-steaks-give.md
+++ b/.changeset/late-steaks-give.md
@@ -1,0 +1,6 @@
+---
+"@blitzjs/next": patch
+"@blitzjs/rpc": patch
+---
+
+Support RPC error middleware

--- a/packages/blitz-next/src/index-server.ts
+++ b/packages/blitz-next/src/index-server.ts
@@ -94,8 +94,13 @@ export const setupBlitzServer = ({plugins, onError}: SetupBlitzOptions) => {
       ctx.prefetchQuery = prefetchQuery
       ctx.prefetchInfiniteQuery = (...args) => prefetchQuery(...args, true)
 
-      const result = await handler({req, res, ctx, ...rest})
-      return withSuperJsonProps(withDehydratedState(result, queryClient))
+      try {
+        const result = await handler({req, res, ctx, ...rest})
+        return withSuperJsonProps(withDehydratedState(result, queryClient))
+      } catch (err: any) {
+        onError?.(err)
+        throw err
+      }
     }
 
   const gSP =
@@ -119,8 +124,13 @@ export const setupBlitzServer = ({plugins, onError}: SetupBlitzOptions) => {
       ctx.prefetchQuery = prefetchQuery
       ctx.prefetchInfiniteQuery = (...args) => prefetchQuery(...args, true)
 
-      const result = await handler({...context, ctx: ctx})
-      return withSuperJsonProps(withDehydratedState(result, queryClient))
+      try {
+        const result = await handler({...context, ctx: ctx})
+        return withSuperJsonProps(withDehydratedState(result, queryClient))
+      } catch (err: any) {
+        onError?.(err)
+        throw err
+      }
     }
 
   const api =

--- a/packages/blitz-next/src/index-server.ts
+++ b/packages/blitz-next/src/index-server.ts
@@ -40,6 +40,7 @@ export type NextApiHandler = (
 
 type SetupBlitzOptions = {
   plugins: BlitzServerPlugin<RequestMiddleware, Ctx>[]
+  onError?: (err: Error) => void
 }
 
 export type BlitzGSSPHandler<TProps, Query extends ParsedUrlQuery = ParsedUrlQuery> = ({
@@ -62,7 +63,7 @@ export type BlitzAPIHandler = (
   ctx: Ctx,
 ) => ReturnType<NextApiHandler>
 
-export const setupBlitzServer = ({plugins}: SetupBlitzOptions) => {
+export const setupBlitzServer = ({plugins, onError}: SetupBlitzOptions) => {
   const middlewares = plugins.flatMap((p) => p.requestMiddlewares)
   const contextMiddleware = plugins.flatMap((p) => p.contextMiddleware).filter(Boolean)
 
@@ -128,7 +129,8 @@ export const setupBlitzServer = ({plugins}: SetupBlitzOptions) => {
       try {
         await handleRequestWithMiddleware(req, res, middlewares)
         return handler(req, res, res.blitzCtx)
-      } catch (error) {
+      } catch (error: any) {
+        onError?.(error)
         return res.status(400).send(error)
       }
     }

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -13,6 +13,7 @@ export * from "./resolver"
 function isObject(value: unknown): value is Record<string | symbol, unknown> {
   return typeof value === "object" && value !== null
 }
+
 function getGlobalObject<T extends Record<string, unknown>>(key: string, defaultValue: T): T {
   assert(key.startsWith("__internal_blitz"), "unsupported key")
   if (typeof global === "undefined") {
@@ -180,6 +181,9 @@ export function rpcHandler(config: RpcConfig) {
         if (error._clearStack) {
           delete error.stack
         }
+
+        config.onError?.(error)
+
         log.error(error)
         newLine()
 


### PR DESCRIPTION
Closes: #3422, #3200

### What are the changes and their implications?

- Adds `onError` for next server init
- Hooks up `onError` from `rpcHandler`