### PR TITLE
Fixes the supports-color warning for pnpm

### DIFF
--- a/.changeset/spicy-beds-float.md
+++ b/.changeset/spicy-beds-float.md
@@ -1,0 +1,8 @@
+---
+"@blitzjs/auth": patch
+"@blitzjs/next": patch
+"@blitzjs/rpc": patch
+"blitz": patch
+"@blitzjs/generator": patch
+---
+Fixes the supports-color warning for pnpm

--- a/packages/blitz-auth/package.json
+++ b/packages/blitz-auth/package.json
@@ -36,6 +36,7 @@
     "passport": "0.5.2",
     "path": "0.12.7",
     "secure-password": "4.0.0",
+    "supports-color": "8.1.1",
     "url": "0.11.0"
   },
   "devDependencies": {

--- a/packages/blitz-next/package.json
+++ b/packages/blitz-next/package.json
@@ -30,7 +30,8 @@
     "debug": "4.3.3",
     "fs-extra": "10.0.1",
     "hoist-non-react-statics": "3.3.2",
-    "superjson": "1.8.0"
+    "superjson": "1.8.0",
+    "supports-color": "8.1.1"
   },
   "devDependencies": {
     "@blitzjs/config": "workspace:2.0.0-alpha.65",

--- a/packages/blitz-rpc/package.json
+++ b/packages/blitz-rpc/package.json
@@ -27,6 +27,7 @@
     "chalk": "^4.1.0",
     "debug": "4.3.3",
     "superjson": "1.8.0",
+    "supports-color": "8.1.1",
     "zod": "3.17.3"
   },
   "devDependencies": {

--- a/packages/blitz/package.json
+++ b/packages/blitz/package.json
@@ -48,6 +48,7 @@
     "resolve-cwd": "3.0.0",
     "resolve-from": "5.0.0",
     "superjson": "1.8.0",
+    "supports-color": "8.1.1",
     "ts-node": "10.7.0",
     "tsconfig-paths": "4.0.0",
     "tslog": "3.3.1",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -40,6 +40,7 @@
     "pluralize": "8.0.0",
     "prettier": "^2.5.1",
     "recast": "0.20.5",
+    "supports-color": "8.1.1",
     "tslog": "3.3.1",
     "username": "5.1.0",
     "vinyl": "2.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,6 +518,7 @@ importers:
       resolve-cwd: 3.0.0
       resolve-from: 5.0.0
       superjson: 1.8.0
+      supports-color: 8.1.1
       test-listen: 1.1.0
       ts-node: 10.7.0
       tsconfig-paths: 4.0.0
@@ -534,8 +535,8 @@ importers:
       chalk: 4.1.2
       console-table-printer: 2.10.0
       cross-spawn: 7.0.3
-      debug: 4.3.3
-      detect-port: 1.3.0
+      debug: 4.3.3_supports-color@8.1.1
+      detect-port: 1.3.0_supports-color@8.1.1
       dotenv: 16.0.0
       dotenv-expand: 8.0.3
       envinfo: 7.8.1
@@ -552,7 +553,8 @@ importers:
       prompts: 2.4.2
       resolve-cwd: 3.0.0
       resolve-from: 5.0.0
-      superjson: 1.8.0
+      superjson: 1.8.0_supports-color@8.1.1
+      supports-color: 8.1.1
       ts-node: 10.7.0_typescript@4.6.3
       tsconfig-paths: 4.0.0
       tslog: 3.3.1
@@ -574,11 +576,11 @@ importers:
       "@types/react-dom": 17.0.14
       "@types/test-listen": 1.1.0
       "@types/watchpack": 1.1.1
-      express: 4.17.3
+      express: 4.17.3_supports-color@8.1.1
       react: 18.0.0
       test-listen: 1.1.0
       typescript: 4.6.3
-      unbuild: 0.7.6
+      unbuild: 0.7.6_supports-color@8.1.1
       watch: 1.0.2
       zod: 3.17.3
 
@@ -610,6 +612,7 @@ importers:
       react: 18.0.0
       react-dom: 18.0.0
       secure-password: 4.0.0
+      supports-color: 8.1.1
       typescript: ^4.5.3
       unbuild: 0.7.6
       url: 0.11.0
@@ -623,14 +626,15 @@ importers:
       bad-behavior: 1.0.1
       blitz: link:../blitz
       cookie: 0.4.1
-      cookie-session: 2.0.0
-      debug: 4.3.3
+      cookie-session: 2.0.0_supports-color@8.1.1
+      debug: 4.3.3_supports-color@8.1.1
       http: 0.0.1-security
       jsonwebtoken: 8.5.1
       nanoid: 3.2.0
       passport: 0.5.2
       path: 0.12.7
       secure-password: 4.0.0
+      supports-color: 8.1.1
       url: 0.11.0
     devDependencies:
       "@blitzjs/config": link:../config
@@ -644,7 +648,7 @@ importers:
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
       typescript: 4.6.3
-      unbuild: 0.7.6
+      unbuild: 0.7.6_supports-color@8.1.1
       watch: 1.0.2
 
   packages/blitz-next:
@@ -673,6 +677,7 @@ importers:
       react-dom: 18.0.0
       resolve-from: 5.0.0
       superjson: 1.8.0
+      supports-color: 8.1.1
       ts-jest: 27.1.4
       typescript: ^4.5.3
       unbuild: 0.7.6
@@ -681,10 +686,11 @@ importers:
       "@blitzjs/rpc": link:../blitz-rpc
       "@tanstack/react-query": 4.0.10_zpnidt7m3osuk7shl3s4oenomq
       "@types/hoist-non-react-statics": 3.3.1
-      debug: 4.3.3
+      debug: 4.3.3_supports-color@8.1.1
       fs-extra: 10.0.1
       hoist-non-react-statics: 3.3.2
-      superjson: 1.8.0
+      superjson: 1.8.0_supports-color@8.1.1
+      supports-color: 8.1.1
     devDependencies:
       "@blitzjs/config": link:../config
       "@testing-library/dom": 8.13.0
@@ -705,7 +711,7 @@ importers:
       resolve-from: 5.0.0
       ts-jest: 27.1.4_typescript@4.6.3
       typescript: 4.6.3
-      unbuild: 0.7.6
+      unbuild: 0.7.6_supports-color@8.1.1
       watch: 1.0.2
 
   packages/blitz-rpc:
@@ -725,6 +731,7 @@ importers:
       react: 18.0.0
       react-dom: 18.0.0
       superjson: 1.8.0
+      supports-color: 8.1.1
       typescript: ^4.5.3
       unbuild: 0.7.6
       watch: 1.0.2
@@ -735,8 +742,9 @@ importers:
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
       chalk: 4.1.2
-      debug: 4.3.3
-      superjson: 1.8.0
+      debug: 4.3.3_supports-color@8.1.1
+      superjson: 1.8.0_supports-color@8.1.1
+      supports-color: 8.1.1
       zod: 3.17.3
     devDependencies:
       "@blitzjs/config": link:../config
@@ -748,7 +756,7 @@ importers:
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
       typescript: 4.6.3
-      unbuild: 0.7.6
+      unbuild: 0.7.6_supports-color@8.1.1
       watch: 1.0.2
 
   packages/codemod:
@@ -854,6 +862,7 @@ importers:
       prettier: ^2.5.1
       react: 18.0.0
       recast: 0.20.5
+      supports-color: 8.1.1
       tslog: 3.3.1
       typescript: ^4.5.3
       unbuild: 0.6.9
@@ -861,9 +870,9 @@ importers:
       vinyl: 2.2.1
       watch: 1.0.2
     dependencies:
-      "@babel/core": 7.12.10
-      "@babel/plugin-transform-typescript": 7.12.1_@babel+core@7.12.10
-      "@babel/preset-env": 7.12.10_@babel+core@7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/plugin-transform-typescript": 7.12.1_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/preset-env": 7.12.10_ps3yxa7qdojvlda5ukda3zlwie
       "@babel/types": 7.12.10
       "@mrleebo/prisma-ast": 0.2.6
       chalk: 4.1.2
@@ -873,7 +882,7 @@ importers:
       enquirer: 2.3.6
       fs-extra: 10.0.1
       got: 11.8.5
-      jscodeshift: 0.13.0_@babel+preset-env@7.12.10
+      jscodeshift: 0.13.0_slgjdbbopna4ebnpdn2nkn3v2a
       mem-fs: 1.2.0
       mem-fs-editor: 8.0.0
       npm-which: 3.0.1
@@ -881,12 +890,13 @@ importers:
       pluralize: 8.0.0
       prettier: 2.6.2
       recast: 0.20.5
+      supports-color: 8.1.1
       tslog: 3.3.1
       username: 5.1.0
       vinyl: 2.2.1
     devDependencies:
       "@blitzjs/config": link:../config
-      "@juanm04/cpx": 2.0.1
+      "@juanm04/cpx": 2.0.1_supports-color@8.1.1
       "@types/babel__core": 7.1.19
       "@types/diff": 5.0.2
       "@types/fs-extra": 9.0.13
@@ -898,14 +908,14 @@ importers:
       "@types/react": 18.0.1
       "@types/react-dom": 17.0.14
       "@types/vinyl": 2.0.6
-      "@typescript-eslint/eslint-plugin": 5.9.1_rvfvfrvgktle2hmlnfpjw2zp4u
-      "@typescript-eslint/parser": 5.9.1_hrkuebk64jiu2ut2d2sm4oylnu
+      "@typescript-eslint/eslint-plugin": 5.9.1_2anf7xzu4gv3hdfa2vphlhds3y
+      "@typescript-eslint/parser": 5.9.1_ep4k34urm5hxazyxrevmf7goie
       babylon: 6.18.0
-      debug: 4.3.3
-      eslint: 7.32.0
+      debug: 4.3.3_supports-color@8.1.1
+      eslint: 7.32.0_supports-color@8.1.1
       react: 18.0.0
       typescript: 4.6.3
-      unbuild: 0.6.9
+      unbuild: 0.6.9_supports-color@8.1.1
       watch: 1.0.2
 
   packages/pkg-template:
@@ -992,6 +1002,31 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/core/7.12.10_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==,
+      }
+    engines: {node: ">=6.9.0"}
+    dependencies:
+      "@babel/code-frame": 7.16.7
+      "@babel/generator": 7.18.2
+      "@babel/helper-module-transforms": 7.18.0_supports-color@8.1.1
+      "@babel/helpers": 7.18.2_supports-color@8.1.1
+      "@babel/parser": 7.18.4
+      "@babel/template": 7.16.7
+      "@babel/traverse": 7.18.2_supports-color@8.1.1
+      "@babel/types": 7.18.4
+      convert-source-map: 1.8.0
+      debug: 4.3.4_supports-color@8.1.1
+      gensync: 1.0.0-beta.2
+      json5: 2.2.1
+      lodash: 4.17.21
+      semver: 5.7.1
+      source-map: 0.5.7
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/core/7.18.2:
     resolution:
       {
@@ -1011,6 +1046,31 @@ packages:
       "@babel/types": 7.18.4
       convert-source-map: 1.8.0
       debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.1
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/core/7.18.2_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==,
+      }
+    engines: {node: ">=6.9.0"}
+    dependencies:
+      "@ampproject/remapping": 2.2.0
+      "@babel/code-frame": 7.16.7
+      "@babel/generator": 7.18.2
+      "@babel/helper-compilation-targets": 7.18.2_@babel+core@7.18.2
+      "@babel/helper-module-transforms": 7.18.0_supports-color@8.1.1
+      "@babel/helpers": 7.18.2_supports-color@8.1.1
+      "@babel/parser": 7.18.4
+      "@babel/template": 7.16.7
+      "@babel/traverse": 7.18.2_supports-color@8.1.1
+      "@babel/types": 7.18.4
+      convert-source-map: 1.8.0
+      debug: 4.3.4_supports-color@8.1.1
       gensync: 1.0.0-beta.2
       json5: 2.2.1
       semver: 6.3.0
@@ -1057,7 +1117,7 @@ packages:
       "@babel/core": ^7.0.0
     dependencies:
       "@babel/compat-data": 7.17.10
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-validator-option": 7.16.7
       browserslist: 4.20.3
       semver: 6.3.0
@@ -1072,7 +1132,7 @@ packages:
       "@babel/core": ^7.0.0
     dependencies:
       "@babel/compat-data": 7.17.10
-      "@babel/core": 7.18.2
+      "@babel/core": 7.18.2_supports-color@8.1.1
       "@babel/helper-validator-option": 7.16.7
       browserslist: 4.20.3
       semver: 6.3.0
@@ -1118,22 +1178,43 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/helper-create-class-features-plugin/7.18.0_@babel+core@7.12.10:
+  /@babel/helper-create-class-features-plugin/7.17.12_aiglbhfglusiuujjiuminyg6ui:
     resolution:
       {
-        integrity: sha512-Kh8zTGR9de3J63e5nS0rQUdRs/kbtwoeQQ0sriS0lItjC96u8XXZN6lKpuyWd2coKSU13py/y+LTmThLuVX0Pg==,
+        integrity: sha512-sZoOeUTkFJMyhqCei2+Z+wtH/BehW8NVKQt7IRUQlRiOARuXymJYfN/FCcI8CvVbR0XVyDM6eLFOlR7YtiXnew==,
       }
     engines: {node: ">=6.9.0"}
     peerDependencies:
       "@babel/core": ^7.0.0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.18.2_supports-color@8.1.1
       "@babel/helper-annotate-as-pure": 7.16.7
       "@babel/helper-environment-visitor": 7.18.2
       "@babel/helper-function-name": 7.17.9
       "@babel/helper-member-expression-to-functions": 7.17.7
       "@babel/helper-optimise-call-expression": 7.16.7
-      "@babel/helper-replace-supers": 7.18.2
+      "@babel/helper-replace-supers": 7.18.2_supports-color@8.1.1
+      "@babel/helper-split-export-declaration": 7.16.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@babel/helper-create-class-features-plugin/7.17.12_ps3yxa7qdojvlda5ukda3zlwie:
+    resolution:
+      {
+        integrity: sha512-sZoOeUTkFJMyhqCei2+Z+wtH/BehW8NVKQt7IRUQlRiOARuXymJYfN/FCcI8CvVbR0XVyDM6eLFOlR7YtiXnew==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0
+    dependencies:
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-annotate-as-pure": 7.16.7
+      "@babel/helper-environment-visitor": 7.18.2
+      "@babel/helper-function-name": 7.17.9
+      "@babel/helper-member-expression-to-functions": 7.17.7
+      "@babel/helper-optimise-call-expression": 7.16.7
+      "@babel/helper-replace-supers": 7.18.2_supports-color@8.1.1
       "@babel/helper-split-export-declaration": 7.16.7
     transitivePeerDependencies:
       - supports-color
@@ -1160,6 +1241,48 @@ packages:
       - supports-color
     dev: false
 
+  /@babel/helper-create-class-features-plugin/7.18.0_aiglbhfglusiuujjiuminyg6ui:
+    resolution:
+      {
+        integrity: sha512-Kh8zTGR9de3J63e5nS0rQUdRs/kbtwoeQQ0sriS0lItjC96u8XXZN6lKpuyWd2coKSU13py/y+LTmThLuVX0Pg==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0
+    dependencies:
+      "@babel/core": 7.18.2_supports-color@8.1.1
+      "@babel/helper-annotate-as-pure": 7.16.7
+      "@babel/helper-environment-visitor": 7.18.2
+      "@babel/helper-function-name": 7.17.9
+      "@babel/helper-member-expression-to-functions": 7.17.7
+      "@babel/helper-optimise-call-expression": 7.16.7
+      "@babel/helper-replace-supers": 7.18.2_supports-color@8.1.1
+      "@babel/helper-split-export-declaration": 7.16.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@babel/helper-create-class-features-plugin/7.18.0_ps3yxa7qdojvlda5ukda3zlwie:
+    resolution:
+      {
+        integrity: sha512-Kh8zTGR9de3J63e5nS0rQUdRs/kbtwoeQQ0sriS0lItjC96u8XXZN6lKpuyWd2coKSU13py/y+LTmThLuVX0Pg==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0
+    dependencies:
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-annotate-as-pure": 7.16.7
+      "@babel/helper-environment-visitor": 7.18.2
+      "@babel/helper-function-name": 7.17.9
+      "@babel/helper-member-expression-to-functions": 7.17.7
+      "@babel/helper-optimise-call-expression": 7.16.7
+      "@babel/helper-replace-supers": 7.18.2_supports-color@8.1.1
+      "@babel/helper-split-export-declaration": 7.16.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/helper-create-regexp-features-plugin/7.17.12_@babel+core@7.12.10:
     resolution:
       {
@@ -1169,7 +1292,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-annotate-as-pure": 7.16.7
       regexpu-core: 5.0.1
 
@@ -1246,6 +1369,24 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/helper-module-transforms/7.18.0_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==,
+      }
+    engines: {node: ">=6.9.0"}
+    dependencies:
+      "@babel/helper-environment-visitor": 7.18.2
+      "@babel/helper-module-imports": 7.16.7
+      "@babel/helper-simple-access": 7.18.2
+      "@babel/helper-split-export-declaration": 7.16.7
+      "@babel/helper-validator-identifier": 7.16.7
+      "@babel/template": 7.16.7
+      "@babel/traverse": 7.18.2_supports-color@8.1.1
+      "@babel/types": 7.18.4
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/helper-optimise-call-expression/7.16.7:
     resolution:
       {
@@ -1275,6 +1416,20 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/helper-remap-async-to-generator/7.16.8_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==,
+      }
+    engines: {node: ">=6.9.0"}
+    dependencies:
+      "@babel/helper-annotate-as-pure": 7.16.7
+      "@babel/helper-wrap-function": 7.16.8_supports-color@8.1.1
+      "@babel/types": 7.18.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/helper-replace-supers/7.18.2:
     resolution:
       {
@@ -1289,6 +1444,22 @@ packages:
       "@babel/types": 7.18.4
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/helper-replace-supers/7.18.2_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-XzAIyxx+vFnrOxiQrToSUOzUOn0e1J2Li40ntddek1Y69AXUTXoDJ40/D5RdjFu7s7qHiaeoTiempZcbuVXh2Q==,
+      }
+    engines: {node: ">=6.9.0"}
+    dependencies:
+      "@babel/helper-environment-visitor": 7.18.2
+      "@babel/helper-member-expression-to-functions": 7.17.7
+      "@babel/helper-optimise-call-expression": 7.16.7
+      "@babel/traverse": 7.18.2_supports-color@8.1.1
+      "@babel/types": 7.18.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@babel/helper-simple-access/7.18.2:
     resolution:
@@ -1345,6 +1516,21 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/helper-wrap-function/7.16.8_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-8RpyRVIAW1RcDDGTA+GpPAwV22wXCfKOoM9bet6TLkGIFTkRQSkH1nMQ5Yet4MpoXe1ZwHPVtNasc2w0uZMqnw==,
+      }
+    engines: {node: ">=6.9.0"}
+    dependencies:
+      "@babel/helper-function-name": 7.17.9
+      "@babel/template": 7.16.7
+      "@babel/traverse": 7.18.2_supports-color@8.1.1
+      "@babel/types": 7.18.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/helpers/7.18.2:
     resolution:
       {
@@ -1354,6 +1540,19 @@ packages:
     dependencies:
       "@babel/template": 7.16.7
       "@babel/traverse": 7.18.2
+      "@babel/types": 7.18.4
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/helpers/7.18.2_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==,
+      }
+    engines: {node: ">=6.9.0"}
+    dependencies:
+      "@babel/template": 7.16.7
+      "@babel/traverse": 7.18.2_supports-color@8.1.1
       "@babel/types": 7.18.4
     transitivePeerDependencies:
       - supports-color
@@ -1395,6 +1594,23 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-proposal-async-generator-functions/7.17.12_ps3yxa7qdojvlda5ukda3zlwie:
+    resolution:
+      {
+        integrity: sha512-RWVvqD1ooLKP6IqWTA5GyFVX2isGEgC5iFxKzfYOIy/QEFdxYyCybBDtIGjipHpb9bDWHzcqGqFakf+mVmBTdQ==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-plugin-utils": 7.17.12
+      "@babel/helper-remap-async-to-generator": 7.16.8_supports-color@8.1.1
+      "@babel/plugin-syntax-async-generators": 7.8.4_@babel+core@7.12.10
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-proposal-class-properties/7.17.12_@babel+core@7.12.10:
     resolution:
       {
@@ -1426,6 +1642,38 @@ packages:
       - supports-color
     dev: false
 
+  /@babel/plugin-proposal-class-properties/7.17.12_aiglbhfglusiuujjiuminyg6ui:
+    resolution:
+      {
+        integrity: sha512-U0mI9q8pW5Q9EaTHFPwSVusPMV/DV9Mm8p7csqROFLtIE9rBF5piLqyrBGigftALrBcsBGu4m38JneAe7ZDLXw==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.18.2_supports-color@8.1.1
+      "@babel/helper-create-class-features-plugin": 7.17.12_aiglbhfglusiuujjiuminyg6ui
+      "@babel/helper-plugin-utils": 7.17.12
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@babel/plugin-proposal-class-properties/7.17.12_ps3yxa7qdojvlda5ukda3zlwie:
+    resolution:
+      {
+        integrity: sha512-U0mI9q8pW5Q9EaTHFPwSVusPMV/DV9Mm8p7csqROFLtIE9rBF5piLqyrBGigftALrBcsBGu4m38JneAe7ZDLXw==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-create-class-features-plugin": 7.17.12_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/helper-plugin-utils": 7.17.12
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-proposal-dynamic-import/7.16.7_@babel+core@7.12.10:
     resolution:
       {
@@ -1435,7 +1683,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/plugin-syntax-dynamic-import": 7.8.3_@babel+core@7.12.10
 
@@ -1448,7 +1696,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/plugin-syntax-export-namespace-from": 7.8.3_@babel+core@7.12.10
 
@@ -1461,7 +1709,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/plugin-syntax-json-strings": 7.8.3_@babel+core@7.12.10
 
@@ -1474,7 +1722,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/plugin-syntax-logical-assignment-operators": 7.10.4_@babel+core@7.12.10
 
@@ -1487,7 +1735,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3_@babel+core@7.12.10
 
@@ -1500,7 +1748,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.18.2
+      "@babel/core": 7.18.2_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3_@babel+core@7.18.2
     dev: false
@@ -1514,7 +1762,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/plugin-syntax-numeric-separator": 7.10.4_@babel+core@7.12.10
 
@@ -1528,7 +1776,7 @@ packages:
       "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/compat-data": 7.17.10
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-compilation-targets": 7.18.2_@babel+core@7.12.10
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/plugin-syntax-object-rest-spread": 7.8.3_@babel+core@7.12.10
@@ -1543,7 +1791,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/plugin-syntax-optional-catch-binding": 7.8.3_@babel+core@7.12.10
 
@@ -1556,7 +1804,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/helper-skip-transparent-expression-wrappers": 7.16.0
       "@babel/plugin-syntax-optional-chaining": 7.8.3_@babel+core@7.12.10
@@ -1570,7 +1818,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.18.2
+      "@babel/core": 7.18.2_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/helper-skip-transparent-expression-wrappers": 7.16.0
       "@babel/plugin-syntax-optional-chaining": 7.8.3_@babel+core@7.18.2
@@ -1591,6 +1839,22 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-proposal-private-methods/7.17.12_ps3yxa7qdojvlda5ukda3zlwie:
+    resolution:
+      {
+        integrity: sha512-SllXoxo19HmxhDWm3luPz+cPhtoTSKLJE9PXshsfrOzBqs60QP0r8OaJItrPhAj0d7mZMnNF0Y1UUggCDgMz1A==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-create-class-features-plugin": 7.17.12_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/helper-plugin-utils": 7.17.12
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-proposal-unicode-property-regex/7.17.12_@babel+core@7.12.10:
     resolution:
       {
@@ -1600,7 +1864,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-create-regexp-features-plugin": 7.17.12_@babel+core@7.12.10
       "@babel/helper-plugin-utils": 7.17.12
 
@@ -1612,7 +1876,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.18.2:
@@ -1645,7 +1909,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.18.2:
@@ -1667,7 +1931,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.12.10:
@@ -1678,7 +1942,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-flow/7.17.12_@babel+core@7.18.2:
@@ -1690,7 +1954,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.18.2
+      "@babel/core": 7.18.2_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
     dev: false
 
@@ -1713,7 +1977,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.18.2:
@@ -1761,7 +2025,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.18.2:
@@ -1783,7 +2047,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.18.2:
@@ -1794,7 +2058,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.18.2
+      "@babel/core": 7.18.2_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.12.10:
@@ -1805,7 +2069,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.18.2:
@@ -1827,7 +2091,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.18.2:
@@ -1849,7 +2113,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.18.2:
@@ -1871,7 +2135,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.18.2:
@@ -1882,7 +2146,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.18.2
+      "@babel/core": 7.18.2_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.12.10:
@@ -1894,7 +2158,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.18.2:
@@ -1918,7 +2182,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
     dev: false
 
@@ -1931,7 +2195,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.18.2
+      "@babel/core": 7.18.2_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-arrow-functions/7.17.12_@babel+core@7.12.10:
@@ -1943,7 +2207,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-async-to-generator/7.17.12_@babel+core@7.12.10:
@@ -1962,6 +2226,23 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-transform-async-to-generator/7.17.12_ps3yxa7qdojvlda5ukda3zlwie:
+    resolution:
+      {
+        integrity: sha512-J8dbrWIOO3orDzir57NRsjg4uxucvhby0L/KZuGsWDj0g7twWK3g7JhJhOrXtuXiw8MeiSdJ3E0OW9H8LYEzLQ==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-module-imports": 7.16.7
+      "@babel/helper-plugin-utils": 7.17.12
+      "@babel/helper-remap-async-to-generator": 7.16.8_supports-color@8.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-transform-block-scoped-functions/7.16.7_@babel+core@7.12.10:
     resolution:
       {
@@ -1971,7 +2252,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-block-scoping/7.18.4_@babel+core@7.12.10:
@@ -1983,7 +2264,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-classes/7.18.4_@babel+core@7.12.10:
@@ -2007,6 +2288,28 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-transform-classes/7.18.4_ps3yxa7qdojvlda5ukda3zlwie:
+    resolution:
+      {
+        integrity: sha512-e42NSG2mlKWgxKUAD9EJJSkZxR67+wZqzNxLSpc51T8tRU5SLFHsPmgYR5yr7sdgX4u+iHA1C5VafJ6AyImV3A==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-annotate-as-pure": 7.16.7
+      "@babel/helper-environment-visitor": 7.18.2
+      "@babel/helper-function-name": 7.17.9
+      "@babel/helper-optimise-call-expression": 7.16.7
+      "@babel/helper-plugin-utils": 7.17.12
+      "@babel/helper-replace-supers": 7.18.2_supports-color@8.1.1
+      "@babel/helper-split-export-declaration": 7.16.7
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-transform-computed-properties/7.17.12_@babel+core@7.12.10:
     resolution:
       {
@@ -2016,7 +2319,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-destructuring/7.18.0_@babel+core@7.12.10:
@@ -2028,7 +2331,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-dotall-regex/7.16.7_@babel+core@7.12.10:
@@ -2040,7 +2343,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-create-regexp-features-plugin": 7.17.12_@babel+core@7.12.10
       "@babel/helper-plugin-utils": 7.17.12
 
@@ -2053,7 +2356,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-exponentiation-operator/7.16.7_@babel+core@7.12.10:
@@ -2065,7 +2368,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-builder-binary-assignment-operator-visitor": 7.16.7
       "@babel/helper-plugin-utils": 7.17.12
 
@@ -2078,7 +2381,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.18.2
+      "@babel/core": 7.18.2_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/plugin-syntax-flow": 7.17.12_@babel+core@7.18.2
     dev: false
@@ -2092,7 +2395,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-function-name/7.16.7_@babel+core@7.12.10:
@@ -2104,7 +2407,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-compilation-targets": 7.18.2_@babel+core@7.12.10
       "@babel/helper-function-name": 7.17.9
       "@babel/helper-plugin-utils": 7.17.12
@@ -2118,7 +2421,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-member-expression-literals/7.16.7_@babel+core@7.12.10:
@@ -2130,7 +2433,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-modules-amd/7.18.0_@babel+core@7.12.10:
@@ -2148,6 +2451,23 @@ packages:
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/plugin-transform-modules-amd/7.18.0_ps3yxa7qdojvlda5ukda3zlwie:
+    resolution:
+      {
+        integrity: sha512-h8FjOlYmdZwl7Xm2Ug4iX2j7Qy63NANI+NQVWQzv6r25fqgg7k2dZl03p95kvqNclglHs4FZ+isv4p1uXMA+QA==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-module-transforms": 7.18.0_supports-color@8.1.1
+      "@babel/helper-plugin-utils": 7.17.12
+      babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@babel/plugin-transform-modules-commonjs/7.18.2_@babel+core@7.12.10:
     resolution:
@@ -2184,6 +2504,42 @@ packages:
       - supports-color
     dev: false
 
+  /@babel/plugin-transform-modules-commonjs/7.18.2_aiglbhfglusiuujjiuminyg6ui:
+    resolution:
+      {
+        integrity: sha512-f5A865gFPAJAEE0K7F/+nm5CmAE3y8AWlMBG9unu5j9+tk50UQVK0QS8RNxSp7MJf0wh97uYyLWt3Zvu71zyOQ==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.18.2_supports-color@8.1.1
+      "@babel/helper-module-transforms": 7.18.0_supports-color@8.1.1
+      "@babel/helper-plugin-utils": 7.17.12
+      "@babel/helper-simple-access": 7.18.2
+      babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@babel/plugin-transform-modules-commonjs/7.18.2_ps3yxa7qdojvlda5ukda3zlwie:
+    resolution:
+      {
+        integrity: sha512-f5A865gFPAJAEE0K7F/+nm5CmAE3y8AWlMBG9unu5j9+tk50UQVK0QS8RNxSp7MJf0wh97uYyLWt3Zvu71zyOQ==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-module-transforms": 7.18.0_supports-color@8.1.1
+      "@babel/helper-plugin-utils": 7.17.12
+      "@babel/helper-simple-access": 7.18.2
+      babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-transform-modules-systemjs/7.18.4_@babel+core@7.12.10:
     resolution:
       {
@@ -2202,6 +2558,25 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-transform-modules-systemjs/7.18.4_ps3yxa7qdojvlda5ukda3zlwie:
+    resolution:
+      {
+        integrity: sha512-lH2UaQaHVOAeYrUUuZ8i38o76J/FnO8vu21OE+tD1MyP9lxdZoSfz+pDbWkq46GogUrdrMz3tiz/FYGB+bVThg==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-hoist-variables": 7.16.7
+      "@babel/helper-module-transforms": 7.18.0_supports-color@8.1.1
+      "@babel/helper-plugin-utils": 7.17.12
+      "@babel/helper-validator-identifier": 7.16.7
+      babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-transform-modules-umd/7.18.0_@babel+core@7.12.10:
     resolution:
       {
@@ -2217,6 +2592,22 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-transform-modules-umd/7.18.0_ps3yxa7qdojvlda5ukda3zlwie:
+    resolution:
+      {
+        integrity: sha512-d/zZ8I3BWli1tmROLxXLc9A6YXvGK8egMxHp+E/rRwMh1Kip0AP77VwZae3snEJ33iiWwvNv2+UIIhfalqhzZA==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-module-transforms": 7.18.0_supports-color@8.1.1
+      "@babel/helper-plugin-utils": 7.17.12
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-transform-named-capturing-groups-regex/7.17.12_@babel+core@7.12.10:
     resolution:
       {
@@ -2226,7 +2617,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-create-regexp-features-plugin": 7.17.12_@babel+core@7.12.10
       "@babel/helper-plugin-utils": 7.17.12
 
@@ -2239,7 +2630,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-object-super/7.16.7_@babel+core@7.12.10:
@@ -2257,6 +2648,22 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-transform-object-super/7.16.7_ps3yxa7qdojvlda5ukda3zlwie:
+    resolution:
+      {
+        integrity: sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-plugin-utils": 7.17.12
+      "@babel/helper-replace-supers": 7.18.2_supports-color@8.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-transform-parameters/7.17.12_@babel+core@7.12.10:
     resolution:
       {
@@ -2266,7 +2673,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-property-literals/7.16.7_@babel+core@7.12.10:
@@ -2278,7 +2685,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-react-jsx-development/7.16.7_@babel+core@7.18.2:
@@ -2346,7 +2753,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       regenerator-transform: 0.15.0
 
@@ -2359,7 +2766,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-shorthand-properties/7.16.7_@babel+core@7.12.10:
@@ -2371,7 +2778,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-spread/7.17.12_@babel+core@7.12.10:
@@ -2383,7 +2790,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/helper-skip-transparent-expression-wrappers": 7.16.0
 
@@ -2396,7 +2803,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-template-literals/7.18.2_@babel+core@7.12.10:
@@ -2408,7 +2815,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-typeof-symbol/7.17.12_@babel+core@7.12.10:
@@ -2420,10 +2827,10 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
-  /@babel/plugin-transform-typescript/7.12.1_@babel+core@7.12.10:
+  /@babel/plugin-transform-typescript/7.12.1_ps3yxa7qdojvlda5ukda3zlwie:
     resolution:
       {
         integrity: sha512-VrsBByqAIntM+EYMqSm59SiMEf7qkmI9dqMt6RbD/wlwueWmYcI0FFK5Fj47pP6DRZm+3teXjosKlwcZJ5lIMw==,
@@ -2431,8 +2838,8 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
-      "@babel/helper-create-class-features-plugin": 7.18.0_@babel+core@7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-create-class-features-plugin": 7.18.0_ps3yxa7qdojvlda5ukda3zlwie
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/plugin-syntax-typescript": 7.17.12_@babel+core@7.12.10
     transitivePeerDependencies:
@@ -2456,6 +2863,23 @@ packages:
       - supports-color
     dev: false
 
+  /@babel/plugin-transform-typescript/7.18.4_aiglbhfglusiuujjiuminyg6ui:
+    resolution:
+      {
+        integrity: sha512-l4vHuSLUajptpHNEOUDEGsnpl9pfRLsN1XUoDQDD/YBuXTM+v37SHGS+c6n4jdcZy96QtuUuSvZYMLSSsjH8Mw==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.18.2_supports-color@8.1.1
+      "@babel/helper-create-class-features-plugin": 7.18.0_aiglbhfglusiuujjiuminyg6ui
+      "@babel/helper-plugin-utils": 7.17.12
+      "@babel/plugin-syntax-typescript": 7.17.12_@babel+core@7.18.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-transform-unicode-escapes/7.16.7_@babel+core@7.12.10:
     resolution:
       {
@@ -2465,7 +2889,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
 
   /@babel/plugin-transform-unicode-regex/7.16.7_@babel+core@7.12.10:
@@ -2477,7 +2901,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-create-regexp-features-plugin": 7.17.12_@babel+core@7.12.10
       "@babel/helper-plugin-utils": 7.17.12
 
@@ -2559,6 +2983,85 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/preset-env/7.12.10_ps3yxa7qdojvlda5ukda3zlwie:
+    resolution:
+      {
+        integrity: sha512-Gz9hnBT/tGeTE2DBNDkD7BiWRELZt+8lSysHuDwmYXUIvtwZl0zI+D6mZgXZX0u8YBlLS4tmai9ONNY9tjRgRA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/compat-data": 7.17.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/helper-compilation-targets": 7.18.2_@babel+core@7.12.10
+      "@babel/helper-module-imports": 7.16.7
+      "@babel/helper-plugin-utils": 7.17.12
+      "@babel/helper-validator-option": 7.16.7
+      "@babel/plugin-proposal-async-generator-functions": 7.17.12_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/plugin-proposal-class-properties": 7.17.12_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/plugin-proposal-dynamic-import": 7.16.7_@babel+core@7.12.10
+      "@babel/plugin-proposal-export-namespace-from": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-proposal-json-strings": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-proposal-logical-assignment-operators": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-proposal-nullish-coalescing-operator": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-proposal-numeric-separator": 7.16.7_@babel+core@7.12.10
+      "@babel/plugin-proposal-object-rest-spread": 7.18.0_@babel+core@7.12.10
+      "@babel/plugin-proposal-optional-catch-binding": 7.16.7_@babel+core@7.12.10
+      "@babel/plugin-proposal-optional-chaining": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-proposal-private-methods": 7.17.12_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/plugin-proposal-unicode-property-regex": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-syntax-async-generators": 7.8.4_@babel+core@7.12.10
+      "@babel/plugin-syntax-class-properties": 7.12.13_@babel+core@7.12.10
+      "@babel/plugin-syntax-dynamic-import": 7.8.3_@babel+core@7.12.10
+      "@babel/plugin-syntax-export-namespace-from": 7.8.3_@babel+core@7.12.10
+      "@babel/plugin-syntax-json-strings": 7.8.3_@babel+core@7.12.10
+      "@babel/plugin-syntax-logical-assignment-operators": 7.10.4_@babel+core@7.12.10
+      "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3_@babel+core@7.12.10
+      "@babel/plugin-syntax-numeric-separator": 7.10.4_@babel+core@7.12.10
+      "@babel/plugin-syntax-object-rest-spread": 7.8.3_@babel+core@7.12.10
+      "@babel/plugin-syntax-optional-catch-binding": 7.8.3_@babel+core@7.12.10
+      "@babel/plugin-syntax-optional-chaining": 7.8.3_@babel+core@7.12.10
+      "@babel/plugin-syntax-top-level-await": 7.14.5_@babel+core@7.12.10
+      "@babel/plugin-transform-arrow-functions": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-transform-async-to-generator": 7.17.12_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/plugin-transform-block-scoped-functions": 7.16.7_@babel+core@7.12.10
+      "@babel/plugin-transform-block-scoping": 7.18.4_@babel+core@7.12.10
+      "@babel/plugin-transform-classes": 7.18.4_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/plugin-transform-computed-properties": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-transform-destructuring": 7.18.0_@babel+core@7.12.10
+      "@babel/plugin-transform-dotall-regex": 7.16.7_@babel+core@7.12.10
+      "@babel/plugin-transform-duplicate-keys": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-transform-exponentiation-operator": 7.16.7_@babel+core@7.12.10
+      "@babel/plugin-transform-for-of": 7.18.1_@babel+core@7.12.10
+      "@babel/plugin-transform-function-name": 7.16.7_@babel+core@7.12.10
+      "@babel/plugin-transform-literals": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-transform-member-expression-literals": 7.16.7_@babel+core@7.12.10
+      "@babel/plugin-transform-modules-amd": 7.18.0_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/plugin-transform-modules-commonjs": 7.18.2_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/plugin-transform-modules-systemjs": 7.18.4_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/plugin-transform-modules-umd": 7.18.0_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/plugin-transform-named-capturing-groups-regex": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-transform-new-target": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-transform-object-super": 7.16.7_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/plugin-transform-parameters": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-transform-property-literals": 7.16.7_@babel+core@7.12.10
+      "@babel/plugin-transform-regenerator": 7.18.0_@babel+core@7.12.10
+      "@babel/plugin-transform-reserved-words": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-transform-shorthand-properties": 7.16.7_@babel+core@7.12.10
+      "@babel/plugin-transform-spread": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-transform-sticky-regex": 7.16.7_@babel+core@7.12.10
+      "@babel/plugin-transform-template-literals": 7.18.2_@babel+core@7.12.10
+      "@babel/plugin-transform-typeof-symbol": 7.17.12_@babel+core@7.12.10
+      "@babel/plugin-transform-unicode-escapes": 7.16.7_@babel+core@7.12.10
+      "@babel/plugin-transform-unicode-regex": 7.16.7_@babel+core@7.12.10
+      "@babel/preset-modules": 0.1.5_@babel+core@7.12.10
+      "@babel/types": 7.17.12
+      core-js-compat: 3.22.5
+      semver: 5.7.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/preset-flow/7.17.12_@babel+core@7.18.2:
     resolution:
       {
@@ -2568,7 +3071,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.18.2
+      "@babel/core": 7.18.2_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/helper-validator-option": 7.16.7
       "@babel/plugin-transform-flow-strip-types": 7.17.12_@babel+core@7.18.2
@@ -2582,7 +3085,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
       "@babel/plugin-proposal-unicode-property-regex": 7.17.12_@babel+core@7.12.10
       "@babel/plugin-transform-dotall-regex": 7.16.7_@babel+core@7.12.10
@@ -2606,6 +3109,23 @@ packages:
       - supports-color
     dev: false
 
+  /@babel/preset-typescript/7.17.12_aiglbhfglusiuujjiuminyg6ui:
+    resolution:
+      {
+        integrity: sha512-S1ViF8W2QwAKUGJXxP9NAfNaqGDdEBJKpYkxHf5Yy2C4NPPzXGeR3Lhk7G8xJaaLcFTRfNjVbtbVtm8Gb0mqvg==,
+      }
+    engines: {node: ">=6.9.0"}
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+    dependencies:
+      "@babel/core": 7.18.2_supports-color@8.1.1
+      "@babel/helper-plugin-utils": 7.17.12
+      "@babel/helper-validator-option": 7.16.7
+      "@babel/plugin-transform-typescript": 7.18.4_aiglbhfglusiuujjiuminyg6ui
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/register/7.17.7_@babel+core@7.18.2:
     resolution:
       {
@@ -2615,7 +3135,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.18.2
+      "@babel/core": 7.18.2_supports-color@8.1.1
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -2677,6 +3197,26 @@ packages:
       "@babel/parser": 7.18.4
       "@babel/types": 7.18.4
       debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/traverse/7.18.2_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==,
+      }
+    engines: {node: ">=6.9.0"}
+    dependencies:
+      "@babel/code-frame": 7.16.7
+      "@babel/generator": 7.18.2
+      "@babel/helper-environment-visitor": 7.18.2
+      "@babel/helper-function-name": 7.17.9
+      "@babel/helper-hoist-variables": 7.16.7
+      "@babel/helper-split-export-declaration": 7.16.7
+      "@babel/parser": 7.18.4
+      "@babel/types": 7.18.4
+      debug: 4.3.4_supports-color@8.1.1
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3033,6 +3573,26 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@eslint/eslintrc/0.4.3_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==,
+      }
+    engines: {node: ^10.12.0 || >=12.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4_supports-color@8.1.1
+      espree: 7.3.1
+      globals: 13.15.0
+      ignore: 4.0.6
+      import-fresh: 3.3.0
+      js-yaml: 3.14.1
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@hapi/hoek/9.3.0:
     resolution:
       {
@@ -3072,6 +3632,20 @@ packages:
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
+
+  /@humanwhocodes/config-array/0.5.0_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==,
+      }
+    engines: {node: ">=10.10.0"}
+    dependencies:
+      "@humanwhocodes/object-schema": 1.2.1
+      debug: 4.3.4_supports-color@8.1.1
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@humanwhocodes/object-schema/1.2.1:
     resolution:
@@ -3362,7 +3936,7 @@ packages:
       "@jridgewell/resolve-uri": 3.0.7
       "@jridgewell/sourcemap-codec": 1.4.13
 
-  /@juanm04/cpx/2.0.1:
+  /@juanm04/cpx/2.0.1_supports-color@8.1.1:
     resolution:
       {
         integrity: sha512-OaTjKI3ycQnF0Cb4KvLVycB/O8nki2wUYBstmMWW7ocrkFil+YzYO23C+zY321h4p9YxSXCA1Xeg30vtminh6A==,
@@ -3372,7 +3946,7 @@ packages:
     dependencies:
       co: 4.6.0
       debounce: 1.2.1
-      debug: 4.3.4
+      debug: 4.3.4_supports-color@8.1.1
       duplexer: 0.1.2
       fs-extra: 9.1.0
       glob: 7.2.0
@@ -4831,6 +5405,36 @@ packages:
     dev: true
     optional: true
 
+  /@typescript-eslint/eslint-plugin/5.9.1_2anf7xzu4gv3hdfa2vphlhds3y:
+    resolution:
+      {
+        integrity: sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      "@typescript-eslint/parser": ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@typescript-eslint/experimental-utils": 5.9.1_ep4k34urm5hxazyxrevmf7goie
+      "@typescript-eslint/parser": 5.9.1_ep4k34urm5hxazyxrevmf7goie
+      "@typescript-eslint/scope-manager": 5.9.1
+      "@typescript-eslint/type-utils": 5.9.1_ep4k34urm5hxazyxrevmf7goie
+      debug: 4.3.4_supports-color@8.1.1
+      eslint: 7.32.0_supports-color@8.1.1
+      functional-red-black-tree: 1.0.1
+      ignore: 5.2.0
+      regexpp: 3.2.0
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.6.3
+      typescript: 4.6.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/eslint-plugin/5.9.1_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
       {
@@ -4846,36 +5450,6 @@ packages:
         optional: true
     dependencies:
       "@typescript-eslint/experimental-utils": 5.9.1_hrkuebk64jiu2ut2d2sm4oylnu
-      "@typescript-eslint/scope-manager": 5.9.1
-      "@typescript-eslint/type-utils": 5.9.1_hrkuebk64jiu2ut2d2sm4oylnu
-      debug: 4.3.4
-      eslint: 7.32.0
-      functional-red-black-tree: 1.0.1
-      ignore: 5.2.0
-      regexpp: 3.2.0
-      semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.6.3
-      typescript: 4.6.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/eslint-plugin/5.9.1_rvfvfrvgktle2hmlnfpjw2zp4u:
-    resolution:
-      {
-        integrity: sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==,
-      }
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      "@typescript-eslint/parser": ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: "*"
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      "@typescript-eslint/experimental-utils": 5.9.1_hrkuebk64jiu2ut2d2sm4oylnu
-      "@typescript-eslint/parser": 5.9.1_hrkuebk64jiu2ut2d2sm4oylnu
       "@typescript-eslint/scope-manager": 5.9.1
       "@typescript-eslint/type-utils": 5.9.1_hrkuebk64jiu2ut2d2sm4oylnu
       debug: 4.3.4
@@ -4917,6 +5491,7 @@ packages:
       typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@typescript-eslint/experimental-utils/5.28.0_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -4929,6 +5504,27 @@ packages:
     dependencies:
       "@typescript-eslint/utils": 5.28.0_hrkuebk64jiu2ut2d2sm4oylnu
       eslint: 7.32.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/experimental-utils/5.9.1_ep4k34urm5hxazyxrevmf7goie:
+    resolution:
+      {
+        integrity: sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      "@types/json-schema": 7.0.11
+      "@typescript-eslint/scope-manager": 5.9.1
+      "@typescript-eslint/types": 5.9.1
+      "@typescript-eslint/typescript-estree": 5.9.1_y3gwtsbczitbhepl6mdo2pvxv4
+      eslint: 7.32.0_supports-color@8.1.1
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@7.32.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5019,7 +5615,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser/5.9.1_hrkuebk64jiu2ut2d2sm4oylnu:
+  /@typescript-eslint/parser/5.9.1_ep4k34urm5hxazyxrevmf7goie:
     resolution:
       {
         integrity: sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==,
@@ -5034,9 +5630,9 @@ packages:
     dependencies:
       "@typescript-eslint/scope-manager": 5.9.1
       "@typescript-eslint/types": 5.9.1
-      "@typescript-eslint/typescript-estree": 5.9.1_typescript@4.6.3
-      debug: 4.3.4
-      eslint: 7.32.0
+      "@typescript-eslint/typescript-estree": 5.9.1_y3gwtsbczitbhepl6mdo2pvxv4
+      debug: 4.3.4_supports-color@8.1.1
+      eslint: 7.32.0_supports-color@8.1.1
       typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
@@ -5083,6 +5679,28 @@ packages:
     dependencies:
       "@typescript-eslint/types": 5.9.1
       "@typescript-eslint/visitor-keys": 5.9.1
+
+  /@typescript-eslint/type-utils/5.9.1_ep4k34urm5hxazyxrevmf7goie:
+    resolution:
+      {
+        integrity: sha512-tRSpdBnPRssjlUh35rE9ug5HrUvaB9ntREy7gPXXKwmIx61TNN7+l5YKgi1hMKxo5NvqZCfYhA5FvyuJG6X6vg==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: "*"
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@typescript-eslint/experimental-utils": 5.9.1_ep4k34urm5hxazyxrevmf7goie
+      debug: 4.3.4_supports-color@8.1.1
+      eslint: 7.32.0_supports-color@8.1.1
+      tsutils: 3.21.0_typescript@4.6.3
+      typescript: 4.6.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@typescript-eslint/type-utils/5.9.1_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -5186,6 +5804,30 @@ packages:
       typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
+
+  /@typescript-eslint/typescript-estree/5.9.1_y3gwtsbczitbhepl6mdo2pvxv4:
+    resolution:
+      {
+        integrity: sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@typescript-eslint/types": 5.9.1
+      "@typescript-eslint/visitor-keys": 5.9.1
+      debug: 4.3.4_supports-color@8.1.1
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.6.3
+      typescript: 4.6.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@typescript-eslint/utils/5.28.0_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -5742,7 +6384,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.18.2
+      "@babel/core": 7.18.2_supports-color@8.1.1
     dev: false
 
   /babel-jest/27.5.1_@babel+core@7.18.2:
@@ -5947,6 +6589,27 @@ packages:
       - supports-color
     dev: true
 
+  /body-parser/1.19.2_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==,
+      }
+    engines: {node: ">= 0.8"}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.4
+      debug: 2.6.9_supports-color@8.1.1
+      depd: 1.1.2
+      http-errors: 1.8.1
+      iconv-lite: 0.4.24
+      on-finished: 2.3.0
+      qs: 6.9.7
+      raw-body: 2.4.3
+      type-is: 1.6.18
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /boxen/4.2.0:
     resolution:
       {
@@ -6013,6 +6676,27 @@ packages:
       isobject: 3.0.1
       repeat-element: 1.1.4
       snapdragon: 0.8.2
+      snapdragon-node: 2.1.1
+      split-string: 3.1.0
+      to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /braces/2.3.2_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==,
+      }
+    engines: {node: ">=0.10.0"}
+    dependencies:
+      arr-flatten: 1.1.0
+      array-unique: 0.3.2
+      extend-shallow: 2.0.1
+      fill-range: 4.0.0
+      isobject: 3.0.1
+      repeat-element: 1.1.4
+      snapdragon: 0.8.2_supports-color@8.1.1
       snapdragon-node: 2.1.1
       split-string: 3.1.0
       to-regex: 3.0.2
@@ -6726,7 +7410,7 @@ packages:
     dependencies:
       safe-buffer: 5.1.2
 
-  /cookie-session/2.0.0:
+  /cookie-session/2.0.0_supports-color@8.1.1:
     resolution:
       {
         integrity: sha512-hKvgoThbw00zQOleSlUr2qpvuNweoqBtxrmx0UFosx6AGi9lYtLoA+RbsvknrEX8Pr6MDbdWAb2j6SnMn+lPsg==,
@@ -6734,7 +7418,7 @@ packages:
     engines: {node: ">= 0.10"}
     dependencies:
       cookies: 0.8.0
-      debug: 3.2.7
+      debug: 3.2.7_supports-color@8.1.1
       on-headers: 1.0.2
       safe-buffer: 5.2.1
     transitivePeerDependencies:
@@ -6992,6 +7676,20 @@ packages:
     dependencies:
       ms: 2.0.0
 
+  /debug/2.6.9_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==,
+      }
+    peerDependencies:
+      supports-color: "*"
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+      supports-color: 8.1.1
+
   /debug/3.2.7:
     resolution:
       {
@@ -7004,6 +7702,21 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
+
+  /debug/3.2.7_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==,
+      }
+    peerDependencies:
+      supports-color: "*"
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+      supports-color: 8.1.1
+    dev: false
 
   /debug/4.3.1:
     resolution:
@@ -7033,6 +7746,22 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: false
+
+  /debug/4.3.3_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==,
+      }
+    engines: {node: ">=6.0"}
+    peerDependencies:
+      supports-color: "*"
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+      supports-color: 8.1.1
 
   /debug/4.3.4:
     resolution:
@@ -7047,6 +7776,21 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+
+  /debug/4.3.4_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==,
+      }
+    engines: {node: ">=6.0"}
+    peerDependencies:
+      supports-color: "*"
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+      supports-color: 8.1.1
 
   /debug/4.3.4_supports-color@9.2.2:
     resolution:
@@ -7301,7 +8045,7 @@ packages:
       }
     engines: {node: ">=8"}
 
-  /detect-port/1.3.0:
+  /detect-port/1.3.0_supports-color@8.1.1:
     resolution:
       {
         integrity: sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==,
@@ -7310,7 +8054,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.0
-      debug: 2.6.9
+      debug: 2.6.9_supports-color@8.1.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8571,6 +9315,7 @@ packages:
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
+    dev: false
 
   /eslint-config-next/12.2.3_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -8608,6 +9353,7 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: ">=7.0.0"
+    dev: false
 
   /eslint-config-prettier/8.5.0_eslint@7.32.0:
     resolution:
@@ -8943,7 +9689,7 @@ packages:
     peerDependencies:
       eslint: ">=5"
     dependencies:
-      eslint: 7.32.0
+      eslint: 7.32.0_supports-color@8.1.1
       eslint-visitor-keys: 2.1.0
     dev: true
 
@@ -9018,6 +9764,58 @@ packages:
       v8-compile-cache: 2.3.0
     transitivePeerDependencies:
       - supports-color
+
+  /eslint/7.32.0_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==,
+      }
+    engines: {node: ^10.12.0 || >=12.0.0}
+    hasBin: true
+    dependencies:
+      "@babel/code-frame": 7.12.11
+      "@eslint/eslintrc": 0.4.3_supports-color@8.1.1
+      "@humanwhocodes/config-array": 0.5.0_supports-color@8.1.1
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4_supports-color@8.1.1
+      doctrine: 3.0.0
+      enquirer: 2.3.6
+      escape-string-regexp: 4.0.0
+      eslint-scope: 5.1.1
+      eslint-utils: 2.1.0
+      eslint-visitor-keys: 2.1.0
+      espree: 7.3.1
+      esquery: 1.4.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      functional-red-black-tree: 1.0.1
+      glob-parent: 5.1.2
+      globals: 13.15.0
+      ignore: 4.0.6
+      import-fresh: 3.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      js-yaml: 3.14.1
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.1
+      progress: 2.0.3
+      regexpp: 3.2.0
+      semver: 7.3.7
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      table: 6.8.0
+      text-table: 0.2.0
+      v8-compile-cache: 2.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /espree/7.3.1:
     resolution:
@@ -9183,6 +9981,24 @@ packages:
       - supports-color
     dev: false
 
+  /expand-brackets/2.1.4_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==,
+      }
+    engines: {node: ">=0.10.0"}
+    dependencies:
+      debug: 2.6.9_supports-color@8.1.1
+      define-property: 0.2.5
+      extend-shallow: 2.0.1
+      posix-character-classes: 0.1.1
+      regex-not: 1.0.2
+      snapdragon: 0.8.2_supports-color@8.1.1
+      to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /expect/27.5.1:
     resolution:
       {
@@ -9227,6 +10043,47 @@ packages:
       safe-buffer: 5.2.1
       send: 0.17.2
       serve-static: 1.14.2
+      setprototypeof: 1.2.0
+      statuses: 1.5.0
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /express/4.17.3_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==,
+      }
+    engines: {node: ">= 0.10.0"}
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.19.2_supports-color@8.1.1
+      content-disposition: 0.5.4
+      content-type: 1.0.4
+      cookie: 0.4.2
+      cookie-signature: 1.0.6
+      debug: 2.6.9_supports-color@8.1.1
+      depd: 1.1.2
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.1.2_supports-color@8.1.1
+      fresh: 0.5.2
+      merge-descriptors: 1.0.1
+      methods: 1.1.2
+      on-finished: 2.3.0
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.7
+      proxy-addr: 2.0.7
+      qs: 6.9.7
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.17.2_supports-color@8.1.1
+      serve-static: 1.14.2_supports-color@8.1.1
       setprototypeof: 1.2.0
       statuses: 1.5.0
       type-is: 1.6.18
@@ -9290,6 +10147,25 @@ packages:
       fragment-cache: 0.2.1
       regex-not: 1.0.2
       snapdragon: 0.8.2
+      to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /extglob/2.0.4_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==,
+      }
+    engines: {node: ">=0.10.0"}
+    dependencies:
+      array-unique: 0.3.2
+      define-property: 1.0.0
+      expand-brackets: 2.1.4_supports-color@8.1.1
+      extend-shallow: 2.0.1
+      fragment-cache: 0.2.1
+      regex-not: 1.0.2
+      snapdragon: 0.8.2_supports-color@8.1.1
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -9443,6 +10319,24 @@ packages:
     engines: {node: ">= 0.8"}
     dependencies:
       debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.3.0
+      parseurl: 1.3.3
+      statuses: 1.5.0
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /finalhandler/1.1.2_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==,
+      }
+    engines: {node: ">= 0.8"}
+    dependencies:
+      debug: 2.6.9_supports-color@8.1.1
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.3.0
@@ -11633,6 +12527,39 @@ packages:
       - supports-color
     dev: false
 
+  /jscodeshift/0.13.0_slgjdbbopna4ebnpdn2nkn3v2a:
+    resolution:
+      {
+        integrity: sha512-FNHLuwh7TeI0F4EzNVIRwUSxSqsGWM5nTv596FK4NfBnEEKFpIcyFeG559DMFGHSTIYA5AY4Fqh2cBrJx0EAwg==,
+      }
+    hasBin: true
+    peerDependencies:
+      "@babel/preset-env": ^7.1.6
+    dependencies:
+      "@babel/core": 7.18.2_supports-color@8.1.1
+      "@babel/parser": 7.18.4
+      "@babel/plugin-proposal-class-properties": 7.17.12_aiglbhfglusiuujjiuminyg6ui
+      "@babel/plugin-proposal-nullish-coalescing-operator": 7.17.12_@babel+core@7.18.2
+      "@babel/plugin-proposal-optional-chaining": 7.17.12_@babel+core@7.18.2
+      "@babel/plugin-transform-modules-commonjs": 7.18.2_aiglbhfglusiuujjiuminyg6ui
+      "@babel/preset-env": 7.12.10_ps3yxa7qdojvlda5ukda3zlwie
+      "@babel/preset-flow": 7.17.12_@babel+core@7.18.2
+      "@babel/preset-typescript": 7.17.12_aiglbhfglusiuujjiuminyg6ui
+      "@babel/register": 7.17.7_@babel+core@7.18.2
+      babel-core: 7.0.0-bridge.0_@babel+core@7.18.2
+      colors: 1.4.0
+      flow-parser: 0.179.0
+      graceful-fs: 4.2.10
+      micromatch: 3.1.10_supports-color@8.1.1
+      neo-async: 2.6.2
+      node-dir: 0.1.17
+      recast: 0.20.5
+      temp: 0.8.4
+      write-file-atomic: 2.4.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /jsdom/16.7.0:
     resolution:
       {
@@ -12595,6 +13522,30 @@ packages:
       - supports-color
     dev: false
 
+  /micromatch/3.1.10_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==,
+      }
+    engines: {node: ">=0.10.0"}
+    dependencies:
+      arr-diff: 4.0.0
+      array-unique: 0.3.2
+      braces: 2.3.2_supports-color@8.1.1
+      define-property: 2.0.2
+      extend-shallow: 3.0.2
+      extglob: 2.0.4_supports-color@8.1.1
+      fragment-cache: 0.2.1
+      kind-of: 6.0.3
+      nanomatch: 1.2.13_supports-color@8.1.1
+      object.pick: 1.3.0
+      regex-not: 1.0.2
+      snapdragon: 0.8.2_supports-color@8.1.1
+      to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /micromatch/4.0.5:
     resolution:
       {
@@ -12880,6 +13831,28 @@ packages:
       object.pick: 1.3.0
       regex-not: 1.0.2
       snapdragon: 0.8.2
+      to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /nanomatch/1.2.13_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==,
+      }
+    engines: {node: ">=0.10.0"}
+    dependencies:
+      arr-diff: 4.0.0
+      array-unique: 0.3.2
+      define-property: 2.0.2
+      extend-shallow: 3.0.2
+      fragment-cache: 0.2.1
+      is-windows: 1.0.2
+      kind-of: 6.0.3
+      object.pick: 1.3.0
+      regex-not: 1.0.2
+      snapdragon: 0.8.2_supports-color@8.1.1
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -14972,6 +15945,27 @@ packages:
       - supports-color
     dev: true
 
+  /rollup-plugin-esbuild/4.9.1_omx4rqyluc7ex52umwalnnwm7m:
+    resolution:
+      {
+        integrity: sha512-qn/x7Wz9p3Xnva99qcb+nopH0d2VJwVnsxJTGEg+Sh2Z3tqQl33MhOwzekVo1YTKgv+yAmosjcBRJygMfGrtLw==,
+      }
+    engines: {node: ">=12"}
+    peerDependencies:
+      esbuild: ">=0.10.1"
+      rollup: ^1.20.0 || ^2.0.0
+    dependencies:
+      "@rollup/pluginutils": 4.2.1
+      debug: 4.3.4_supports-color@8.1.1
+      es-module-lexer: 0.9.3
+      esbuild: 0.14.51
+      joycon: 3.1.1
+      jsonc-parser: 3.0.0
+      rollup: 2.77.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /rollup/2.70.2:
     resolution:
       {
@@ -15160,6 +16154,30 @@ packages:
       - supports-color
     dev: true
 
+  /send/0.17.2_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==,
+      }
+    engines: {node: ">= 0.8.0"}
+    dependencies:
+      debug: 2.6.9_supports-color@8.1.1
+      depd: 1.1.2
+      destroy: 1.0.4
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 1.8.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.3.0
+      range-parser: 1.2.1
+      statuses: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /serve-static/1.14.2:
     resolution:
       {
@@ -15171,6 +16189,21 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.17.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /serve-static/1.14.2_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==,
+      }
+    engines: {node: ">= 0.8.0"}
+    dependencies:
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.17.2_supports-color@8.1.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15394,6 +16427,25 @@ packages:
     dependencies:
       base: 0.11.2
       debug: 2.6.9
+      define-property: 0.2.5
+      extend-shallow: 2.0.1
+      map-cache: 0.2.2
+      source-map: 0.5.7
+      source-map-resolve: 0.5.3
+      use: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /snapdragon/0.8.2_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==,
+      }
+    engines: {node: ">=0.10.0"}
+    dependencies:
+      base: 0.11.2
+      debug: 2.6.9_supports-color@8.1.1
       define-property: 0.2.5
       extend-shallow: 2.0.1
       map-cache: 0.2.2
@@ -15834,14 +16886,14 @@ packages:
       minimist: 1.2.6
     dev: true
 
-  /superjson/1.8.0:
+  /superjson/1.8.0_supports-color@8.1.1:
     resolution:
       {
         integrity: sha512-8FWCa0T9JQ9kVax9nmRqEEebhbRGmU3IV1gevZWQGJRFmSNVN4hnyfb0858aWeEOoS3atwnhjYGleRQHTGI/lA==,
       }
     engines: {node: ">=10"}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4_supports-color@8.1.1
       lodash.clonedeep: 4.5.0
     transitivePeerDependencies:
       - supports-color
@@ -16645,7 +17697,7 @@ packages:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
-  /unbuild/0.6.9:
+  /unbuild/0.6.9_supports-color@8.1.1:
     resolution:
       {
         integrity: sha512-IALhVj6cLWAxFqX5qcuR932Y3OKFgWcZXPeQ0qU1YAuBucWzpY171GHMi+rXot3C4V7JwD0khGmjvu41E980mQ==,
@@ -16675,7 +17727,7 @@ packages:
       rimraf: 3.0.2
       rollup: 2.77.2
       rollup-plugin-dts: 4.2.2_oo3i3f3qmqiztdz5qgxrrjmd5e
-      rollup-plugin-esbuild: 4.9.1_ecpsl2p7zl5puhr4xxlpah6uzm
+      rollup-plugin-esbuild: 4.9.1_omx4rqyluc7ex52umwalnnwm7m
       scule: 0.2.1
       typescript: 4.7.4
       untyped: 0.3.0
@@ -16717,6 +17769,44 @@ packages:
       scule: 0.2.1
       typescript: 4.7.4
       untyped: 0.4.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /unbuild/0.7.6_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-W6pFPS6/ewlEV5uWbNgfo0i2LbVBsue5GKlOkCo6ozIrInOBEgq4s3HCUB5eZSw6Ty2iwF8dKM65pZX7QGZJ0g==,
+      }
+    hasBin: true
+    dependencies:
+      "@rollup/plugin-alias": 3.1.9_rollup@2.77.2
+      "@rollup/plugin-commonjs": 22.0.1_rollup@2.77.2
+      "@rollup/plugin-json": 4.1.0_rollup@2.77.2
+      "@rollup/plugin-node-resolve": 13.3.0_rollup@2.77.2
+      "@rollup/plugin-replace": 4.0.0_rollup@2.77.2
+      "@rollup/pluginutils": 4.2.1
+      chalk: 5.0.1
+      consola: 2.15.3
+      defu: 6.0.0
+      esbuild: 0.14.51
+      hookable: 5.1.1
+      jiti: 1.14.0
+      magic-string: 0.26.2
+      mkdirp: 1.0.4
+      mkdist: 0.3.13_typescript@4.7.4
+      mlly: 0.5.5
+      mri: 1.2.0
+      pathe: 0.3.2
+      pkg-types: 0.3.3
+      pretty-bytes: 6.0.0
+      rimraf: 3.0.2
+      rollup: 2.77.2
+      rollup-plugin-dts: 4.2.2_oo3i3f3qmqiztdz5qgxrrjmd5e
+      rollup-plugin-esbuild: 4.9.1_omx4rqyluc7ex52umwalnnwm7m
+      scule: 0.2.1
+      typescript: 4.7.4
+      untyped: 0.4.4_supports-color@8.1.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16812,6 +17902,20 @@ packages:
       }
     dependencies:
       "@babel/core": 7.18.2
+      "@babel/standalone": 7.18.9
+      "@babel/types": 7.18.4
+      scule: 0.2.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /untyped/0.4.4_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-sY6u8RedwfLfBis0copfU/fzROieyAndqPs8Kn2PfyzTjtA88vCk81J1b5z+8/VJc+cwfGy23/AqOCpvAbkNVw==,
+      }
+    dependencies:
+      "@babel/core": 7.18.2_supports-color@8.1.1
       "@babel/standalone": 7.18.9
       "@babel/types": 7.18.4
       scule: 0.2.1


### PR DESCRIPTION
Closes: #3580

### What are the changes and their implications?
Adds
```js
  "resolutions": {
    "supports-color": "8"
  }
``` 
to each package.json 
