### PR TITLE
Check if DocumentHead is self closing in the codemod step

### DIFF
--- a/.changeset/twelve-hornets-sip.md
+++ b/.changeset/twelve-hornets-sip.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/codemod": patch
+---
+
+Fix codemod to accept a self closing `DocumentHead` in the `_document` page

--- a/packages/codemod/src/upgrade-legacy.ts
+++ b/packages/codemod/src/upgrade-legacy.ts
@@ -979,7 +979,9 @@ const upgradeLegacy = async () => {
           .get()
 
         documentHead.value.openingElement.name.name = "Head"
-        documentHead.value.closingElement.name.name = "Head"
+        if (documentHead.value.closingElement) {
+          documentHead.value.closingElement.name.name = "Head"
+        }
 
         const blitzScript = program.find(j.Identifier, (node) => node.name === "BlitzScript").get()
         blitzScript.value.name = "NextScript"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3060,7 +3060,6 @@ packages:
       semver: 5.7.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/preset-flow/7.17.12_@babel+core@7.18.2:
     resolution:
@@ -5491,7 +5490,6 @@ packages:
       typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/experimental-utils/5.28.0_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -9315,7 +9313,6 @@ packages:
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
 
   /eslint-config-next/12.2.4_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -9353,7 +9350,6 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: ">=7.0.0"
-    dev: false
 
   /eslint-config-prettier/8.5.0_eslint@7.32.0:
     resolution:


### PR DESCRIPTION
Closes: #3641 

### What are the changes and their implications?

This checks if `DocumentHead` has a closing element or not. If there is a closing element, only then will the codemod change it's name.