### PR TITLE
Fixes db seed command

### DIFF
--- a/.changeset/calm-carpets-deny.md
+++ b/.changeset/calm-carpets-deny.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Fixes the db seed command so that the database can disconnect after running the seed file.

--- a/packages/blitz/src/cli/commands/db.ts
+++ b/packages/blitz/src/cli/commands/db.ts
@@ -51,7 +51,7 @@ const runSeed = async (seedBasePath: string) => {
     throw err
   }
 
-  const db = require(dbPath)
+  const db = require(dbPath).default
   await db.$disconnect()
   console.log("Done Seeding")
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4989,6 +4989,7 @@ packages:
       typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@typescript-eslint/scope-manager/5.28.0:
     resolution:


### PR DESCRIPTION
Closes: ?

### What are the changes and their implications?
Previously when running `blitz db seed`, we would get an error saying `db2.$disconnect` not found. This is because inside the cli command we weren't requiring the default export.

```diff
-const db = require(dbPath)
+const db = require(dbPath).default
  await db.$disconnect()
```