### PR TITLE
Update regex for wildcard blitz route in webpack config

### DIFF
--- a/.changeset/itchy-spoons-tan.md
+++ b/.changeset/itchy-spoons-tan.md
@@ -1,0 +1,6 @@
+---
+"@blitzjs/rpc": patch
+"blitz": patch
+---
+
+Allow for custom page extensions for the wildcard blitz route. For example [...blitz].api.ts

--- a/.changeset/itchy-spoons-tan.md
+++ b/.changeset/itchy-spoons-tan.md
@@ -3,4 +3,4 @@
 "blitz": patch
 ---
 
-Allow for custom page extensions for the wildcard blitz route. For example [...blitz].api.ts
+Allow for custom page extensions for the wildcard blitz route. For example [...blitz].api.ts. For more information vist https://nextjs.org/docs/api-reference/next.config.js/custom-page-extensions

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -88,7 +88,7 @@ export function installWebpackConfig({
   webpackConfig.resolve.alias["npm-which"] = false
   webpackConfig.resolve.alias["cross-spawn"] = false
   webpackConfig.module.rules.push({
-    test: /[\\/]\[\[\.\.\.blitz]].+\.[jt]sx?$/,
+    test: /[\\/]\[\[\.\.\.blitz]]?.+\.[jt]sx?$/,
     use: [
       {
         loader: loaderServer,

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -88,7 +88,7 @@ export function installWebpackConfig({
   webpackConfig.resolve.alias["npm-which"] = false
   webpackConfig.resolve.alias["cross-spawn"] = false
   webpackConfig.module.rules.push({
-    test: /[\\/]\[\[\.\.\.blitz]]\.[jt]sx?$/,
+    test: /[\\/]\[\[\.\.\.blitz]].+\.[jt]sx?$/,
     use: [
       {
         loader: loaderServer,


### PR DESCRIPTION
Closes: #3841

### What are the changes and their implications?

Allow for custom page extensions for the wildcard blitz route. This PR update's the regex in the webpack config found in `blitz-rpc`.