### PR TITLE
Only generate the prisma client if it's not found

### DIFF
--- a/.changeset/olive-kings-invent.md
+++ b/.changeset/olive-kings-invent.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Only generate the prisma client if it's not found in node_modules when running a blitz cli command.

--- a/packages/blitz/src/cli/utils/codegen-tasks.ts
+++ b/packages/blitz/src/cli/utils/codegen-tasks.ts
@@ -40,21 +40,24 @@ export const codegenTasks = async () => {
 
     if (hasPrisma) {
       const foundPrismaClient = resolveFrom.silent(process.cwd(), "@prisma/client")
+      const foundDotPrismaClient = resolveFrom.silent(process.cwd(), ".prisma")
+
       if (
         !foundPrismaClient ||
-        (foundPrismaClient && !fs.existsSync(join(foundPrismaClient, "../../..", ".prisma")))
+        (foundPrismaClient && !fs.existsSync(join(foundPrismaClient, "../../..", ".prisma"))) ||
+        (foundDotPrismaClient && !foundDotPrismaClient)
       ) {
         let prismaSpinner = log.spinner(`Generating Prisma client`).start()
         const result = await runPrisma(["generate"], true)
-        if (result.success) {
-          prismaSpinner.succeed(log.greenText("Generated Prisma client"))
-        } else {
-          prismaSpinner.fail()
-          console.log("\n" + result.stderr)
-          process.exit(1)
+        if (typeof result === "object") {
+          if (result.success) {
+            prismaSpinner.succeed(log.greenText("Generated Prisma client"))
+          } else {
+            prismaSpinner.fail()
+            console.log("\n" + result.stderr)
+            process.exit(1)
+          }
         }
-      } else {
-        log.success("Prisma client was up to date")
       }
     }
   } catch (err) {

--- a/packages/blitz/src/cli/utils/codegen-tasks.ts
+++ b/packages/blitz/src/cli/utils/codegen-tasks.ts
@@ -5,8 +5,8 @@ import {join} from "path"
 import fs from "fs-extra"
 import {getPackageJson} from "./get-package-json"
 import {runPrisma} from "../../utils/run-prisma"
-import os from "os"
 
+import resolveFrom from "resolve-from"
 export const codegenTasks = async () => {
   try {
     /* 
@@ -39,33 +39,23 @@ export const codegenTasks = async () => {
     )
 
     if (hasPrisma) {
-        const tempDir = os.tmpdir()
-        const creationDate = await fs.stat(process.cwd())
-        if (!fs.existsSync(join(tempDir, `blitz-${creationDate.birthtimeMs}-prisma-client.json`))) {
-            const lastModified = await fs.stat(join(process.cwd(), "db/schema.prisma"))
-            await fs.writeFile(
-                join(tempDir, `blitz-${creationDate.birthtimeMs}-prisma-client.json`),
-                JSON.stringify({ lastModified: lastModified.mtimeMs }),
-            )
-        }
-        const prismaStatus = await fs.readJson(join(tempDir, `blitz-${creationDate.birthtimeMs}-prisma-client.json`))
-        const lastModified = await fs.stat(join(process.cwd(), "db/schema.prisma"))
-        if (prismaStatus.lastModified !== lastModified.mtimeMs) {
-            let prismaSpinner = log.spinner(`Generating Prisma client`).start()
-            const result = await runPrisma(["generate"], true)
-            if (result.success) {
-                prismaSpinner.succeed(log.greenText("Generated Prisma client"))
-            } else {
-                prismaSpinner.fail()
-                console.log("\n" + result.stderr)
-                process.exit(1)
-            }
-            await fs.writeJson(join(process.cwd(), `blitz-${creationDate.birthtimeMs}-prisma-client.json`), {
-                lastModified: lastModified.mtimeMs,
-            })
+      const foundPrismaClient = resolveFrom.silent(process.cwd(), "@prisma/client")
+      if (
+        !foundPrismaClient ||
+        (foundPrismaClient && !fs.existsSync(join(foundPrismaClient, "../../..", ".prisma")))
+      ) {
+        let prismaSpinner = log.spinner(`Generating Prisma client`).start()
+        const result = await runPrisma(["generate"], true)
+        if (result.success) {
+          prismaSpinner.succeed(log.greenText("Generated Prisma client"))
         } else {
-            log.success("Prisma client was up to date")
+          prismaSpinner.fail()
+          console.log("\n" + result.stderr)
+          process.exit(1)
         }
+      } else {
+        log.success("Prisma client was up to date")
+      }
     }
   } catch (err) {
     log.error(JSON.stringify(err, null, 2))

--- a/packages/blitz/src/utils/run-prisma.ts
+++ b/packages/blitz/src/utils/run-prisma.ts
@@ -1,27 +1,32 @@
-import which from "npm-which"
 import pEvent from "p-event"
 import {Readable} from "stream"
 import {spawn} from "cross-spawn"
+import resolveFrom from "resolve-from"
+import {log} from "../logging"
 
 export const runPrisma = async (args: string[], silent = false) => {
-  const prismaBin = which(process.cwd()).sync("prisma")
+  const prismaBin = resolveFrom.silent(process.cwd(), "prisma")
 
-  const cp = spawn(prismaBin, args, {
-    stdio: silent ? "pipe" : "inherit",
-    env: process.env,
-  })
-
-  const cp_stderr: string[] = []
-  if (silent) {
-    cp?.stderr?.on("data", (chunk: Readable) => {
-      cp_stderr.push(chunk.toString())
+  if (prismaBin) {
+    const cp = spawn(prismaBin, args, {
+      stdio: silent ? "pipe" : "inherit",
+      env: process.env,
     })
-  }
 
-  const code = await pEvent(cp, "exit", {rejectionEvents: []})
+    const cp_stderr: string[] = []
+    if (silent) {
+      cp?.stderr?.on("data", (chunk: Readable) => {
+        cp_stderr.push(chunk.toString())
+      })
+    }
 
-  return {
-    success: code === 0,
-    stderr: silent ? cp_stderr.join("") : undefined,
+    const code = await pEvent(cp, "exit", {rejectionEvents: []})
+
+    return {
+      success: code === 0,
+      stderr: silent ? cp_stderr.join("") : undefined,
+    }
+  } else {
+    log.error("Prisma bin not found")
   }
 }

--- a/packages/blitz/src/utils/run-prisma.ts
+++ b/packages/blitz/src/utils/run-prisma.ts
@@ -27,6 +27,8 @@ export const runPrisma = async (args: string[], silent = false) => {
       stderr: silent ? cp_stderr.join("") : undefined,
     }
   } else {
-    log.error("Prisma bin not found")
+    return {
+      success: false,
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,7 +450,7 @@ importers:
       "@vitejs/plugin-react": 1.3.0
       delay: 5.0.0
       eslint: 7.32.0
-      eslint-config-next: 12.3.0_hrkuebk64jiu2ut2d2sm4oylnu
+      eslint-config-next: 12.3.1_hrkuebk64jiu2ut2d2sm4oylnu
       eslint-plugin-testing-library: 5.0.1_hrkuebk64jiu2ut2d2sm4oylnu
       jsdom: 19.0.0
       typescript: 4.6.3
@@ -4228,10 +4228,10 @@ packages:
     dependencies:
       glob: 7.1.7
 
-  /@next/eslint-plugin-next/12.3.0:
+  /@next/eslint-plugin-next/12.3.1:
     resolution:
       {
-        integrity: sha512-jVdq1qYTNDjUtulnE8/hkPv0pHILV4jMg5La99iaY/FFm20WxVnsAZtbNnMvlPbf8dc010oO304SX9yXbg5PAw==,
+        integrity: sha512-sw+lTf6r6P0j+g/n9y4qdWWI2syPqZx+uc0+B/fRENqfR3KpSid6MIKqc9gNwGhJASazEQ5b3w8h4cAET213jw==,
       }
     dependencies:
       glob: 7.1.7
@@ -9703,10 +9703,10 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-config-next/12.3.0_hrkuebk64jiu2ut2d2sm4oylnu:
+  /eslint-config-next/12.3.1_hrkuebk64jiu2ut2d2sm4oylnu:
     resolution:
       {
-        integrity: sha512-guHSkNyKnTBB8HU35COgAMeMV0E026BiYRYvyEVVaTOeFcnU3i1EI8/Da0Rl7H3Sgua5FEvoA0vYd2s8kdIUXg==,
+        integrity: sha512-EN/xwKPU6jz1G0Qi6Bd/BqMnHLyRAL0VsaQaWA7F3KkjAgZHi4f1uL1JKGWNxdQpHTW/sdGONBd0bzxUka/DJg==,
       }
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -9715,7 +9715,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      "@next/eslint-plugin-next": 12.3.0
+      "@next/eslint-plugin-next": 12.3.1
       "@rushstack/eslint-patch": 1.1.3
       "@typescript-eslint/parser": 5.28.0_hrkuebk64jiu2ut2d2sm4oylnu
       eslint: 7.32.0
@@ -9723,7 +9723,7 @@ packages:
       eslint-import-resolver-typescript: 2.7.1_hpmu7kn6tcn2vnxpfzvv33bxmy
       eslint-plugin-import: 2.26.0_zhtk6rij7obli3ams3sxis7j7e
       eslint-plugin-jsx-a11y: 6.5.1_eslint@7.32.0
-      eslint-plugin-react: 7.30.0_eslint@7.32.0
+      eslint-plugin-react: 7.31.8_eslint@7.32.0
       eslint-plugin-react-hooks: 4.5.0_eslint@7.32.0
       typescript: 4.6.3
     transitivePeerDependencies:
@@ -9997,6 +9997,32 @@ packages:
     resolution:
       {
         integrity: sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==,
+      }
+    engines: {node: ">=4"}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+    dependencies:
+      array-includes: 3.1.5
+      array.prototype.flatmap: 1.3.0
+      doctrine: 2.1.0
+      eslint: 7.32.0
+      estraverse: 5.3.0
+      jsx-ast-utils: 3.3.0
+      minimatch: 3.1.2
+      object.entries: 1.1.5
+      object.fromentries: 2.0.5
+      object.hasown: 1.1.1
+      object.values: 1.1.5
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.3
+      semver: 6.3.0
+      string.prototype.matchall: 4.0.7
+    dev: true
+
+  /eslint-plugin-react/7.31.8_eslint@7.32.0:
+    resolution:
+      {
+        integrity: sha512-5lBTZmgQmARLLSYiwI71tiGVTLUuqXantZM6vlSY39OaDSV0M7+32K5DnLkmFrwTe+Ksz0ffuLUC91RUviVZfw==,
       }
     engines: {node: ">=4"}
     peerDependencies:


### PR DESCRIPTION
Closes: #3801 , https://github.com/blitz-js/blitz/issues/3776

### What are the changes and their implications?

Only generate the prisma client if it's not found. It checks for both `@prisma/client` and `.prisma`.