### PR TITLE
Adds rootDir prefix to tsconfig alias module name mapper

### DIFF
--- a/.changeset/wicked-rings-walk.md
+++ b/.changeset/wicked-rings-walk.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/next": patch
+---
+
+Set prefix in moduleNameWrapper's options in Blitz's jest configuration

--- a/packages/blitz-next/jest/index.js
+++ b/packages/blitz-next/jest/index.js
@@ -21,6 +21,7 @@ function createJestConfigForNext(options) {
         // This ensures any path aliases in tsconfig also work in jest
         ...pathsToModuleNameMapper(
           (tsConfig && tsConfig.compilerOptions && tsConfig.compilerOptions.paths) || {},
+          {prefix: "<rootDir>/"},
         ),
         "\\.(jpg|jpeg|png|gif|webp|ico)$": path.resolve(__dirname, "./jest-preset/image-mock.js"),
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
       "@types/preview-email": 2.0.1
       "@types/react": 18.0.1
       "@typescript-eslint/eslint-plugin": 5.9.1
-      blitz: workspace:2.0.0-alpha.60
+      blitz: workspace:2.0.0-alpha.61
       eslint: 7.32.0
       eslint-config-next: 12.2.0
       eslint-config-prettier: 8.5.0
@@ -475,8 +475,8 @@ importers:
 
   packages/blitz:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-alpha.60
-      "@blitzjs/generator": 2.0.0-alpha.60
+      "@blitzjs/config": workspace:2.0.0-alpha.61
+      "@blitzjs/generator": 2.0.0-alpha.61
       "@types/cookie": 0.4.1
       "@types/cross-spawn": 6.0.2
       "@types/debug": 4.1.7
@@ -584,7 +584,7 @@ importers:
 
   packages/blitz-auth:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-alpha.60
+      "@blitzjs/config": workspace:2.0.0-alpha.61
       "@testing-library/react": 13.0.0
       "@testing-library/react-hooks": 7.0.2
       "@types/b64-lite": 1.3.0
@@ -598,7 +598,7 @@ importers:
       "@types/secure-password": 3.1.1
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-alpha.60
+      blitz: 2.0.0-alpha.61
       cookie: 0.4.1
       cookie-session: 2.0.0
       debug: 4.3.3
@@ -649,8 +649,8 @@ importers:
 
   packages/blitz-next:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-alpha.60
-      "@blitzjs/rpc": 2.0.0-alpha.60
+      "@blitzjs/config": workspace:2.0.0-alpha.61
+      "@blitzjs/rpc": 2.0.0-alpha.61
       "@testing-library/dom": 8.13.0
       "@testing-library/jest-dom": 5.16.3
       "@testing-library/react": 13.0.0
@@ -661,7 +661,7 @@ importers:
       "@types/react": 18.0.1
       "@types/react-dom": 17.0.14
       "@types/testing-library__react-hooks": 4.0.0
-      blitz: 2.0.0-alpha.60
+      blitz: 2.0.0-alpha.61
       cross-spawn: 7.0.3
       debug: 4.3.3
       find-up: 4.1.0
@@ -710,14 +710,14 @@ importers:
 
   packages/blitz-rpc:
     specifiers:
-      "@blitzjs/auth": 2.0.0-alpha.60
-      "@blitzjs/config": workspace:2.0.0-alpha.60
+      "@blitzjs/auth": 2.0.0-alpha.61
+      "@blitzjs/config": workspace:2.0.0-alpha.61
       "@types/debug": 4.1.7
       "@types/react": 18.0.1
       "@types/react-dom": 17.0.14
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-alpha.60
+      blitz: 2.0.0-alpha.61
       chalk: ^4.1.0
       debug: 4.3.3
       next: 12.2.0
@@ -759,12 +759,12 @@ importers:
       "@babel/plugin-syntax-typescript": 7.17.12
       "@babel/preset-env": 7.12.10
       "@blitzjs/config": workspace:*
-      "@blitzjs/generator": 2.0.0-alpha.60
+      "@blitzjs/generator": 2.0.0-alpha.61
       "@types/jscodeshift": 0.11.2
       "@types/node": 17.0.16
       arg: 5.0.1
       ast-types: 0.14.2
-      blitz: 2.0.0-alpha.60
+      blitz: 2.0.0-alpha.61
       chalk: ^4.1.0
       cross-spawn: 7.0.3
       debug: 4.3.3
@@ -819,7 +819,7 @@ importers:
       "@babel/plugin-transform-typescript": 7.12.1
       "@babel/preset-env": 7.12.10
       "@babel/types": 7.12.10
-      "@blitzjs/config": 2.0.0-alpha.60
+      "@blitzjs/config": 2.0.0-alpha.61
       "@juanm04/cpx": 2.0.1
       "@mrleebo/prisma-ast": 0.2.6
       "@types/babel__core": 7.1.19
@@ -910,7 +910,7 @@ importers:
 
   packages/pkg-template:
     specifiers:
-      "@blitzjs/config": 2.0.0-alpha.60
+      "@blitzjs/config": 2.0.0-alpha.61
       "@types/react": 18.0.1
       "@types/react-dom": 17.0.14
       "@typescript-eslint/eslint-plugin": 5.9.1
@@ -4989,7 +4989,6 @@ packages:
       typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/scope-manager/5.28.0:
     resolution:
@@ -10984,7 +10983,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.7.0_fxg3r7oju3tntkxsvleuiot4fa
+      ts-node: 10.7.0_typescript@4.6.3
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -16138,6 +16137,7 @@ packages:
       typescript: 4.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: false
 
   /ts-node/10.7.0_typescript@4.6.3:
     resolution:
@@ -16170,7 +16170,6 @@ packages:
       typescript: 4.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: false
 
   /tsconfig-paths/3.14.1:
     resolution:


### PR DESCRIPTION
Closes: ?

### What are the changes and their implications?

When using a path alias with tsconfig, jest doesn't set the right route. Adding `<rootDir>/` to the `prefix` key in `pathsToModuleNameMapper` second parameter fixes the issues.

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
