### PR TITLE
Throw redirect errors when component has mounted in blitz-auth

### DIFF
--- a/.changeset/heavy-cobras-own.md
+++ b/.changeset/heavy-cobras-own.md
@@ -1,0 +1,7 @@
+---
+"@blitzjs/auth": patch
+"@blitzjs/next": patch
+"blitz": patch
+---
+
+Ensure the component has mounted before throwing a redirect with redirectAuthenticatedTo. This will fix the hydration error from react.

--- a/.changeset/heavy-cobras-own.md
+++ b/.changeset/heavy-cobras-own.md
@@ -4,4 +4,4 @@
 "blitz": patch
 ---
 
-Ensure the component has mounted before throwing a redirect with redirectAuthenticatedTo. This will fix the hydration error from react.
+Fix auth related React hydration errors by not redirecting until after component mount.

--- a/apps/toolkit-app/pages/index.tsx
+++ b/apps/toolkit-app/pages/index.tsx
@@ -271,4 +271,6 @@ const Home: BlitzPage = () => {
   )
 }
 
+Home.authenticate = true
+
 export default Home

--- a/packages/blitz-auth/src/client/index.tsx
+++ b/packages/blitz-auth/src/client/index.tsx
@@ -248,10 +248,12 @@ export function getAuthValues<TProps = any>(
 function withBlitzAuthPlugin<TProps = any>(Page: ComponentType<TProps> | BlitzPage<TProps>) {
   const AuthRoot = (props: ComponentProps<any>) => {
     useSession({suspense: false})
-    const [mounted, setMounted] = useState<boolean>(false)
+    const [mounted, setMounted] = useState(false)
 
     useEffect(() => {
       setMounted(true)
+
+      return () => setMounted(false)
     }, [])
 
     let {authenticate, redirectAuthenticatedTo} = getAuthValues(Page, props)

--- a/packages/blitz-auth/src/client/index.tsx
+++ b/packages/blitz-auth/src/client/index.tsx
@@ -169,8 +169,6 @@ export const useAuthorizeIf = (condition?: boolean) => {
 
   useEffect(() => {
     setMounted(true)
-
-    return () => setMounted(false)
   }, [])
 
   if (isClient && condition && !getPublicDataStore().getData().userId && mounted) {
@@ -196,8 +194,6 @@ export const useRedirectAuthenticated = (to: UrlObject | string) => {
 
   useEffect(() => {
     setMounted(true)
-
-    return () => setMounted(false)
   }, [])
 
   if (isClient && getPublicDataStore().getData().userId && mounted) {
@@ -268,8 +264,6 @@ function withBlitzAuthPlugin<TProps = any>(Page: ComponentType<TProps> | BlitzPa
 
     useEffect(() => {
       setMounted(true)
-
-      return () => setMounted(false)
     }, [])
 
     let {authenticate, redirectAuthenticatedTo} = getAuthValues(Page, props)

--- a/packages/blitz-auth/src/client/index.tsx
+++ b/packages/blitz-auth/src/client/index.tsx
@@ -248,6 +248,11 @@ export function getAuthValues<TProps = any>(
 function withBlitzAuthPlugin<TProps = any>(Page: ComponentType<TProps> | BlitzPage<TProps>) {
   const AuthRoot = (props: ComponentProps<any>) => {
     useSession({suspense: false})
+    const [mounted, setMounted] = useState<boolean>(false)
+
+    useEffect(() => {
+      setMounted(true)
+    }, [])
 
     let {authenticate, redirectAuthenticatedTo} = getAuthValues(Page, props)
 
@@ -274,9 +279,11 @@ function withBlitzAuthPlugin<TProps = any>(Page: ComponentType<TProps> | BlitzPa
               : formatWithValidation(redirectAuthenticatedTo)
 
           debug("[BlitzAuthInnerRoot] redirecting to", redirectUrl)
-          const error = new RedirectError(redirectUrl)
-          error.stack = null!
-          throw error
+          if (mounted) {
+            const error = new RedirectError(redirectUrl)
+            error.stack = null!
+            throw error
+          }
         }
       } else {
         debug("[BlitzAuthInnerRoot] logged out")
@@ -289,9 +296,11 @@ function withBlitzAuthPlugin<TProps = any>(Page: ComponentType<TProps> | BlitzPa
           const url = new URL(redirectTo, window.location.href)
           url.searchParams.append("next", window.location.pathname)
           debug("[BlitzAuthInnerRoot] redirecting to", url.toString())
-          const error = new RedirectError(url.toString())
-          error.stack = null!
-          throw error
+          if (mounted) {
+            const error = new RedirectError(url.toString())
+            error.stack = null!
+            throw error
+          }
         }
       }
     }

--- a/packages/blitz-auth/src/client/index.tsx
+++ b/packages/blitz-auth/src/client/index.tsx
@@ -165,7 +165,15 @@ export const useSession = (options: UseSessionOptions = {}): ClientSession => {
 }
 
 export const useAuthorizeIf = (condition?: boolean) => {
-  if (isClient && condition && !getPublicDataStore().getData().userId) {
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+
+    return () => setMounted(false)
+  }, [])
+
+  if (isClient && condition && !getPublicDataStore().getData().userId && mounted) {
     const error = new AuthenticationError()
     error.stack = null!
     throw error
@@ -184,7 +192,15 @@ export const useAuthenticatedSession = (
 }
 
 export const useRedirectAuthenticated = (to: UrlObject | string) => {
-  if (isClient && getPublicDataStore().getData().userId) {
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+
+    return () => setMounted(false)
+  }, [])
+
+  if (isClient && getPublicDataStore().getData().userId && mounted) {
     const error = new RedirectError(to)
     error.stack = null!
     throw error
@@ -280,8 +296,8 @@ function withBlitzAuthPlugin<TProps = any>(Page: ComponentType<TProps> | BlitzPa
               ? redirectAuthenticatedTo
               : formatWithValidation(redirectAuthenticatedTo)
 
-          debug("[BlitzAuthInnerRoot] redirecting to", redirectUrl)
           if (mounted) {
+            debug("[BlitzAuthInnerRoot] redirecting to", redirectUrl)
             const error = new RedirectError(redirectUrl)
             error.stack = null!
             throw error
@@ -297,8 +313,9 @@ function withBlitzAuthPlugin<TProps = any>(Page: ComponentType<TProps> | BlitzPa
 
           const url = new URL(redirectTo, window.location.href)
           url.searchParams.append("next", window.location.pathname)
-          debug("[BlitzAuthInnerRoot] redirecting to", url.toString())
+
           if (mounted) {
+            debug("[BlitzAuthInnerRoot] redirecting to", url.toString())
             const error = new RedirectError(url.toString())
             error.stack = null!
             throw error

--- a/packages/blitz-next/src/error-boundary.tsx
+++ b/packages/blitz-next/src/error-boundary.tsx
@@ -81,6 +81,7 @@ class ErrorBoundary extends React.Component<
 
   state = initialState
   updatedWithError = false
+
   resetErrorBoundary = (...args: Array<unknown>) => {
     this.props.onReset?.(...args)
     this.reset()
@@ -94,6 +95,7 @@ class ErrorBoundary extends React.Component<
   async componentDidCatch(error: Error, info: React.ErrorInfo) {
     if (error instanceof RedirectError) {
       debug("Redirecting from ErrorBoundary to", error.url)
+
       await (this.context as Router)?.push(error.url)
       return
     }


### PR DESCRIPTION
Closes: #3840

### What are the changes and their implications?

Inside `blitz-auth`, make sure the component has mounted before throwing the `RedirectError()`.