### PR TITLE
Codemod should convert import statements to require when creating next.config.js

### DIFF
--- a/.changeset/long-dancers-jog.md
+++ b/.changeset/long-dancers-jog.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/codemod": patch
+---
+
+Convert import statements to require when creating the next.config.js file in the codemod

--- a/packages/codemod/src/upgrade-legacy.ts
+++ b/packages/codemod/src/upgrade-legacy.ts
@@ -68,8 +68,6 @@ const upgradeLegacy = async () => {
         })
       }
       
-      
-
       // Remove all typescript stuff
       let findTypes = program.find(j.TSType, (node) => node)
       if (findTypes.length) {

--- a/packages/codemod/src/upgrade-legacy.ts
+++ b/packages/codemod/src/upgrade-legacy.ts
@@ -66,7 +66,8 @@ const upgradeLegacy = async () => {
             j(c.parentPath).remove()
           }
         })
-      }     
+      }
+      
       // Remove all typescript stuff
       let findTypes = program.find(j.TSType, (node) => node)
       if (findTypes.length) {
@@ -114,20 +115,20 @@ const upgradeLegacy = async () => {
               j.assignmentExpression(
                 "=",
                 j.identifier("const " + defaultImport.local.name),
-                j.callExpression(j.identifier("require"), [j.stringLiteral(i.value.source.value as string)]),
+                j.callExpression(j.identifier("require"), [j.stringLiteral(`${i.value.source.value}`)]),
               ),
             )
             parsedProgram.value.program.body.unshift(importStatement)
             flag=true
           }  
           if(namedImports && namedImports.length){
-            const namedImportNames = namedImports.map((s) => s.local?.name as string)
+            const namedImportNames = namedImports.map((s) => s.local?.name)
             const namedImportNamesString = namedImportNames.join(", ")
             const importStatement = j.expressionStatement(
               j.assignmentExpression(
                 "=",
                 j.identifier("const {" + namedImportNamesString + "}"),
-                j.callExpression(j.identifier("require"), [j.stringLiteral(i.value.source.value as string)]),
+                j.callExpression(j.identifier("require"), [j.stringLiteral(`${i.value.source.value}`)]),
               ),
             )
             parsedProgram.value.program.body.unshift(importStatement)

--- a/packages/codemod/src/upgrade-legacy.ts
+++ b/packages/codemod/src/upgrade-legacy.ts
@@ -67,6 +67,8 @@ const upgradeLegacy = async () => {
           }
         })
       }
+      
+      
 
       // Remove all typescript stuff
       let findTypes = program.find(j.TSType, (node) => node)

--- a/packages/codemod/src/upgrade-legacy.ts
+++ b/packages/codemod/src/upgrade-legacy.ts
@@ -66,8 +66,7 @@ const upgradeLegacy = async () => {
             j(c.parentPath).remove()
           }
         })
-      }
-      
+      }     
       // Remove all typescript stuff
       let findTypes = program.find(j.TSType, (node) => node)
       if (findTypes.length) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: #3800

**Testing using https://github.com/blitz-js/legacy-framework/blob/main/examples/auth/blitz.config.ts**

## Before
```ts
//blitz.config.ts
import {sessionMiddleware, simpleRolesIsAuthorized} from "blitz"
import db from "db"
const withBundleAnalyzer = require("@next/bundle-analyzer")({
  enabled: process.env.ANALYZE === "true",
})

module.exports = withBundleAnalyzer({
  middleware: [
    sessionMiddleware({
      cookiePrefix: "blitz-auth-example",
      isAuthorized: simpleRolesIsAuthorized,
      // sessionExpiryMinutes: 4,
      getSession: (handle) => db.session.findFirst({where: {handle}}),
    }),
  ],
  cli: {
    clearConsoleOnBlitzDev: false,
  },
  codegen: {
    templateDir: "./my-templates",
  },
  log: {
    // level: "trace",
  },
  experimental: {
    initServer() {
      console.log("Hello world from initServer")
    },
  },
  /*
  webpack: (config, {buildId, dev, isServer, defaultLoaders, webpack}) => {
    // Note: we provide webpack above so you should not `require` it
    // Perform customizations to webpack config
    // Important: return the modified config
    return config
  },
  webpackDevMiddleware: (config) => {
    // Perform customizations to webpack dev middleware config
    // Important: return the modified config
    return config
  },
  */
})
```

## After
```js
//next.config.js
const db = require("db");
const {sessionMiddleware, simpleRolesIsAuthorized} = require("blitz");
const { withBlitz } = require("@blitzjs/next");
const withBundleAnalyzer = require("@next/bundle-analyzer")({
  enabled: process.env.ANALYZE === "true",
})

module.exports = withBlitz(withBundleAnalyzer({
  cli: {
    clearConsoleOnBlitzDev: false,
  },

  codegen: {
    templateDir: "./my-templates",
  },

  log: {
    // level: "trace",
  },

  experimental: {
    initServer() {
      console.log("Hello world from initServer")
    },
  }
  /*
  webpack: (config, {buildId, dev, isServer, defaultLoaders, webpack}) => {
    // Note: we provide webpack above so you should not `require` it
    // Perform customizations to webpack config
    // Important: return the modified config
    return config
  },
  webpackDevMiddleware: (config) => {
    // Perform customizations to webpack dev middleware config
    // Important: return the modified config
    return config
  },
  */
}));
```