### PR TITLE
fix(blitz-rpc): fix 6th pipe resolver not returning resolved value -- canary

### DIFF
--- a/nextjs/packages/next/stdlib-server/resolver.ts
+++ b/nextjs/packages/next/stdlib-server/resolver.ts
@@ -93,7 +93,7 @@ function pipe<
   de: PipeFn<D, E, CD, CE>,
   ef: PipeFn<E, F, CE, CF>,
   fg: PipeFn<F, G, CF, CG>
-): (input: A, ctx: CA) => EnsurePromise<CG>
+): (input: A, ctx: CA) => EnsurePromise<G>
 function pipe<
   A,
   B,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

### What are the changes and their implications?

exact same as #3537 but for the canary branch

No idea how this wasn't caught by now, but the 6th function in a given pipe will return the `Ctx` instead of the value yielded by the function (according to the type info) 🤷‍♂️

```ts
// this yields Ctx
export default resolver.pipe(
  fn1,
  fn2,
  fn3,
  fn4,
  fn5,
  fn6
)
```


## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
