### PR TITLE
Fix `replaceIdentifiers` codemod utility

### DIFF
--- a/.changeset/orange-zebras-reflect.md
+++ b/.changeset/orange-zebras-reflect.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/codemod": patch
+---
+
+Fix upgrade-legacy codemod replacing identifiers with an invalid value. Previously new values were hardcoded to `NextApiRequest`. Now we're using correct values provided as `replaceIdentifiers` function argument.

--- a/packages/blitz-next/src/index-browser.tsx
+++ b/packages/blitz-next/src/index-browser.tsx
@@ -46,7 +46,6 @@ const buildWithBlitz = <TPlugins extends readonly ClientPlugin<object>[]>(plugin
       return (
         <BlitzProvider dehydratedState={props.pageProps?.dehydratedState}>
           <>
-            {/* @ts-ignore todo */}
             {props.Component.suppressFirstRenderFlicker && <NoPageFlicker />}
             <UserAppRoot {...props} Component={component} />
           </>

--- a/packages/codemod/src/utils.ts
+++ b/packages/codemod/src/utils.ts
@@ -325,7 +325,7 @@ export function replaceIdentifiers(
   findIdentifier(program, identifier)
     .paths()
     .forEach((path) => {
-      path.value.name = "NextApiRequest"
+      path.value.name = newIdentifier
     })
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: https://github.com/blitz-js/blitz/issues/3758

Fixes a hardcoded value in `replaceIdentifiers` codemod utility.