### PR TITLE
Delete and ignore next-env.d.ts files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ dist
 **/.env.local
 **/.env.*.local
 **/.envrc
+**/next-env.d.ts
 .blitz-*
 .blitz-cli-cache
 .tsbuildinfo
@@ -65,6 +66,4 @@ db.sqlite-journal
 **/db/db.sqlite
 test/integration/**/db.json
 test/**/*/out
-test/**/next-env.d.ts
-examples/**/next-env.d.ts
 .blitz**

--- a/apps/toolkit-app/next-env.d.ts
+++ b/apps/toolkit-app/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/integration-tests/auth/next-env.d.ts
+++ b/integration-tests/auth/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/integration-tests/get-initial-props/next-env.d.ts
+++ b/integration-tests/get-initial-props/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/integration-tests/middleware/next-env.d.ts
+++ b/integration-tests/middleware/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/integration-tests/no-suspense/next-env.d.ts
+++ b/integration-tests/no-suspense/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/integration-tests/qm/next-env.d.ts
+++ b/integration-tests/qm/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/integration-tests/react-query-utils/next-env.d.ts
+++ b/integration-tests/react-query-utils/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/integration-tests/rpc/next-env.d.ts
+++ b/integration-tests/rpc/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/integration-tests/trailing-slash/next-env.d.ts
+++ b/integration-tests/trailing-slash/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/generator/src/generators/app-generator.ts
+++ b/packages/generator/src/generators/app-generator.ts
@@ -41,14 +41,7 @@ export class AppGenerator extends Generator<AppGeneratorOptions> {
 
   filesToIgnore() {
     if (!this.options.useTs) {
-      return [
-        "tsconfig.json",
-        "next-env.d.ts",
-        "jest.config.ts",
-        "package.ts.json",
-        "pre-push-ts",
-        "types.ts",
-      ]
+      return ["tsconfig.json", "jest.config.ts", "package.ts.json", "pre-push-ts", "types.ts"]
     }
     return ["jsconfig.json", "package.js.json", "pre-push-js"]
   }

--- a/packages/generator/templates/app/gitignore
+++ b/packages/generator/templates/app/gitignore
@@ -18,6 +18,7 @@ web_modules/
 .now
 .blitz**
 blitz-log.log
+next-env.d.ts
 
 # misc
 .DS_Store

--- a/packages/generator/templates/app/next-env.d.ts
+++ b/packages/generator/templates/app/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/types/global" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/generator/templates/minimalapp/gitignore
+++ b/packages/generator/templates/minimalapp/gitignore
@@ -15,6 +15,7 @@ web_modules/
 .now
 .blitz**
 blitz-log.log
+next-env.d.ts
 
 # misc
 .DS_Store

--- a/packages/generator/templates/minimalapp/next-env.d.ts
+++ b/packages/generator/templates/minimalapp/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
Closes: Not associated with any issue

### What are the changes and their implications?

According to the [Next.js TypeScript documentation](https://nextjs.org/docs/basic-features/typescript#existing-projects) (see one of those boxes there) `next-env.d.ts` should not be put under version control.

I am not sure if we should just do this for newly generated apps using the templates or also the example apps and integrations tests. That's why I used two commits (if you only want to merge one of them).

> "This file should not be committed and should be ignored by version control (e.g. inside your .gitignore file)

By the way, the `.gitignore` files in the blitz repo are quite messy and could need a bit of love. Yeah, I know ... there are more important issues ;-)
