### PR TITLE
Passes the correct arguments to runCommandFromBin

### DIFF
--- a/.changeset/polite-lizards-love.md
+++ b/.changeset/polite-lizards-love.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Passes the correct arguments (without flags) to any bin command ran with the blitz cli

--- a/packages/blitz/src/cli/index.ts
+++ b/packages/blitz/src/cli/index.ts
@@ -63,6 +63,7 @@ async function runCommandFromBin() {
     process.exit(1)
   }
   let commandBin: string | null = null
+
   try {
     commandBin = await getCommandBin(args._[0])
   } catch (e: any) {
@@ -73,7 +74,7 @@ async function runCommandFromBin() {
     process.exit(1)
   }
 
-  const result = spawn.sync(commandBin, process.argv.slice(3), {stdio: "inherit"})
+  const result = spawn.sync(commandBin, args._.slice(1), {stdio: "inherit"})
   process.exit(result.status || 0)
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
       "@types/preview-email": 2.0.1
       "@types/react": 18.0.1
       "@typescript-eslint/eslint-plugin": 5.9.1
-      blitz: workspace:2.0.0-alpha.59
+      blitz: workspace:2.0.0-alpha.60
       eslint: 7.32.0
       eslint-config-next: 12.2.0
       eslint-config-prettier: 8.5.0
@@ -475,8 +475,8 @@ importers:
 
   packages/blitz:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-alpha.59
-      "@blitzjs/generator": 2.0.0-alpha.59
+      "@blitzjs/config": workspace:2.0.0-alpha.60
+      "@blitzjs/generator": 2.0.0-alpha.60
       "@types/cookie": 0.4.1
       "@types/cross-spawn": 6.0.2
       "@types/debug": 4.1.7
@@ -584,7 +584,7 @@ importers:
 
   packages/blitz-auth:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-alpha.59
+      "@blitzjs/config": workspace:2.0.0-alpha.60
       "@testing-library/react": 13.0.0
       "@testing-library/react-hooks": 7.0.2
       "@types/b64-lite": 1.3.0
@@ -598,7 +598,7 @@ importers:
       "@types/secure-password": 3.1.1
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-alpha.59
+      blitz: 2.0.0-alpha.60
       cookie: 0.4.1
       cookie-session: 2.0.0
       debug: 4.3.3
@@ -649,8 +649,8 @@ importers:
 
   packages/blitz-next:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-alpha.59
-      "@blitzjs/rpc": 2.0.0-alpha.59
+      "@blitzjs/config": workspace:2.0.0-alpha.60
+      "@blitzjs/rpc": 2.0.0-alpha.60
       "@testing-library/dom": 8.13.0
       "@testing-library/jest-dom": 5.16.3
       "@testing-library/react": 13.0.0
@@ -661,7 +661,7 @@ importers:
       "@types/react": 18.0.1
       "@types/react-dom": 17.0.14
       "@types/testing-library__react-hooks": 4.0.0
-      blitz: 2.0.0-alpha.59
+      blitz: 2.0.0-alpha.60
       cross-spawn: 7.0.3
       debug: 4.3.3
       find-up: 4.1.0
@@ -710,14 +710,14 @@ importers:
 
   packages/blitz-rpc:
     specifiers:
-      "@blitzjs/auth": 2.0.0-alpha.59
-      "@blitzjs/config": workspace:2.0.0-alpha.59
+      "@blitzjs/auth": 2.0.0-alpha.60
+      "@blitzjs/config": workspace:2.0.0-alpha.60
       "@types/debug": 4.1.7
       "@types/react": 18.0.1
       "@types/react-dom": 17.0.14
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-alpha.59
+      blitz: 2.0.0-alpha.60
       chalk: ^4.1.0
       debug: 4.3.3
       next: 12.2.0
@@ -759,12 +759,12 @@ importers:
       "@babel/plugin-syntax-typescript": 7.17.12
       "@babel/preset-env": 7.12.10
       "@blitzjs/config": workspace:*
-      "@blitzjs/generator": 2.0.0-alpha.59
+      "@blitzjs/generator": 2.0.0-alpha.60
       "@types/jscodeshift": 0.11.2
       "@types/node": 17.0.16
       arg: 5.0.1
       ast-types: 0.14.2
-      blitz: 2.0.0-alpha.59
+      blitz: 2.0.0-alpha.60
       chalk: ^4.1.0
       cross-spawn: 7.0.3
       debug: 4.3.3
@@ -819,7 +819,7 @@ importers:
       "@babel/plugin-transform-typescript": 7.12.1
       "@babel/preset-env": 7.12.10
       "@babel/types": 7.12.10
-      "@blitzjs/config": 2.0.0-alpha.59
+      "@blitzjs/config": 2.0.0-alpha.60
       "@juanm04/cpx": 2.0.1
       "@mrleebo/prisma-ast": 0.2.6
       "@types/babel__core": 7.1.19
@@ -910,7 +910,7 @@ importers:
 
   packages/pkg-template:
     specifiers:
-      "@blitzjs/config": 2.0.0-alpha.59
+      "@blitzjs/config": 2.0.0-alpha.60
       "@types/react": 18.0.1
       "@types/react-dom": 17.0.14
       "@typescript-eslint/eslint-plugin": 5.9.1


### PR DESCRIPTION
Closes: ?

### What are the changes and their implications?

```diff
async function runCommandFromBin() {
  if (!args._[0]) {
    console.log("No command specified")
    process.exit(1)
  }
  let commandBin: string | null = null

  try {
    commandBin = await getCommandBin(args._[0])
  } catch (e: any) {
    console.error(`Error: ${e.message}`)
  }

  if (!commandBin) {
    process.exit(1)
  }
- const result = spawn.sync(commandBin, process.argv.slice(3), {stdio: "inherit"})
+ const result = spawn.sync(commandBin, args._.slice(1), {stdio: "inherit"})
  process.exit(result.status || 0)
}
```