### PR TITLE
Add RPC handler to middleware stack

### DIFF
--- a/packages/blitz-next/src/index-server.ts
+++ b/packages/blitz-next/src/index-server.ts
@@ -187,8 +187,8 @@ export const setupBlitzServer = ({plugins, onError}: SetupBlitzOptions) => {
     ): NextApiHandler<TResult | void> =>
     async (req, res) => {
       try {
-        await handleRequestWithMiddleware(req, res, middlewares)
-        return handler(req, res, res.blitzCtx)
+        middlewares.push((req, res) => handler(req, res, res.blitzCtx));
+        return await blitz.handleRequestWithMiddleware(req, res, middlewares);
       } catch (error: any) {
         onError?.(error)
         return res.status(400).send(error)


### PR DESCRIPTION
Closes: #3829 

### What are the changes and their implications?
Changed the `api` function factory to treat any Blitz RPC handler the same way as other middlewares, allowing middleware code to run after the handler has run.

## Bug Checklist
- Not sure if this requires an integration test.