### PR TITLE
If project name argument is set to "." change it to current folder name

### DIFF
--- a/.changeset/two-carpets-rhyme.md
+++ b/.changeset/two-carpets-rhyme.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+During `blitz new` if project name argument is set to "." change it to current folder name

--- a/packages/blitz/src/cli/commands/new.ts
+++ b/packages/blitz/src/cli/commands/new.ts
@@ -87,6 +87,10 @@ const determineProjectName = async () => {
     projectPath = path.resolve(projectName)
   } else {
     projectName = args._.slice(1)[0] as string
+    if (projectName === ".") {
+      projectName = path.basename(process.cwd())
+    }
+
     projectPath = path.resolve(projectName)
   }
 }


### PR DESCRIPTION
Closes: #3521

### What are the changes and their implications?

## Bug Checklist

- [x] `blitz new .` used to name the project `.` causing yarn to fail, now it reads the directory name