### PR TITLE
Fixes loading production env variables by default for blitz build command

### DIFF
--- a/.changeset/fair-carrots-guess.md
+++ b/.changeset/fair-carrots-guess.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Fixes loading production env variables by default for blitz build command

--- a/packages/blitz/src/cli/index.ts
+++ b/packages/blitz/src/cli/index.ts
@@ -124,7 +124,6 @@ async function main() {
   if (args["--env"]) {
     process.env.APP_ENV = args["--env"]
   }
-  loadEnvConfig(process.cwd(), undefined, {error: console.error, info: console.info})
 
   // Version is inlined into the file using taskr build pipeline
   if (args["_"].length === 0 && args["--version"]) {
@@ -145,7 +144,7 @@ async function main() {
   }
 
   process.env.NODE_ENV = process.env.NODE_ENV || defaultEnv
-
+  loadEnvConfig(process.cwd(), undefined, {error: console.error, info: console.info})
   // Make sure commands gracefully respect termination signals (e.g. from Docker)
   process.on("SIGTERM", () => process.exit(0))
   process.on("SIGINT", () => process.exit(0))


### PR DESCRIPTION
### What are the changes and their implications?

Runs `loadEnvConfig()` after setting `process.env.NODE_ENV`
