### PR TITLE
Fix remote caching in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+  
+env:
+  TURBO_TOKEN: 05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8
+  TURBO_TEAM: foo
 
 jobs:
   lint:
@@ -37,11 +41,11 @@ jobs:
           uses: felixmosh/turborepo-gh-artifacts@v1
           with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
-            server-token: 05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8
+            server-token: ${{ env.TURBO_TOKEN }}
         - name: Build
-          run: pnpm build -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
+          run: pnpm build -- --api="http://127.0.0.1:9080"
         - name: Lint
-          run: pnpm lint -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
+          run: pnpm lint -- --api="http://127.0.0.1:9080"
     
   build:
       runs-on: ${{ matrix.os }}
@@ -68,11 +72,11 @@ jobs:
           uses: felixmosh/turborepo-gh-artifacts@v1
           with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
-            server-token: 05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8
+            server-token: ${{ env.TURBO_TOKEN }}
         - name: Build
-          run: pnpm build -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
+          run: pnpm build -- --api="http://127.0.0.1:9080"
         - name: Build Apps 
-          run: pnpm build:apps -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
+          run: pnpm build:apps -- --api="http://127.0.0.1:9080"
 
   test:
     name: 'Test: ${{ matrix.os }} (node@${{ matrix.NODE_VERSION }})'
@@ -108,11 +112,11 @@ jobs:
         uses: felixmosh/turborepo-gh-artifacts@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          server-token: 05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8
+          server-token: ${{ env.TURBO_TOKEN }}
 
       - name: Build
-        run: pnpm build -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
+        run: pnpm build -- --api="http://127.0.0.1:9080"
 
       - name: Test
-        run: pnpm test -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
+        run: pnpm test -- --api="http://127.0.0.1:9080"
             

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,11 +37,11 @@ jobs:
           uses: felixmosh/turborepo-gh-artifacts@v1
           with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
-            server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
+            server-token: 05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8
         - name: Build
-          run: pnpm build -- --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="foo"
+          run: pnpm build -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
         - name: Lint
-          run: pnpm lint -- --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="foo"
+          run: pnpm lint -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
     
   build:
       runs-on: ${{ matrix.os }}
@@ -68,11 +68,11 @@ jobs:
           uses: felixmosh/turborepo-gh-artifacts@v1
           with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
-            server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
+            server-token: 05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8
         - name: Build
-          run: pnpm build -- --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="foo"
+          run: pnpm build -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
         - name: Build Apps
-          run: pnpm build:apps -- --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="foo"
+          run: pnpm build:apps -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
 
   test:
     name: 'Test: ${{ matrix.os }} (node@${{ matrix.NODE_VERSION }})'
@@ -108,11 +108,11 @@ jobs:
         uses: felixmosh/turborepo-gh-artifacts@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
+          server-token: 05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8
 
       - name: Build
-        run: pnpm build -- --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="foo"
+        run: pnpm build -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
 
       - name: Test
-        run: pnpm test -- --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="foo"
+        run: pnpm test -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
             

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
             server-token: 05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8
         - name: Build
           run: pnpm build -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
-        - name: Build Apps
+        - name: Build Apps 
           run: pnpm build:apps -- --api="http://127.0.0.1:9080" --token="05de0230f01174d1f8cb4845a01dc6c895ce28f04ebef2318ab11615791b871c35eabbf8" --team="foo"
 
   test:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

Closes: ?

### What are the changes and their implications?

- [x] Change the server-token given to the ```felixmosh/turborepo-gh-artifacts@v1``` GitHub action from secret value to pre-defined random 36 hex value generated by ```openssl```.

This is requested to be changed as GitHub only allows actions triggered from within the repository the access the secrets defined in the repository, with the exception of the ```GITHUB_TOKEN```

https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow

![image](https://user-images.githubusercontent.com/83594610/187928259-10501dcb-ba38-4e12-84dd-8b98dacb7532.png)

So, whenever a fork triggers the action the windows test fails most of the time due to an exit of a test as the remote caching feature of turbo is not enabled due to a null string being passed as the server-token argument

![image](https://user-images.githubusercontent.com/83594610/187926354-c735afda-6931-42ae-b2ad-229aae6232cb.png)
