### PR TITLE
update userId to be exclusive union of `number` and `string`

### DIFF
--- a/packages/blitz-auth/src/shared/types.ts
+++ b/packages/blitz-auth/src/shared/types.ts
@@ -4,10 +4,20 @@ export interface Session {
   // isAuthorize can be injected here
   // PublicData can be injected here
 }
+/**
+ * XOR is needed to have a real mutually exclusive union type
+ * https://stackoverflow.com/a/53229567/5608461
+ */
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+type XOR<T, U> =
+ T extends object ?
+ U extends object ?
+   (Without<T, U> & U) | (Without<U, T> & T)
+ : U : T
 
 export type PublicData = Session extends {PublicData: unknown}
   ? Session["PublicData"]
-  : {userId: unknown}
+  : {userId: XOR<number,string>}
 
 export interface EmptyPublicData extends Partial<Omit<PublicData, "userId">> {
   userId: PublicData["userId"] | null


### PR DESCRIPTION
Closes: I haven't opened an issue for this. I [documented this](https://twitter.com/richardpoelderl/status/1575166499827744772?s=20&t=sSgCX9pPyrtUTQ0uN1QYsg) in a twitter thread if that's any help. Also, you can see the error in the demo below.

### What are the changes and their implications?
The userId is currently typed as `unknown` which throws a type error when the prisma model is defined as an `Int`
![image](https://user-images.githubusercontent.com/18185649/192862199-df194453-2a32-496c-a3fb-6a9b85117bd8.png)

Similarly to how prisma provides `XOR` types, I've patched the PublicData["userId"] type to be a mutually exclusive union instead.

I'm not sure where to include the `XOR` & `Without` type utilities, please let me know if they should be moved elsewhere.

Here's a demo of how this makes the types error disappear (& how a regular union isn't enough):
https://user-images.githubusercontent.com/18185649/192862646-ae681846-1db5-4d60-9ff7-4591f9b17a87.mov

## Bug Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `canary` branch](https://github.com/blitz-js/blitzjs.com/tree/canary))
