### PR TITLE
Remove trailing comma from tsconfig.json in new app template

### DIFF
--- a/.changeset/slimy-humans-impress.md
+++ b/.changeset/slimy-humans-impress.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Remove trailing comma from tsconfig.json file in the new app template"

--- a/packages/generator/templates/app/tsconfig.json
+++ b/packages/generator/templates/app/tsconfig.json
@@ -17,7 +17,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "tsBuildInfoFile": ".tsbuildinfo",
+    "tsBuildInfoFile": ".tsbuildinfo"
   },
   "exclude": ["node_modules", "**/*.e2e.ts", "cypress"],
   "include": ["blitz-env.d.ts", "**/*.ts", "**/*.tsx", "types"]


### PR DESCRIPTION
The trailing comma was causing parse errors when jest was trying to load `tsconfig.json`. For example on the pre-push hook:
```
git push

> app@1.0.0 lint
> eslint --ignore-path .gitignore --ext .js,.ts,.tsx .


> app@1.0.0 test
> jest

SyntaxError: app/tsconfig.json: Unexpected token } in JSON at position 548
    at parse (<anonymous>)
    at Object.Module._extensions..json (node:internal/modules/cjs/loader:1173:22)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/Users/aleksandra/workspace/conf-demo-app/node_modules/@blitzjs/next/jest/index.js:9:14)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
husky - pre-push hook exited with code 1 (error)
```
