### PR TITLE
Truncate error messages in passportAuth redirectUri

### DIFF
--- a/.changeset/breezy-moose-behave.md
+++ b/.changeset/breezy-moose-behave.md
@@ -1,0 +1,6 @@
+---
+"blitz": minor
+"@blitzjs/auth": patch
+---
+
+Error messages representing errors that are thrown while handling the `api/auth/<strategy>/callback` request, will be truncated to a maximum of 100 characters before being passed as to the `?authError=` query parameter of the redirectUrl.

--- a/.changeset/breezy-moose-behave.md
+++ b/.changeset/breezy-moose-behave.md
@@ -3,4 +3,4 @@
 "@blitzjs/auth": patch
 ---
 
-Error messages representing errors that are thrown while handling the `api/auth/<strategy>/callback` request, will be truncated to a maximum of 100 characters before being passed as to the `?authError=` query parameter of the redirectUrl.
+Truncate errors from `api/auth/<strategy>/callback` request to 100 characters before passing them to the `?authError=` query parameter

--- a/packages/blitz-auth/src/server/passport-adapter.ts
+++ b/packages/blitz-auth/src/server/passport-adapter.ts
@@ -162,6 +162,8 @@ export function passportAuth(config: BlitzPassportConfig): ApiHandler {
                 "/"
 
               if (error) {
+                console.error(`Login via ${strategyName} was unsuccessful.`)
+                console.error(error)
                 redirectUrl +=
                   "?authError=" + encodeURIComponent(truncateString(error.toString(), 100))
                 res.setHeader("Location", redirectUrl)

--- a/packages/blitz-auth/src/server/passport-adapter.ts
+++ b/packages/blitz-auth/src/server/passport-adapter.ts
@@ -11,6 +11,7 @@ import {
   RequestMiddleware,
   MiddlewareResponse,
   secureProxyMiddleware,
+  truncateString,
 } from "blitz"
 import {IncomingMessage, ServerResponse} from "http"
 import {PublicData, SessionContext} from "../shared"
@@ -161,7 +162,8 @@ export function passportAuth(config: BlitzPassportConfig): ApiHandler {
                 "/"
 
               if (error) {
-                redirectUrl += "?authError=" + encodeURIComponent(error.toString())
+                redirectUrl +=
+                  "?authError=" + encodeURIComponent(truncateString(error.toString(), 100))
                 res.setHeader("Location", redirectUrl)
                 res.statusCode = 302
                 res.end()

--- a/packages/blitz/src/utils.ts
+++ b/packages/blitz/src/utils.ts
@@ -142,3 +142,7 @@ export function prettyMs(ms: number): string {
 export function interopDefault(mod: any) {
   return mod.default || mod
 }
+
+export function truncateString(str: string, maxLength: number): string {
+  return str.length > maxLength ? str.substring(0, maxLength - 3) + "..." : str
+}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #2831

### What are the changes and their implications?

Error messages representing errors that are thrown while handling the `api/auth/<strategy>/callback` request, will be truncated to a maximum of 100 characters before being passed as to the `?authError=` query  parameter of the redirectUrl. This will ensure that error messages in the request header do not cause the server to refuse processing the redirect request because of its large size.  

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
