### PR TITLE
Don't throw error on app/api folder not found when doing codemod

### DIFF
--- a/.changeset/hungry-baboons-swim.md
+++ b/.changeset/hungry-baboons-swim.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Improve codemod utilities

--- a/packages/codemod/src/utils.ts
+++ b/packages/codemod/src/utils.ts
@@ -224,7 +224,16 @@ export function getAllFiles(
   skipDirs?: string[],
   allowedExt?: string[],
 ) {
-  let currentFiles = fs.readdirSync(dirPath)
+  let currentFiles: string[] = []
+  try {
+    currentFiles = fs.readdirSync(dirPath)
+  } catch (e: any) {
+    if (e.code === "ENOENT") {
+      return []
+    }
+
+    throw e
+  }
 
   currentFiles.forEach((file) => {
     if (fs.statSync(dirPath + "/" + file).isDirectory()) {


### PR DESCRIPTION
Closes: #3567

### What are the changes and their implications?

## Bug Checklist

- [ ] `getAllFiles` method now returns an empty array if folder not found
