### PR TITLE
Update generator templates to stop breaking no-floating-promises rule

### DIFF
--- a/.changeset/eleven-lobsters-drop.md
+++ b/.changeset/eleven-lobsters-drop.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Fix `no-floating-promises` lint errors after generating pages with Blitz generator by adding `await` to `router.push` calls in the templates

--- a/packages/generator/templates/page/__modelIdParam__.tsx
+++ b/packages/generator/templates/page/__modelIdParam__.tsx
@@ -46,9 +46,9 @@ export const __ModelName__ = () => {
             if (window.confirm("This will be deleted")) {
               await delete__ModelName__Mutation({id: __modelName__.id})
               if (process.env.parentModel) {
-                router.push(Routes.__ModelNames__Page({ __parentModelId__: __parentModelId__! }))
+                await router.push(Routes.__ModelNames__Page({ __parentModelId__: __parentModelId__! }))
               } else {
-                router.push(Routes.__ModelNames__Page())
+                await router.push(Routes.__ModelNames__Page())
               }
             }
           }}

--- a/packages/generator/templates/page/__modelIdParam__/edit.tsx
+++ b/packages/generator/templates/page/__modelIdParam__/edit.tsx
@@ -51,7 +51,7 @@ export const Edit__ModelName__ = () => {
                 ...values
               })
               await setQueryData(updated)
-              router.push(
+              await router.push(
                 process.env.parentModel
                   ? Routes.Show__ModelName__Page({ __parentModelId__: __parentModelId__!, __modelId__: updated.id })
                   : Routes.Show__ModelName__Page({ __modelId__: updated.id })

--- a/packages/generator/templates/page/new.tsx
+++ b/packages/generator/templates/page/new.tsx
@@ -38,7 +38,7 @@ const New__ModelName__Page = () => {
                 ? {...values, __parentModelId__: __parentModelId__!}
                 : values,
             )
-            router.push(
+            await router.push(
               process.env.parentModel
                 ? Routes.Show__ModelName__Page({ __parentModelId__: __parentModelId__!, __modelId__: __modelName__.id })
                 : Routes.Show__ModelName__Page({ __modelId__: __modelName__.id }),


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/3633
