### PR TITLE
Fix a long-standing issue with occasional blitz auth flakiness

### DIFF
--- a/packages/blitz-auth/src/server/auth-sessions.test.ts
+++ b/packages/blitz-auth/src/server/auth-sessions.test.ts
@@ -1,0 +1,41 @@
+import {expect, describe, it} from "vitest"
+import {setCookie} from "./auth-sessions"
+import cookie from "cookie"
+import {ServerResponse} from "http"
+
+describe("blitz-auth", () => {
+  describe("setCookie", () => {
+    it("works with empty start", async () => {
+      const res = new ServerResponse({} as any)
+      setCookie(res, cookie.serialize("A", "a-value", {}))
+      expect(res.getHeader("Set-Cookie")).toBe("A=a-value")
+    })
+
+    it("works with string start", async () => {
+      const res = new ServerResponse({} as any)
+      res.setHeader("Set-Cookie", cookie.serialize("A", "a-value", {}))
+      setCookie(res, cookie.serialize("B", "b-value", {}))
+      expect(res.getHeader("Set-Cookie")).toEqual(["A=a-value", "B=b-value"])
+    })
+
+    it("works with array start for new name", async () => {
+      const res = new ServerResponse({} as any)
+      res.setHeader("Set-Cookie", [
+        cookie.serialize("A", "a-value", {}),
+        cookie.serialize("B", "b-value", {}),
+      ])
+      setCookie(res, cookie.serialize("C", "c-value", {}))
+      expect(res.getHeader("Set-Cookie")).toEqual(["A=a-value", "B=b-value", "C=c-value"])
+    })
+
+    it("works with array start for existing name", async () => {
+      const res = new ServerResponse({} as any)
+      res.setHeader("Set-Cookie", [
+        cookie.serialize("A", "a-value", {}),
+        cookie.serialize("B", "b-value", {}),
+      ])
+      setCookie(res, cookie.serialize("A", "new-a-value", {}))
+      expect(res.getHeader("Set-Cookie")).toEqual(["A=new-a-value", "B=b-value"])
+    })
+  })
+})

--- a/packages/blitz-auth/src/server/auth-sessions.ts
+++ b/packages/blitz-auth/src/server/auth-sessions.ts
@@ -385,7 +385,7 @@ const parseAnonymousSessionToken = (token: string) => {
   }
 }
 
-const setCookie = (res: ServerResponse, cookieStr: string) => {
+export const setCookie = (res: ServerResponse, cookieStr: string) => {
   const getCookieName = (c: string) => c.split("=", 2)[0]
   const appendCookie = () => append(res, "Set-Cookie", cookieStr)
 
@@ -407,7 +407,7 @@ const setCookie = (res: ServerResponse, cookieStr: string) => {
     for (let i = 0; i < cookiesHeader.length; i++) {
       if (cookieName === getCookieName(cookiesHeader[i] || "")) {
         cookiesHeader[i] = cookieStr
-        res.setHeader("Set-Cookie", cookieStr)
+        res.setHeader("Set-Cookie", cookiesHeader)
         return
       }
     }


### PR DESCRIPTION
### What are the changes and their implications?

This bug would sometimes cause users to be logged out or to experience an CSRFTokenMismatchError. This bug, when encountered, usually by lots of setPublicData or session.create calls, would not set the cookie headers correctly resulting in cookies being set to a previous state or in a possibly undefined state.

There are no security concerns as far as I can tell.

## Bug Checklist

- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

