### PR TITLE
Fixes #3614 - changed console logs to standard logger

### DIFF
--- a/.changeset/great-candles-stare.md
+++ b/.changeset/great-candles-stare.md
@@ -1,0 +1,6 @@
+---
+"@blitzjs/rpc": patch
+"blitz": patch
+---
+
+Use internal branded blitz logger for @blitzjs/rpc

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -1,7 +1,8 @@
-import {assert, Ctx, prettyMs} from "blitz"
+import {assert, baseLogger, Ctx, newLine, prettyMs} from "blitz"
 import {NextApiRequest, NextApiResponse} from "next"
 import {deserialize, serialize as superjsonSerialize} from "superjson"
 import {resolve} from "path"
+import chalk from "chalk"
 
 // TODO - optimize end user server bundles by not exporting all client stuff here
 export * from "./index-browser"
@@ -156,6 +157,13 @@ export function rpcHandler(config: RpcConfig) {
     const relativeRoutePath = (req.query.blitz as string[])?.join("/")
     const routePath = "/" + relativeRoutePath
 
+    const log = baseLogger().getChildLogger({
+      prefix: [routePath.replace("/api/rpc/", "") + "()"],
+    })
+    const customChalk = new chalk.Instance({
+      level: log.settings.type === "json" ? 0 : chalk.level,
+    })
+
     const loadableResolver = resolverMap?.[routePath]
     if (!loadableResolver) {
       throw new Error("No resolver for path: " + routePath)
@@ -175,7 +183,7 @@ export function rpcHandler(config: RpcConfig) {
 
       if (typeof req.body.params === "undefined") {
         const error = {message: "Request body is missing the `params` key"}
-        console.error(error.message)
+        log.error(error.message)
         res.status(400).json({
           result: null,
           error,
@@ -189,11 +197,11 @@ export function rpcHandler(config: RpcConfig) {
           meta: req.body.meta?.params,
         })
 
-        console.info("Starting with input:", data ? data : JSON.stringify(data))
+        log.info(customChalk.dim("Starting with input:"), data ? data : JSON.stringify(data))
         const startTime = Date.now()
         const result = await resolver(data, (res as any).blitzCtx)
         const resolverDuration = Date.now() - startTime
-        console.debug("Result:", result ? result : JSON.stringify(result))
+        log.debug(customChalk.dim("Result:"), result ? result : JSON.stringify(result))
 
         const serializerStartTime = Date.now()
         const serializedResult = superjsonSerialize(result)
@@ -207,16 +215,22 @@ export function rpcHandler(config: RpcConfig) {
             result: serializedResult.meta,
           },
         })
-        console.debug(`Next.js serialization:${prettyMs(Date.now() - nextSerializerStartTime)}`)
+        log.debug(
+          customChalk.dim(
+            `Next.js serialization:${prettyMs(Date.now() - nextSerializerStartTime)}`,
+          ),
+        )
         const serializerDuration = Date.now() - serializerStartTime
         const duration = Date.now() - startTime
 
-        console.info(
-          `Finished: resolver:${prettyMs(resolverDuration)} serializer:${prettyMs(
-            serializerDuration,
-          )} total:${prettyMs(duration)}`,
+        log.info(
+          customChalk.dim(
+            `Finished: resolver:${prettyMs(resolverDuration)} serializer:${prettyMs(
+              serializerDuration,
+            )} total:${prettyMs(duration)}`,
+          ),
         )
-        console.log("\n")
+        newLine()
 
         return
       } catch (error: any) {
@@ -226,8 +240,8 @@ export function rpcHandler(config: RpcConfig) {
 
         config.onError?.(error)
 
-        console.error(error)
-        console.log("\n")
+        log.error(error)
+        newLine()
 
         if (!error.statusCode) {
           error.statusCode = 500
@@ -246,7 +260,7 @@ export function rpcHandler(config: RpcConfig) {
       }
     } else {
       // Everything else is error
-      console.warn(`${req.method} method not supported`)
+      log.warn(`${req.method} method not supported`)
       res.status(404).end()
       return
     }


### PR DESCRIPTION
I tried to keep the logging format close to what has been present before, by also including the chalk package for coloring.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #3614 

### What are the changes and their implications?

As requested, the logging of the RPC package has been moved to the built-in standard logger. Additionally, the `chalk` packages has been used to be as close as possible to the logging as it was before. All tests passed locally.

> **INFO** There are two other PRs open for this issue, which both shouldn't be able to correctly run through the workflow. See #3690 and #3614 .

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
