### PR TITLE
Fix help CLI command not working correctly

### DIFF
--- a/.changeset/breezy-bees-beg.md
+++ b/.changeset/breezy-bees-beg.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Fix `blitz --help` CLI command not being found

--- a/packages/blitz/src/cli/index.ts
+++ b/packages/blitz/src/cli/index.ts
@@ -41,7 +41,7 @@ const aliases: Record<string, keyof typeof commands> = {
   b: "build",
   s: "start",
   n: "new",
-  // g: "generate",
+  g: "generate",
 }
 
 type Command = keyof typeof commands
@@ -164,10 +164,7 @@ async function main() {
         console.log(err)
       })
   } else {
-    if (args["--help"] && args._.length === 0) {
-      // TODO: add back the generate command description once it's working
-      // generate, g     Generate new files for your Blitz project 🤠
-
+    if (args["--help"] && forwardedArgs.length === 1 && forwardedArgs[0] === "--help") {
       console.log(`
       Usage
         $ blitz <command>
@@ -177,6 +174,7 @@ async function main() {
         build, b        Create a production build 🏗️
         start, s        Start the production server 🐎
         new, n          Create a new Blitz project ✨
+        generate, g     Generate new files for your Blitz project 🤠
         codegen         Run the blitz codegen 🤖
         db              Run database commands 🗄️
         


### PR DESCRIPTION
Fixed the condition for displaying the help message. `--help` is in the argument so we need to check whether it's the only argument (otherwise it should be passed to a bin command).

Closes: https://github.com/blitz-js/blitz/issues/3812
