### PR TITLE
Remove `-cookie-prefix` appended to the cookiePrefix string

### DIFF
--- a/.changeset/silly-shoes-agree.md
+++ b/.changeset/silly-shoes-agree.md
@@ -2,4 +2,4 @@
 "@blitzjs/generator": patch
 ---
 
-Remove `-cookie-prefix` appended to the cookiePrefix string
+Remove `-cookie-prefix` appended to the cookiePrefix string in the generator template. This will also fix auth and CSRF issues for people upgrading.

--- a/.changeset/silly-shoes-agree.md
+++ b/.changeset/silly-shoes-agree.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Remove `-cookie-prefix` appended to the cookiePrefix string

--- a/.changeset/silly-shoes-agree.md
+++ b/.changeset/silly-shoes-agree.md
@@ -2,4 +2,4 @@
 "@blitzjs/generator": patch
 ---
 
-Remove `-cookie-prefix` appended to the cookiePrefix string in the generator template. This will also fix auth and CSRF issues for people upgrading.
+Remove `-cookie-prefix` appended to the `cookiePrefix` config property in the new app template. It will also fix auth and CSRF issues for users upgrading from a legacy framework.

--- a/packages/generator/templates/app/app/blitz-client.ts
+++ b/packages/generator/templates/app/app/blitz-client.ts
@@ -3,7 +3,7 @@ import { setupBlitzClient } from "@blitzjs/next"
 import { BlitzRpcPlugin } from "@blitzjs/rpc"
 
 export const authConfig = {
-  cookiePrefix: "__safeNameSlug__-cookie-prefix"
+  cookiePrefix: "__safeNameSlug__"
 }
 
 export const { withBlitz } = setupBlitzClient({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3231,7 +3231,6 @@ packages:
       semver: 5.7.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/preset-flow/7.17.12_@babel+core@7.18.2:
     resolution:
@@ -5691,7 +5690,6 @@ packages:
       typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/experimental-utils/5.28.0_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -9660,7 +9658,6 @@ packages:
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
 
   /eslint-config-next/12.2.5_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
@@ -9698,7 +9695,6 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: ">=7.0.0"
-    dev: false
 
   /eslint-config-prettier/8.5.0_eslint@7.32.0:
     resolution:


### PR DESCRIPTION
Per: https://discord.com/channels/802917734999523368/1012007617700315306/1012085676398886942

### What are the changes and their implications?

Legacy blitz never had the `-cookie-prefix` appended to the cookiePrefix string. This removes it from the generator that is also used for the codemod.
