### PR TITLE
Runs codegen on build & remove stopWatcher console log

### DIFF
--- a/.changeset/green-pillows-hammer.md
+++ b/.changeset/green-pillows-hammer.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Runs the codegen on the blitz build command

--- a/packages/blitz/src/cli/commands/codegen.ts
+++ b/packages/blitz/src/cli/commands/codegen.ts
@@ -1,37 +1,15 @@
 import {CliCommand} from "../index"
+import {codegenTasks} from "../utils/codegen-tasks"
 /* @ts-ignore */
-import {generateManifest} from "../utils/routes-manifest"
-import resolveCwd from "resolve-cwd"
-import {join} from "path"
-import fs from "fs-extra"
 
 const codegen: CliCommand = async () => {
   try {
-    /* 
-      Updates the user's nextjs file and adds onRecoverableError to the hydrateRoot 3rd parameter object.
-      We can remove this when https://github.com/vercel/next.js/pull/38207 is merged into next.js
-    */
-    const nextDir = await resolveCwd("next")
-    const nextClientIndex = join(nextDir, "../..", "client", "index.js")
-    const readFile = await fs.readFile(nextClientIndex)
-    const updatedFile = readFile
-      .toString()
-      .replace(
-        /ReactDOM\.hydrateRoot\(.*?\);/,
-        `ReactDOM.hydrateRoot(domEl, reactEl, process.env.NODE_ENV === 'development' ? {onRecoverableError: (err) => err.toString().includes("could not finish this Suspense boundary") ? null : console.error(err)} : undefined);`,
-      )
-    await fs.writeFile(nextClientIndex, updatedFile)
+    await codegenTasks()
+    process.exit(0)
   } catch (err) {
     console.log(err)
+    process.exit(1)
   }
-
-  try {
-    await generateManifest()
-  } catch (err) {
-    console.log(err)
-  }
-
-  process.exit(0)
 }
 
 export {codegen}

--- a/packages/blitz/src/cli/commands/next/build.ts
+++ b/packages/blitz/src/cli/commands/next/build.ts
@@ -15,7 +15,7 @@ const build: CliCommand = async () => {
   const config: ServerConfig = {
     rootFolder: process.cwd(),
     inspect: nextArgs["--inspect"],
-    env: process.env.NODE_ENV === "production" ? "prod" : "dev",
+    env: "prod",
   }
 
   await import("../../utils/next-commands").then((i) => i.build(config))

--- a/packages/blitz/src/cli/utils/codegen-tasks.ts
+++ b/packages/blitz/src/cli/utils/codegen-tasks.ts
@@ -1,0 +1,34 @@
+import {generateManifest} from "./routes-manifest"
+import {log} from "../../logging"
+import resolveCwd from "resolve-cwd"
+import {join} from "path"
+import fs from "fs-extra"
+
+export const codegenTasks = async () => {
+  try {
+    /* 
+      Updates the user's nextjs file and adds onRecoverableError to the hydrateRoot 3rd parameter object.
+      We can remove this when https://github.com/vercel/next.js/pull/38207 is merged into next.js
+    */
+    const nextDir = await resolveCwd("next")
+    const nextClientIndex = join(nextDir, "../..", "client", "index.js")
+    const readFile = await fs.readFile(nextClientIndex)
+    const updatedFile = readFile
+      .toString()
+      .replace(
+        /ReactDOM\.hydrateRoot\(.*?\);/,
+        `ReactDOM.hydrateRoot(domEl, reactEl, process.env.NODE_ENV === 'development' ? {onRecoverableError: (err) => err.toString().includes("could not finish this Suspense boundary") ? null : console.error(err)} : undefined);`,
+      )
+    await fs.writeFile(nextClientIndex, updatedFile)
+    log.success("Next.js patched for suspense error issue")
+  } catch (err) {
+    log.error(err)
+  }
+
+  try {
+    await generateManifest()
+    log.success("Routes manifest generated")
+  } catch (err) {
+    log.error(err)
+  }
+}

--- a/packages/blitz/src/cli/utils/next-commands.ts
+++ b/packages/blitz/src/cli/utils/next-commands.ts
@@ -9,10 +9,11 @@ import {
 } from "./next-utils"
 import {checkLatestVersion} from "./check-latest-version"
 import {readBlitzConfig} from "../../server-utils"
+import {codegenTasks} from "./codegen-tasks"
 
 export async function build(config: ServerConfig) {
   const {rootFolder, nextBin, watch} = await normalize(config)
-
+  await codegenTasks()
   await nextBuild(nextBin, rootFolder, {} as any, config)
   if (customServerExists()) await buildCustomServer({watch})
 }

--- a/packages/blitz/src/cli/utils/routes-manifest.ts
+++ b/packages/blitz/src/cli/utils/routes-manifest.ts
@@ -590,7 +590,7 @@ export async function stopWatcher(): Promise<void> {
   if (!webpackWatcher) {
     return
   }
-  console.log("stopWatcher")
+
   webpackWatcher.close()
   webpackWatcher = null
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11124,7 +11124,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.7.0_typescript@4.6.3
+      ts-node: 10.7.0_fxg3r7oju3tntkxsvleuiot4fa
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -16252,7 +16252,6 @@ packages:
       typescript: 4.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: false
 
   /ts-node/10.7.0_typescript@4.6.3:
     resolution:
@@ -16285,6 +16284,7 @@ packages:
       typescript: 4.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: false
 
   /tsconfig-paths/3.14.1:
     resolution:


### PR DESCRIPTION
Closes: ?

### What are the changes and their implications?

- Puts codegen into a util file then calls it before next build & still on the codegen command
- Removes the left over console.log from webpack watcher stopping