### PR TITLE
Export `BlitzServerMiddleware` utility function

### DIFF
--- a/.changeset/great-terms-rescue.md
+++ b/.changeset/great-terms-rescue.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Add BlitzServerMiddleware utility function to wrap middleware in blitz server file

--- a/packages/blitz/src/index-server.ts
+++ b/packages/blitz/src/index-server.ts
@@ -60,3 +60,11 @@ export function createSetupServer<TMiddleware extends RequestMiddleware, TExport
 ) {
   return setupServerConstructor
 }
+
+export const BlitzServerMiddleware = <
+  TMiddleware extends RequestMiddleware<any, any> = RequestMiddleware,
+>(
+  middleware: TMiddleware,
+): BlitzServerPlugin => ({
+  requestMiddlewares: [middleware],
+})


### PR DESCRIPTION
### What are the changes and their implications?

Exports a `BlitzServerMiddleware()` function from `blitz` that allows you to wrap legacy blitz middleware functions.

An example:
```ts
BlitzServerMiddleware(BlitzGuardMiddleware({
  excluded: [
   '/api/rpc/signup'
  ]
})),
```

## Feature Checklist

- [X] Documentation added/updated (https://github.com/blitz-js/blitzjs.com/pull/723)
