### PR TITLE
Include `.env.test` to generator templates

### DIFF
--- a/.changeset/calm-tomatoes-drive.md
+++ b/.changeset/calm-tomatoes-drive.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Include `.env.test` file to the generator templates

--- a/packages/generator/templates/app/.env.test
+++ b/packages/generator/templates/app/.env.test
@@ -1,0 +1,5 @@
+# SQLite is ready to go out of the box, but you can switch to Postgres
+# by first changing the provider from "sqlite" to "postgres" in the Prisma
+# schema file and by second swapping the DATABASE_URL below.
+DATABASE_URL="file:./db_test.sqlite"
+# DATABASE_URL=postgresql://__username__@localhost:5432/__name___test

--- a/packages/generator/templates/minimalapp/.env.test
+++ b/packages/generator/templates/minimalapp/.env.test
@@ -1,0 +1,5 @@
+# SQLite is ready to go out of the box, but you can switch to Postgres
+# by first changing the provider from "sqlite" to "postgres" in the Prisma
+# schema file and by second swapping the DATABASE_URL below.
+DATABASE_URL="file:./db_test.sqlite"
+# DATABASE_URL=postgresql://__username__@localhost:5432/__name___test


### PR DESCRIPTION
### What are the changes and their implications?

Includes an `.env.test` file to the generator templates.
