### PR TITLE
Fix SSP / SP not prefetching queries correctly

### DIFF
--- a/.changeset/nine-birds-confess.md
+++ b/.changeset/nine-birds-confess.md
@@ -1,0 +1,7 @@
+---
+"@blitzjs/next": patch
+"@blitzjs/rpc": patch
+"blitz": patch
+---
+
+Fix SSP / SP not prefetching queries correctly

--- a/packages/blitz-next/src/index-server.ts
+++ b/packages/blitz-next/src/index-server.ts
@@ -224,8 +224,8 @@ function withDehydratedState<T extends Result>(result: T, queryClient: QueryClie
   if (!queryClient) {
     return result
   }
-  const dehydratedProps = dehydrate(queryClient)
-  return {...result, props: {...("props" in result ? result.props : undefined), dehydratedProps}}
+  const dehydratedState = dehydrate(queryClient)
+  return {...result, props: {...("props" in result ? result.props : undefined), dehydratedState}}
 }
 
 declare module "blitz" {

--- a/packages/blitz-next/src/index-server.ts
+++ b/packages/blitz-next/src/index-server.ts
@@ -104,7 +104,7 @@ export const setupBlitzServer = ({plugins, onError}: SetupBlitzOptions) => {
       ) => {
         queryClient = new QueryClient({defaultOptions})
 
-        const queryKey = infinite ? getQueryKey(fn, input) : getInfiniteQueryKey(fn, input)
+        const queryKey = infinite ? getInfiniteQueryKey(fn, input) : getQueryKey(fn, input)
         await queryClient.prefetchQuery(queryKey, () => fn(input, ctx))
       }
 
@@ -136,7 +136,7 @@ export const setupBlitzServer = ({plugins, onError}: SetupBlitzOptions) => {
       ) => {
         queryClient = new QueryClient({defaultOptions})
 
-        const queryKey = infinite ? getQueryKey(fn, input) : getInfiniteQueryKey(fn, input)
+        const queryKey = infinite ? getInfiniteQueryKey(fn, input) : getQueryKey(fn, input)
         await queryClient.prefetchQuery(queryKey, () => fn(input, ctx))
       }
 

--- a/packages/blitz-rpc/build.config.ts
+++ b/packages/blitz-rpc/build.config.ts
@@ -5,6 +5,7 @@ const config: BuildConfig = {
     "./src/index-browser",
     "./src/index-server",
     "./src/loader-server",
+    "./src/loader-server-resolvers",
     "./src/loader-client",
   ],
   externals: [

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -50,8 +50,9 @@ export function __internal_addBlitzRpcResolver(
 }
 
 const dir = __dirname + (() => "")() // trick to avoid `@vercel/ncc` to glob import
-const loaderServer = resolve(dir, "./loader-server.cjs")
 const loaderClient = resolve(dir, "./loader-client.cjs")
+const loaderServer = resolve(dir, "./loader-server.cjs")
+const loaderServerResolvers = resolve(dir, "./loader-server-resolvers.cjs")
 
 interface WebpackRuleOptions {
   resolverPath: ResolverPathOptions | undefined
@@ -92,6 +93,10 @@ export function installWebpackConfig({
     use: [
       {
         loader: loaderClient,
+        options: webpackRuleOptions,
+      },
+      {
+        loader: loaderServerResolvers,
         options: webpackRuleOptions,
       },
     ],

--- a/packages/blitz-rpc/src/loader-server-resolvers.test.ts
+++ b/packages/blitz-rpc/src/loader-server-resolvers.test.ts
@@ -1,0 +1,50 @@
+import {describe, expect, it} from "vitest"
+import {transformBlitzRpcResolverServer} from "./loader-server-resolvers"
+
+const META_TAGS_AND_EXPORT = `
+__internal_rpcHandler._resolverName = 'test'
+__internal_rpcHandler._resolverType = 'query'
+__internal_rpcHandler._routePath = '/api/rpc/test'
+
+export default __internal_rpcHandler
+`.trim()
+
+describe("transformBlitzRpcResolverServer", () => {
+  it("should compile for function", async () => {
+    const result = await transformBlitzRpcResolverServer(
+      "export default function test() { return 'test' }",
+      "queries/test.js",
+      "/",
+    )
+
+    expect(result).toBe(
+      `const __internal_rpcHandler = function test() { return 'test' }\n\n${META_TAGS_AND_EXPORT}`,
+    )
+  })
+
+  it("should compile with resolver", async () => {
+    const result = await transformBlitzRpcResolverServer(
+      `const test = resolver.pipe(() => Promise.resolve('test'))
+export default test`,
+      "queries/test.js",
+      "/",
+    )
+
+    expect(result).toBe(
+      `const test = resolver.pipe(() => Promise.resolve('test'))
+const __internal_rpcHandler = test\n\n${META_TAGS_AND_EXPORT}`,
+    )
+  })
+
+  it("should compile for plain lambda", async () => {
+    const result = await transformBlitzRpcResolverServer(
+      "export default () => Promise.resolve('test')",
+      "queries/test.js",
+      "/",
+    )
+
+    expect(result).toBe(
+      `const __internal_rpcHandler = () => Promise.resolve('test')\n\n${META_TAGS_AND_EXPORT}`,
+    )
+  })
+})

--- a/packages/blitz-rpc/src/loader-server-resolvers.ts
+++ b/packages/blitz-rpc/src/loader-server-resolvers.ts
@@ -1,0 +1,68 @@
+import {
+  assertPosixPath,
+  convertFilePathToResolverName,
+  convertFilePathToResolverType,
+  convertPageFilePathToRoutePath,
+  Loader,
+  LoaderOptions,
+  toPosixPath,
+} from "./loader-utils"
+import {normalizeApiRoute} from "./data-client"
+import {posix} from "path"
+
+// Subset of `import type { LoaderDefinitionFunction } from 'webpack'`
+
+export async function loader(this: Loader, input: string): Promise<string> {
+  const compiler = this._compiler!
+  const id = this.resource
+  const root = this._compiler!.context
+
+  const isSSR = compiler.name === "server"
+  if (isSSR) {
+    return await transformBlitzRpcResolverServer(
+      input,
+      toPosixPath(id),
+      toPosixPath(root),
+      this.query,
+    )
+  }
+
+  return input
+}
+
+module.exports = loader
+
+export async function transformBlitzRpcResolverServer(
+  src: string,
+  id: string,
+  root: string,
+  options?: LoaderOptions,
+) {
+  assertPosixPath(id)
+  assertPosixPath(root)
+
+  const resolverFilePath = "/" + posix.relative(root, id)
+  assertPosixPath(resolverFilePath)
+  const routePath = convertPageFilePathToRoutePath(resolverFilePath, options?.resolverPath)
+  const resolverName = convertFilePathToResolverName(resolverFilePath)
+  const resolverType = convertFilePathToResolverType(resolverFilePath)
+
+  const fullRoutePath = normalizeApiRoute("/api/rpc" + routePath)
+
+  const lines = src.split("\n")
+  const newLines = lines.map((line) => {
+    if (line.trim().startsWith("export default")) {
+      return line.replace("export default", "const __internal_rpcHandler =")
+    }
+
+    return line
+  })
+
+  return `${newLines.join("\n")}
+
+__internal_rpcHandler._resolverName = '${resolverName}'
+__internal_rpcHandler._resolverType = '${resolverType}'
+__internal_rpcHandler._routePath = '${fullRoutePath}'
+
+export default __internal_rpcHandler`
+}


### PR DESCRIPTION
Closes: #3517

### What are the changes and their implications?

## Bug Checklist

- [x] Infinite and non infinite getQueryKey were reversed
- [x] Added a Webpack loader that transforms resolvers and adds metadata to them so they can be used in getQueryKey on the server as well as on the client
- [x] Fix key error when loading `dehydratedState`