### PR TITLE
Fix template path for the generator

### DIFF
--- a/.changeset/shaggy-carpets-brake.md
+++ b/.changeset/shaggy-carpets-brake.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Fix template path for the generator

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -302,7 +302,7 @@ export abstract class Generator<
       return path.join(
         __dirname,
         "..",
-        process.env.NODE_ENV === "test" ? "./templates" : "./templates",
+        process.env.NODE_ENV === "test" ? "./templates" : "./dist/templates",
         this.sourceRoot.path,
         ...paths,
       )


### PR DESCRIPTION
### What are the changes and their implications?

Corrects the path for the templates directory when using the blitz generator. 

```diff
- process.env.NODE_ENV === "test" ? "./templates" : "./templates",
+ process.env.NODE_ENV === "test" ? "./templates" : "./dist/templates",
```