### PR TITLE
Remove console log from blitz util file

### DIFF
--- a/packages/blitz/src/utils/index.ts
+++ b/packages/blitz/src/utils/index.ts
@@ -104,7 +104,6 @@ export function compose(middleware: RequestMiddleware<any, any>[]) {
       }
 
       try {
-        console.log(`[${handler.name}] Starting handler...`)
         return Promise.resolve(handler(req, res, dispatch.bind(null, i + 1)))
       } catch (err) {
         return Promise.reject(err)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
       "@types/preview-email": 2.0.1
       "@types/react": 18.0.1
       "@typescript-eslint/eslint-plugin": 5.9.1
-      blitz: workspace:2.0.0-beta.0
+      blitz: workspace:2.0.0-beta.1
       eslint: 7.32.0
       eslint-config-next: 12.2.0
       eslint-config-prettier: 8.5.0
@@ -524,8 +524,8 @@ importers:
 
   packages/blitz:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-beta.0
-      "@blitzjs/generator": 2.0.0-beta.0
+      "@blitzjs/config": workspace:2.0.0-beta.1
+      "@blitzjs/generator": 2.0.0-beta.1
       "@types/cookie": 0.4.1
       "@types/cross-spawn": 6.0.2
       "@types/debug": 4.1.7
@@ -635,7 +635,7 @@ importers:
 
   packages/blitz-auth:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-beta.0
+      "@blitzjs/config": workspace:2.0.0-beta.1
       "@testing-library/react": 13.0.0
       "@testing-library/react-hooks": 7.0.2
       "@types/b64-lite": 1.3.0
@@ -649,7 +649,7 @@ importers:
       "@types/secure-password": 3.1.1
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-beta.0
+      blitz: 2.0.0-beta.1
       cookie: 0.4.1
       cookie-session: 2.0.0
       debug: 4.3.3
@@ -702,8 +702,8 @@ importers:
 
   packages/blitz-next:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-beta.0
-      "@blitzjs/rpc": 2.0.0-beta.0
+      "@blitzjs/config": workspace:2.0.0-beta.1
+      "@blitzjs/rpc": 2.0.0-beta.1
       "@tanstack/react-query": 4.0.10
       "@testing-library/dom": 8.13.0
       "@testing-library/jest-dom": 5.16.3
@@ -715,7 +715,7 @@ importers:
       "@types/react": 18.0.1
       "@types/react-dom": 17.0.14
       "@types/testing-library__react-hooks": 4.0.0
-      blitz: 2.0.0-beta.0
+      blitz: 2.0.0-beta.1
       cross-spawn: 7.0.3
       debug: 4.3.3
       find-up: 4.1.0
@@ -765,15 +765,15 @@ importers:
 
   packages/blitz-rpc:
     specifiers:
-      "@blitzjs/auth": 2.0.0-beta.0
-      "@blitzjs/config": workspace:2.0.0-beta.0
+      "@blitzjs/auth": 2.0.0-beta.1
+      "@blitzjs/config": workspace:2.0.0-beta.1
       "@tanstack/react-query": 4.0.10
       "@types/debug": 4.1.7
       "@types/react": 18.0.1
       "@types/react-dom": 17.0.14
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-beta.0
+      blitz: 2.0.0-beta.1
       chalk: ^4.1.0
       debug: 4.3.3
       next: 12.2.0
@@ -816,12 +816,12 @@ importers:
       "@babel/plugin-syntax-typescript": 7.17.12
       "@babel/preset-env": 7.12.10
       "@blitzjs/config": workspace:*
-      "@blitzjs/generator": 2.0.0-beta.0
+      "@blitzjs/generator": 2.0.0-beta.1
       "@types/jscodeshift": 0.11.2
       "@types/node": 17.0.16
       arg: 5.0.1
       ast-types: 0.14.2
-      blitz: 2.0.0-beta.0
+      blitz: 2.0.0-beta.1
       chalk: ^4.1.0
       cross-spawn: 7.0.3
       debug: 4.3.3
@@ -876,7 +876,7 @@ importers:
       "@babel/plugin-transform-typescript": 7.12.1
       "@babel/preset-env": 7.12.10
       "@babel/types": 7.12.10
-      "@blitzjs/config": 2.0.0-beta.0
+      "@blitzjs/config": 2.0.0-beta.1
       "@juanm04/cpx": 2.0.1
       "@mrleebo/prisma-ast": 0.2.6
       "@types/babel__core": 7.1.19
@@ -969,7 +969,7 @@ importers:
 
   packages/pkg-template:
     specifiers:
-      "@blitzjs/config": 2.0.0-beta.0
+      "@blitzjs/config": 2.0.0-beta.1
       "@types/react": 18.0.1
       "@types/react-dom": 17.0.14
       "@typescript-eslint/eslint-plugin": 5.9.1
@@ -3109,7 +3109,6 @@ packages:
       semver: 5.7.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/preset-flow/7.17.12_@babel+core@7.18.2:
     resolution:
@@ -5540,7 +5539,6 @@ packages:
       typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/experimental-utils/5.28.0_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -9367,7 +9365,6 @@ packages:
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
 
   /eslint-config-next/12.2.5_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -9405,7 +9402,6 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: ">=7.0.0"
-    dev: false
 
   /eslint-config-prettier/8.5.0_eslint@7.32.0:
     resolution:


### PR DESCRIPTION
### What are the changes and their implications?

- Remove `console.log(`[${handler.name}] Starting handler...`)` from the blitz util file
