### PR TITLE
Add AuthenticatedSessionContext to the codemod import map

### DIFF
--- a/.changeset/early-lamps-itch.md
+++ b/.changeset/early-lamps-itch.md
@@ -2,4 +2,4 @@
 "@blitzjs/codemod": patch
 ---
 
-Add AuthenticatedSessionContext to the codemod import map
+Add `AuthenticatedSessionContext` to the `upgrade-legacy` codemod import map

--- a/.changeset/early-lamps-itch.md
+++ b/.changeset/early-lamps-itch.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/codemod": patch
+---
+
+Add AuthenticatedSessionContext to the codemod import map

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib"
-}

--- a/packages/codemod/src/upgrade-legacy.ts
+++ b/packages/codemod/src/upgrade-legacy.ts
@@ -200,6 +200,7 @@ const upgradeLegacy = async () => {
         useSession: "@blitzjs/auth",
         useAuthenticatedSession: "@blitzjs/auth",
         useRedirectAuthenticated: "@blitzjs/auth",
+        AuthenticatedSessionContext: "@blitzjs/auth",
         SessionContext: "@blitzjs/auth",
         useAuthorize: "@blitzjs/auth",
         useQuery: "@blitzjs/rpc",
@@ -1099,7 +1100,7 @@ const upgradeLegacy = async () => {
             addNamedImport(program, "gSP", "app/blitz-server")
           }
           fs.writeFileSync(path.join(path.resolve(file)), program.toSource())
-        } catch (e:any) {
+        } catch (e: any) {
           log.error(`Error in wrapping getServerSideProps, getStaticProps in ${file}`)
           throw new Error(e)
         }
@@ -1129,7 +1130,7 @@ const upgradeLegacy = async () => {
 
               fs.writeFileSync(path.join(path.resolve(file)), program.toSource())
             }
-          } catch (e:any) {
+          } catch (e: any) {
             log.error(`Error in wrapping api in ${file}`)
             throw new Error(e)
           }


### PR DESCRIPTION
Closes: #3769 
### What are the changes and their implications?

We were missing `AuthenticatedSessionContext` from the codemod import map
