### PR TITLE
Fixes the supports-color warning for pnpm

### DIFF
--- a/packages/blitz-auth/package.json
+++ b/packages/blitz-auth/package.json
@@ -55,5 +55,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "resolutions": {
+    "supports-color": "8"
   }
 }

--- a/packages/blitz-next/package.json
+++ b/packages/blitz-next/package.json
@@ -61,5 +61,8 @@
   "peerDependencies": {
     "next": ">=12.2.0",
     "react": "*"
+  },
+  "resolutions": {
+    "supports-color": "8"
   }
 }

--- a/packages/blitz-rpc/package.json
+++ b/packages/blitz-rpc/package.json
@@ -48,5 +48,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "resolutions": {
+    "supports-color": "8"
   }
 }

--- a/packages/blitz/package.json
+++ b/packages/blitz/package.json
@@ -83,5 +83,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "resolutions": {
+    "supports-color": "8"
   }
 }

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -47,5 +47,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "resolutions": {
+    "supports-color": "8"
   }
 }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -73,5 +73,8 @@
   },
   "peerDependencies": {
     "react": "*"
+  },
+  "resolutions": {
+    "supports-color": "8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11124,7 +11124,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.7.0_fxg3r7oju3tntkxsvleuiot4fa
+      ts-node: 10.7.0_typescript@4.6.3
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -16252,6 +16252,7 @@ packages:
       typescript: 4.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: false
 
   /ts-node/10.7.0_typescript@4.6.3:
     resolution:
@@ -16284,7 +16285,6 @@ packages:
       typescript: 4.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: false
 
   /tsconfig-paths/3.14.1:
     resolution:


### PR DESCRIPTION
Closes: #3580

### What are the changes and their implications?
Adds
```js
  "resolutions": {
    "supports-color": "8"
  }
``` 
to each package.json 
