### PR TITLE
Run codegen tasks after installing dependecies in the new command

### DIFF
--- a/.changeset/rotten-rocks-remember.md
+++ b/.changeset/rotten-rocks-remember.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Run codegen tasks after creating a new app if user chose yarn as a package manager

--- a/packages/blitz/src/cli/commands/new.ts
+++ b/packages/blitz/src/cli/commands/new.ts
@@ -8,6 +8,7 @@ import {AppGenerator, AppGeneratorOptions, getLatestVersion} from "@blitzjs/gene
 import {loadEnvConfig} from "../../utils/env"
 import {runPrisma} from "../../utils/run-prisma"
 import {checkLatestVersion} from "../utils/check-latest-version"
+import {codegenTasks} from "../utils/codegen-tasks"
 
 const forms: Record<AppGeneratorOptions["form"], string> = {
   finalform: "React Final Form (recommended)",
@@ -269,6 +270,10 @@ const newApp: CliCommand = async (argv) => {
           )
           const result = await runPrisma(["migrate", "dev", "--name", "Initial migration"], true)
           if (!result.success) throw new Error()
+
+          if (projectPkgManger === "yarn") {
+            await codegenTasks()
+          }
         } catch (error) {
           postInstallSteps.push(
             "blitz prisma migrate dev (when asked, you can name the migration anything)",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3060,6 +3060,7 @@ packages:
       semver: 5.7.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/preset-flow/7.17.12_@babel+core@7.18.2:
     resolution:
@@ -5490,6 +5491,7 @@ packages:
       typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@typescript-eslint/experimental-utils/5.28.0_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -9313,6 +9315,7 @@ packages:
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
+    dev: false
 
   /eslint-config-next/12.2.4_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -9350,6 +9353,7 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: ">=7.0.0"
+    dev: false
 
   /eslint-config-prettier/8.5.0_eslint@7.32.0:
     resolution:


### PR DESCRIPTION
After some debugging, me and @dillonraphael figured out that the issue only happens with yarn and only on a fresh app creation (ie if you create a new app, remove node_modules, and install them again you won't get an error). Apparently, we can't modify node modules on the fly with yarn, so we're adding the codegen step to the post-install method in `new.ts`.

Closes: https://github.com/blitz-js/blitz/issues/3623
