### PR TITLE
fix(blitz-rpc): fix 6th pipe resolver not returning resolved value

### DIFF
--- a/.changeset/perfect-eyes-repeat.md
+++ b/.changeset/perfect-eyes-repeat.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/rpc": patch
+---
+
+Fix pipe resolver return type

--- a/packages/blitz-rpc/src/resolver.ts
+++ b/packages/blitz-rpc/src/resolver.ts
@@ -54,7 +54,7 @@ function pipe<A, B, C, D, E, F, G, CA = Ctx, CB = CA, CC = CB, CD = CC, CE = CD,
   de: PipeFn<D, E, CD, CE>,
   ef: PipeFn<E, F, CE, CF>,
   fg: PipeFn<F, G, CF, CG>,
-): (input: A, ctx: CA) => EnsurePromise<CG>
+): (input: A, ctx: CA) => EnsurePromise<G>
 function pipe<
   A,
   B,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
       "@types/preview-email": 2.0.1
       "@types/react": 18.0.1
       "@typescript-eslint/eslint-plugin": 5.9.1
-      blitz: workspace:2.0.0-alpha.53
+      blitz: workspace:2.0.0-alpha.54
       eslint: 7.32.0
       eslint-config-next: 12.2.0
       eslint-config-prettier: 8.5.0
@@ -324,7 +324,7 @@ importers:
       "@vitejs/plugin-react": 1.3.0
       delay: 5.0.0
       eslint: 7.32.0
-      eslint-config-next: 12.2.0_hrkuebk64jiu2ut2d2sm4oylnu
+      eslint-config-next: 12.2.2_hrkuebk64jiu2ut2d2sm4oylnu
       eslint-plugin-testing-library: 5.0.1_hrkuebk64jiu2ut2d2sm4oylnu
       jsdom: 19.0.0
       typescript: 4.6.3
@@ -475,8 +475,8 @@ importers:
 
   packages/blitz:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-alpha.53
-      "@blitzjs/generator": 2.0.0-alpha.53
+      "@blitzjs/config": workspace:2.0.0-alpha.54
+      "@blitzjs/generator": 2.0.0-alpha.54
       "@types/cookie": 0.4.1
       "@types/cross-spawn": 6.0.2
       "@types/debug": 4.1.7
@@ -582,7 +582,7 @@ importers:
 
   packages/blitz-auth:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-alpha.53
+      "@blitzjs/config": workspace:2.0.0-alpha.54
       "@testing-library/react": 13.0.0
       "@testing-library/react-hooks": 7.0.2
       "@types/b64-lite": 1.3.0
@@ -596,7 +596,7 @@ importers:
       "@types/secure-password": 3.1.1
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-alpha.53
+      blitz: 2.0.0-alpha.54
       cookie: 0.4.1
       cookie-session: 2.0.0
       debug: 4.3.3
@@ -647,8 +647,8 @@ importers:
 
   packages/blitz-next:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-alpha.53
-      "@blitzjs/rpc": 2.0.0-alpha.53
+      "@blitzjs/config": workspace:2.0.0-alpha.54
+      "@blitzjs/rpc": 2.0.0-alpha.54
       "@testing-library/dom": 8.13.0
       "@testing-library/jest-dom": 5.16.3
       "@testing-library/react": 13.0.0
@@ -659,7 +659,7 @@ importers:
       "@types/react": 18.0.1
       "@types/react-dom": 17.0.14
       "@types/testing-library__react-hooks": 4.0.0
-      blitz: 2.0.0-alpha.53
+      blitz: 2.0.0-alpha.54
       cross-spawn: 7.0.3
       debug: 4.3.3
       find-up: 4.1.0
@@ -708,14 +708,14 @@ importers:
 
   packages/blitz-rpc:
     specifiers:
-      "@blitzjs/auth": 2.0.0-alpha.53
-      "@blitzjs/config": workspace:2.0.0-alpha.53
+      "@blitzjs/auth": 2.0.0-alpha.54
+      "@blitzjs/config": workspace:2.0.0-alpha.54
       "@types/debug": 4.1.7
       "@types/react": 18.0.1
       "@types/react-dom": 17.0.14
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-alpha.53
+      blitz: 2.0.0-alpha.54
       chalk: ^4.1.0
       debug: 4.3.3
       next: 12.2.0
@@ -757,12 +757,12 @@ importers:
       "@babel/plugin-syntax-typescript": 7.17.12
       "@babel/preset-env": 7.12.10
       "@blitzjs/config": workspace:*
-      "@blitzjs/generator": 2.0.0-alpha.53
+      "@blitzjs/generator": 2.0.0-alpha.54
       "@types/jscodeshift": 0.11.2
       "@types/node": 17.0.16
       arg: 5.0.1
       ast-types: 0.14.2
-      blitz: 2.0.0-alpha.53
+      blitz: 2.0.0-alpha.54
       chalk: ^4.1.0
       cross-spawn: 7.0.3
       debug: 4.3.3
@@ -817,7 +817,7 @@ importers:
       "@babel/plugin-transform-typescript": 7.12.1
       "@babel/preset-env": 7.12.10
       "@babel/types": 7.12.10
-      "@blitzjs/config": 2.0.0-alpha.53
+      "@blitzjs/config": 2.0.0-alpha.54
       "@juanm04/cpx": 2.0.1
       "@mrleebo/prisma-ast": 0.2.6
       "@types/babel__core": 7.1.19
@@ -908,7 +908,7 @@ importers:
 
   packages/pkg-template:
     specifiers:
-      "@blitzjs/config": 2.0.0-alpha.53
+      "@blitzjs/config": 2.0.0-alpha.54
       "@types/react": 18.0.1
       "@types/react-dom": 17.0.14
       "@typescript-eslint/eslint-plugin": 5.9.1
@@ -3448,6 +3448,15 @@ packages:
       }
     dependencies:
       glob: 7.1.7
+
+  /@next/eslint-plugin-next/12.2.2:
+    resolution:
+      {
+        integrity: sha512-XOi0WzJhGH3Lk51SkSu9eZxF+IY1ZZhWcJTIGBycAbWU877IQa6+6KxMATWCOs7c+bmp6Sd8KywXJaDRxzu0JA==,
+      }
+    dependencies:
+      glob: 7.1.7
+    dev: true
 
   /@next/swc-android-arm-eabi/12.2.0:
     resolution:
@@ -8401,6 +8410,34 @@ packages:
       - eslint-import-resolver-webpack
       - supports-color
     dev: false
+
+  /eslint-config-next/12.2.2_hrkuebk64jiu2ut2d2sm4oylnu:
+    resolution:
+      {
+        integrity: sha512-oJhWBLC4wDYYUFv/5APbjHUFd0QRFCojMdj/QnMoOEktmeTvwnnoA8F8uaXs0fQgsaTK0tbUxBRv9/Y4/rpxOA==,
+      }
+    peerDependencies:
+      eslint: ^7.23.0 || ^8.0.0
+      typescript: ">=3.3.1"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@next/eslint-plugin-next": 12.2.2
+      "@rushstack/eslint-patch": 1.1.3
+      "@typescript-eslint/parser": 5.28.0_hrkuebk64jiu2ut2d2sm4oylnu
+      eslint: 7.32.0
+      eslint-import-resolver-node: 0.3.6
+      eslint-import-resolver-typescript: 2.7.1_hpmu7kn6tcn2vnxpfzvv33bxmy
+      eslint-plugin-import: 2.26.0_zhtk6rij7obli3ams3sxis7j7e
+      eslint-plugin-jsx-a11y: 6.5.1_eslint@7.32.0
+      eslint-plugin-react: 7.30.0_eslint@7.32.0
+      eslint-plugin-react-hooks: 4.5.0_eslint@7.32.0
+      typescript: 4.6.3
+    transitivePeerDependencies:
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
 
   /eslint-config-prettier/8.5.0:
     resolution:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->



### What are the changes and their implications?

exact same as #3538 but for the canary branch

No idea how this wasn't caught by now, but the 6th function in a given pipe will return the `Ctx` instead of the value yielded by the function (according to the type info) 🤷‍♂️

```ts
// this yields Ctx
export default resolver.pipe(
  fn1,
  fn2,
  fn3,
  fn4,
  fn5,
  fn6
)
```


## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
