### PR TITLE
Fix prefetching multiple queries causes only the last one to be passed to page

### DIFF
--- a/.changeset/twelve-lemons-smile.md
+++ b/.changeset/twelve-lemons-smile.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/next": patch
+---
+
+Fix prefetching multiple queries causes only the last one to be passed to page

--- a/packages/blitz-next/src/index-server.ts
+++ b/packages/blitz-next/src/index-server.ts
@@ -134,7 +134,9 @@ export const setupBlitzServer = ({plugins, onError}: SetupBlitzOptions) => {
         defaultOptions = {},
         infinite = false,
       ) => {
-        queryClient = new QueryClient({defaultOptions})
+        if (!queryClient) {
+          queryClient = new QueryClient({defaultOptions})
+        }
 
         const queryKey = infinite ? getInfiniteQueryKey(fn, input) : getQueryKey(fn, input)
         await queryClient.prefetchQuery(queryKey, () => fn(input, ctx))


### PR DESCRIPTION
Closes: #3550

### What are the changes and their implications?

## Bug Checklist

- [x] Initialise QueryClient only the first time (instead of on every prefetch)