### PR TITLE
Print model added or updated in schema.prisma after running model generator

### DIFF
--- a/.changeset/brown-avocados-wink.md
+++ b/.changeset/brown-avocados-wink.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Print model added or updated in schema.prisma after running model generator

--- a/packages/generator/src/generators/model-generator.ts
+++ b/packages/generator/src/generators/model-generator.ts
@@ -89,7 +89,6 @@ export class ModelGenerator extends Generator<ModelGeneratorOptions> {
           dryRun ? "" : ` ${updatedOrCreated} in schema.prisma`
         }:\n`,
       )
-      console.log({model})
       ast
         .printSchema({type: "schema", list: [model]})
         .split("\n")

--- a/packages/generator/src/generators/model-generator.ts
+++ b/packages/generator/src/generators/model-generator.ts
@@ -2,6 +2,7 @@ import * as ast from "@mrleebo/prisma-ast"
 import {spawn} from "cross-spawn"
 import which from "npm-which"
 import path from "path"
+import {log} from "src/utils/log"
 import {Generator, GeneratorOptions, SourceRootType} from "../generator"
 import {Field} from "../prisma/field"
 import {Model} from "../prisma/model"
@@ -88,8 +89,11 @@ export class ModelGenerator extends Generator<ModelGeneratorOptions> {
           dryRun ? "" : ` ${updatedOrCreated} in schema.prisma`
         }:\n`,
       )
-      ast.printSchema({type: "schema", list: [model]}).split("\n")
-      // .map(log.progress) // todo
+      console.log({model})
+      ast
+        .printSchema({type: "schema", list: [model]})
+        .split("\n")
+        .map(log.progress)
       console.log("\n")
     }
   }


### PR DESCRIPTION
We are currently printing an empty message:
<img width="767" alt="CleanShot 2022-08-12 at 19 40 55@2x" src="https://user-images.githubusercontent.com/9019397/184413869-283d95a3-5878-435f-aea6-89be07a559e7.png">

This PR fixes that.
