### PR TITLE
Avoid Next's `invalid config detected` warnings by deleting `"blitz"` key from the config object

### DIFF
--- a/.changeset/gorgeous-games-obey.md
+++ b/.changeset/gorgeous-games-obey.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/next": patch
+---
+
+Avoid `invalid config detected` warnings by deleting `"blitz"` key from next config object

--- a/packages/blitz-next/src/index-server.ts
+++ b/packages/blitz-next/src/index-server.ts
@@ -209,7 +209,8 @@ export function withBlitz(nextConfig: BlitzConfig = {}) {
     },
   })
 
-  return config
+  const {blitz, ...rest} = config
+  return rest
 }
 
 export type PrefetchQueryFn = <T extends AsyncFunc, TInput = FirstParam<T>>(


### PR DESCRIPTION

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/blitz/issues/3657

### What are the changes and their implications?

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
