### PR TITLE
Fix peerDependency warnings

### DIFF
--- a/.changeset/red-badgers-retire.md
+++ b/.changeset/red-badgers-retire.md
@@ -1,0 +1,8 @@
+---
+"blitz": patch
+"@blitzjs/next": patch
+"@blitzjs/rpc": patch
+"@blitzjs/generator": patch
+---
+
+Fixes peer dependency warnings

--- a/packages/blitz-next/build.config.ts
+++ b/packages/blitz-next/build.config.ts
@@ -2,7 +2,7 @@ import {BuildConfig} from "unbuild"
 
 const config: BuildConfig = {
   entries: ["./src/index-browser", "./src/index-server"],
-  externals: ["index-browser.cjs", "index-browser.mjs", "blitz", ".blitz"],
+  externals: ["index-browser.cjs", "index-browser.mjs", "blitz", ".blitz", "next", "react"],
   declaration: true,
   rollup: {
     emitCJS: true,

--- a/packages/blitz-next/package.json
+++ b/packages/blitz-next/package.json
@@ -58,9 +58,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "peerDependencies": {
-    "next": ">=12.2.0",
-    "react": "*"
   }
 }

--- a/packages/blitz-rpc/build.config.ts
+++ b/packages/blitz-rpc/build.config.ts
@@ -14,6 +14,8 @@ const config: BuildConfig = {
     "index-server.cjs",
     "index-server.mjs",
     "react",
+    "blitz",
+    "next",
   ],
   declaration: true,
   rollup: {

--- a/packages/blitz-rpc/package.json
+++ b/packages/blitz-rpc/package.json
@@ -43,10 +43,6 @@
     "unbuild": "0.7.6",
     "watch": "1.0.2"
   },
-  "peerDependencies": {
-    "blitz": "2.0.0-alpha.65",
-    "next": ">=12.2.0"
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/blitz/build.config.ts
+++ b/packages/blitz/build.config.ts
@@ -2,7 +2,7 @@ import {BuildConfig} from "unbuild"
 
 const config: BuildConfig = {
   entries: ["./src/index-browser", "./src/index-server", "./src/cli/index"],
-  externals: ["index-browser.cjs", "index-browser.mjs", "index.cjs", "zod"],
+  externals: ["index-browser.cjs", "index-browser.mjs", "index.cjs", "zod", "react"],
   declaration: true,
   rollup: {
     emitCJS: true,

--- a/packages/blitz/package.json
+++ b/packages/blitz/package.json
@@ -79,9 +79,6 @@
     "watch": "1.0.2",
     "zod": "3.17.3"
   },
-  "peerDependencies": {
-    "react": "*"
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -71,8 +71,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "peerDependencies": {
-    "react": "*"
   }
 }


### PR DESCRIPTION
### What are the changes and their implications?

Removes `peerDependencies` from all `package.json` & adds to build externals