### PR TITLE
Fixes generator templates: Mocking `generateToken` in forgotPassword mutation test & use hardcoded blitz pkg versions

### DIFF
--- a/.changeset/wise-rabbits-complain.md
+++ b/.changeset/wise-rabbits-complain.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Mocks @blitzjs/auth instead of blitz inside the forgotPassword mutation test & hardcodes blitz package version types instead of just using the alpha tag.

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -302,7 +302,7 @@ export abstract class Generator<
       return path.join(
         __dirname,
         "..",
-        process.env.NODE_ENV === "test" ? "./templates" : "./dist/templates",
+        process.env.NODE_ENV === "test" ? "./templates" : "./templates",
         this.sourceRoot.path,
         ...paths,
       )

--- a/packages/generator/src/generators/app-generator.ts
+++ b/packages/generator/src/generators/app-generator.ts
@@ -126,6 +126,9 @@ export class AppGenerator extends Generator<AppGeneratorOptions> {
     pkg.dependencies = newDependencies
     pkg.devDependencies = newDevDependencies
     pkg.dependencies.blitz = blitzDependencyVersion
+    pkg.dependencies["@blitzjs/next"] = blitzDependencyVersion
+    pkg.dependencies["@blitzjs/rpc"] = blitzDependencyVersion
+    pkg.dependencies["@blitzjs/auth"] = blitzDependencyVersion
 
     const fallbackUsed = dependenciesUsedFallback || devDependenciesUsedFallback
 

--- a/packages/generator/templates/app/app/auth/mutations/forgotPassword.test.ts
+++ b/packages/generator/templates/app/app/auth/mutations/forgotPassword.test.ts
@@ -9,8 +9,8 @@ beforeEach(async () => {
 })
 
 const generatedToken = "plain-token"
-jest.mock("blitz", () => ({
-  ...jest.requireActual<Record<string, unknown>>("blitz")!,
+jest.mock("@blitzjs/auth", () => ({
+  ...jest.requireActual<Record<string, unknown>>("@blitzjs/auth")!,
   generateToken: () => generatedToken,
 }))
 jest.mock("preview-email", () => jest.fn())

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4917,7 +4917,6 @@ packages:
       typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/experimental-utils/5.28.0_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -8572,7 +8571,6 @@ packages:
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
 
   /eslint-config-next/12.2.3_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -8610,7 +8608,6 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: ">=7.0.0"
-    dev: false
 
   /eslint-config-prettier/8.5.0_eslint@7.32.0:
     resolution:
@@ -11127,7 +11124,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.7.0_fxg3r7oju3tntkxsvleuiot4fa
+      ts-node: 10.7.0_typescript@4.6.3
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -16255,6 +16252,7 @@ packages:
       typescript: 4.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: false
 
   /ts-node/10.7.0_typescript@4.6.3:
     resolution:
@@ -16287,7 +16285,6 @@ packages:
       typescript: 4.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: false
 
   /tsconfig-paths/3.14.1:
     resolution:


### PR DESCRIPTION
Closes: ?

### What are the changes and their implications?

Mocks @blitzjs/auth instead of blitz inside the forgotPassword mutation test & hardcodes blitz package version types instead of just using the alpha tag.