### PR TITLE
fix: fix wrong import of the db module in `blitz db seed` command function

### DIFF
--- a/.changeset/good-apes-drum.md
+++ b/.changeset/good-apes-drum.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Fixes wrong import of the db module in `blitz db seed` command function

--- a/packages/blitz/src/cli/commands/db.ts
+++ b/packages/blitz/src/cli/commands/db.ts
@@ -51,7 +51,7 @@ const runSeed = async (seedBasePath: string) => {
     throw err
   }
 
-  const db = require(dbPath).db
+  const db = require(dbPath)
   await db.$disconnect()
   console.log("Done Seeding")
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Hey! I am testing blitz v2 (alpha) and I encountered issue with `blitz db seed` command. It throws when trying to disconnect Prisma client, because "`db` object is undefined". The root of the problem is requiring `db/index` and trying to access `db` object, but in reality Prisma client is a default export.

Closes: There is no issue yet, or I simply haven't found one.

### What are the changes and their implications?

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
