### PR TITLE
Include ResetPasswordPage in new app template

### DIFF
--- a/.changeset/long-lobsters-drop.md
+++ b/.changeset/long-lobsters-drop.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Include ResetPasswordPage in new app template

--- a/apps/toolkit-app/mailers/forgotPasswordMailer.ts
+++ b/apps/toolkit-app/mailers/forgotPasswordMailer.ts
@@ -13,7 +13,7 @@ type ResetPasswordMailer = {
 export function forgotPasswordMailer({ to, token }: ResetPasswordMailer) {
   // In production, set APP_ORIGIN to your production server origin
   const origin = process.env.APP_ORIGIN || process.env.BLITZ_DEV_SERVER_ORIGIN
-  const resetUrl = `${origin}/reset-password?token=${token}`
+  const resetUrl = `${origin}/auth/reset-password?token=${token}`
 
   const msg = {
     from: "TODO@example.com",

--- a/apps/toolkit-app/pages/auth/reset-password.tsx
+++ b/apps/toolkit-app/pages/auth/reset-password.tsx
@@ -1,0 +1,66 @@
+import Layout from "app/core/layouts/Layout"
+import { LabeledTextField } from "app/core/components/LabeledTextField"
+import { Form, FORM_ERROR } from "app/core/components/Form"
+import { ResetPassword } from "app/auth/validations"
+import resetPassword from "app/auth/mutations/resetPassword"
+import { BlitzPage, Routes } from "@blitzjs/next"
+import { useRouter } from "next/router"
+import { useMutation } from "@blitzjs/rpc"
+import Link from "next/link"
+
+const ResetPasswordPage: BlitzPage = () => {
+  const router = useRouter()
+  const [resetPasswordMutation, { isSuccess }] = useMutation(resetPassword)
+
+  return (
+    <div>
+      <h1>Set a New Password</h1>
+
+      {isSuccess ? (
+        <div>
+          <h2>Password Reset Successfully</h2>
+          <p>
+            Go to the <Link href={Routes.Home()}>homepage</Link>
+          </p>
+        </div>
+      ) : (
+        <Form
+          submitText="Reset Password"
+          schema={ResetPassword}
+          initialValues={{
+            password: "",
+            passwordConfirmation: "",
+            token: router.query.token as string,
+          }}
+          onSubmit={async (values) => {
+            try {
+              await resetPasswordMutation(values)
+            } catch (error: any) {
+              if (error.name === "ResetPasswordError") {
+                return {
+                  [FORM_ERROR]: error.message,
+                }
+              } else {
+                return {
+                  [FORM_ERROR]: "Sorry, we had an unexpected error. Please try again.",
+                }
+              }
+            }
+          }}
+        >
+          <LabeledTextField name="password" label="New Password" type="password" />
+          <LabeledTextField
+            name="passwordConfirmation"
+            label="Confirm New Password"
+            type="password"
+          />
+        </Form>
+      )}
+    </div>
+  )
+}
+
+ResetPasswordPage.redirectAuthenticatedTo = "/"
+ResetPasswordPage.getLayout = (page) => <Layout title="Reset Your Password">{page}</Layout>
+
+export default ResetPasswordPage

--- a/packages/generator/templates/app/mailers/forgotPasswordMailer.ts
+++ b/packages/generator/templates/app/mailers/forgotPasswordMailer.ts
@@ -13,7 +13,7 @@ type ResetPasswordMailer = {
 export function forgotPasswordMailer({ to, token }: ResetPasswordMailer) {
   // In production, set APP_ORIGIN to your production server origin
   const origin = process.env.APP_ORIGIN || process.env.BLITZ_DEV_SERVER_ORIGIN
-  const resetUrl = `${origin}/reset-password?token=${token}`
+  const resetUrl = `${origin}/auth/reset-password?token=${token}`
 
   const msg = {
     from: "TODO@example.com",

--- a/packages/generator/templates/app/pages/auth/reset-password.tsx
+++ b/packages/generator/templates/app/pages/auth/reset-password.tsx
@@ -1,0 +1,62 @@
+import Layout from "app/core/layouts/Layout"
+import { LabeledTextField } from "app/core/components/LabeledTextField"
+import { Form, FORM_ERROR } from "app/core/components/Form"
+import { ResetPassword } from "app/auth/validations"
+import resetPassword from "app/auth/mutations/resetPassword"
+import { BlitzPage, Routes } from "@blitzjs/next"
+import { useRouter } from "next/router"
+import { useMutation } from "@blitzjs/rpc"
+import Link from "next/link"
+
+const ResetPasswordPage: BlitzPage = () => {
+  const router = useRouter()
+  const [resetPasswordMutation, { isSuccess }] = useMutation(resetPassword)
+
+  return (
+    <div>
+      <h1>Set a New Password</h1>
+
+      {isSuccess ? (
+        <div>
+          <h2>Password Reset Successfully</h2>
+          <p>
+            Go to the <Link href={Routes.Home()}>homepage</Link>
+          </p>
+        </div>
+      ) : (
+        <Form
+          submitText="Reset Password"
+          schema={ResetPassword}
+          initialValues={{ password: "", passwordConfirmation: "", token: router.query.token as string }}
+          onSubmit={async (values) => {
+            try {
+              await resetPasswordMutation(values)
+            } catch (error: any) {
+              if (error.name === "ResetPasswordError") {
+                return {
+                  [FORM_ERROR]: error.message,
+                }
+              } else {
+                return {
+                  [FORM_ERROR]: "Sorry, we had an unexpected error. Please try again.",
+                }
+              }
+            }
+          }}
+        >
+          <LabeledTextField name="password" label="New Password" type="password" />
+          <LabeledTextField
+            name="passwordConfirmation"
+            label="Confirm New Password"
+            type="password"
+          />
+        </Form>
+      )}
+    </div>
+  )
+}
+
+ResetPasswordPage.redirectAuthenticatedTo = "/"
+ResetPasswordPage.getLayout = (page) => <Layout title="Reset Your Password">{page}</Layout>
+
+export default ResetPasswordPage


### PR DESCRIPTION
Related discussion: https://discord.com/channels/802917734999523368/870041934046060615/1009109220462968852

### What are the changes and their implications?

We were missing a `reset-password.tsx` file in the new app template. This PR adds it, and updates the reset password URL from `<host>/reset-password` to `<host>/auth/reset-password`.