### PR TITLE
Fix finding package location for blitz in node_modules

### DIFF
--- a/packages/blitz-next/scripts/postinstall.js
+++ b/packages/blitz-next/scripts/postinstall.js
@@ -12,17 +12,7 @@ const stat = promisify(fs.stat)
 const debug = require("debug")("blitz:postinstall")
 
 const isInBlitzMonorepo = fs.existsSync(path.join(__dirname, "../../blitz-next"))
-let isInstalledGlobally = isInBlitzMonorepo ? false : true // default
 
-try {
-  const maybeGlobalBlitzPath = resolveFrom(__dirname, "blitz")
-  const localBlitzPath = resolveFrom.silent(process.cwd(), "blitz/dist/index.cjs")
-  isInstalledGlobally = maybeGlobalBlitzPath !== localBlitzPath
-} catch (error) {
-  // noop
-}
-
-// todo: we should reuse `findNodeModulesRoot` from /nextjs/packages/next/build/routes.ts
 async function findNodeModulesRoot(src) {
   let root
   if (isInBlitzMonorepo) {
@@ -105,11 +95,10 @@ function codegen() {
     try {
       const packagePath = require.resolve("blitz/package.json")
       if (packagePath) {
-        const blitzPkg = require.resolve("blitz/dist/index.cjs")
-        if (blitzPkg.includes(".pnpm")) {
-          return path.join(blitzPkg, "../../../../../../blitz/dist/index.cjs")
+        if (packagePath.includes(".pnpm")) {
+          return path.join(packagePath, "../../blitz/dist/index.cjs")
         } else {
-          return path.join(blitzPkg)
+          return path.join(packagePath, "../dist/index.cjs")
         }
       }
     } catch (e) {
@@ -337,6 +326,4 @@ function codegen() {
   const UNABLE_TO_FIND_POSTINSTALL_TRIGGER_JSON_SCHEMA_ERROR = 'UNABLE_TO_FIND_POSTINSTALL_TRIGGER_JSON_SCHEMA_ERROR'
 }
 
-// if (!isInstalledGlobally) {
 codegen()
-// }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4917,7 +4917,6 @@ packages:
       typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/experimental-utils/5.28.0_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -8572,7 +8571,6 @@ packages:
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
 
   /eslint-config-next/12.2.3_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -8610,7 +8608,6 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: ">=7.0.0"
-    dev: false
 
   /eslint-config-prettier/8.5.0_eslint@7.32.0:
     resolution:


### PR DESCRIPTION
Closes: ?

### What are the changes and their implications?

Previously `postinstall` which is ran when `@blitzjs/next` is installed was finding the wrong node_modules directory. This fix should locate the right blitz cli node script.