### PR TITLE
Remove suspense wrapper from withBlitz

### DIFF
--- a/.changeset/quiet-pans-hunt.md
+++ b/.changeset/quiet-pans-hunt.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/next": patch
+---
+
+Removes the suspense wrapper from withBlitz since it's not needed

--- a/packages/blitz-next/src/index-browser.tsx
+++ b/packages/blitz-next/src/index-browser.tsx
@@ -51,11 +51,7 @@ const buildWithBlitz = <TPlugins extends readonly ClientPlugin<object>[]>(plugin
           <>
             {/* @ts-ignore todo */}
             {props.Component.suppressFirstRenderFlicker && <NoPageFlicker />}
-            {mounted && (
-              <React.Suspense fallback="Loading...">
-                <UserAppRoot {...props} Component={component} />
-              </React.Suspense>
-            )}
+            {mounted && <UserAppRoot {...props} Component={component} />}
           </>
         </BlitzProvider>
       )


### PR DESCRIPTION
Removes the unnecessary suspense wrapper from withBlitz in @blitzjs/next since there is a mounted check.  