### PR TITLE
add missing `g` in next.config.js file name

### DIFF
--- a/.changeset/smooth-rice-clap.md
+++ b/.changeset/smooth-rice-clap.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Fix typo in a next.config.js file name

--- a/packages/generator/src/utils/log.ts
+++ b/packages/generator/src/utils/log.ts
@@ -67,7 +67,7 @@ export function assignDefaultsBase(userConfig: {[key: string]: any}) {
 export function loadConfigProduction(pagesDir: string) {
   let userConfigModule
   try {
-    const path = join(pagesDir, "next.confi.js")
+    const path = join(pagesDir, "next.config.js")
     debug("Loading config from ", path)
     // eslint-disable-next-line no-eval -- block webpack from following this module path
     userConfigModule = eval("require")(path)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Fixes a typo in a next.config.js file name (adding missing `g`).
