### PR TITLE
Add `blitz export` command

### DIFF
--- a/.changeset/itchy-houses-marry.md
+++ b/.changeset/itchy-houses-marry.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Add `blitz export` CLI command to toolkit

--- a/packages/blitz/src/cli/commands/next/export.ts
+++ b/packages/blitz/src/cli/commands/next/export.ts
@@ -1,6 +1,5 @@
 import arg from "arg"
-import {resolve, join} from "path"
-import chalk from "chalk"
+import {resolve} from "path"
 import {CliCommand} from "../../index"
 import {ServerConfig} from "../../utils/config"
 
@@ -29,15 +28,17 @@ const nextExport: CliCommand = async () => {
   const getHelp = async () => {
     if (nextArgs["--help"]) {
       console.log(`
-        Description
-          Exports the application for production deployment
-        Usage
-          $ next export [options] <dir>
-        <dir> represents the directory of the Blitz.js application.
-        If no directory is provided, the current directory will be used.
-        Options
-          -h - list this help
-          -o - set the output dir (defaults to 'out')
+Description
+  Exports your Blitz app as a static application. Make sure to run "blitz build" before!
+
+Usage
+  $ blitz export [options] <dir>
+
+<dir> represents the directory of the Blitz.js application. If no directory is provided, the current directory will be used.
+
+Options
+  --help -h — help
+  -o — set the output dir (default: '/out')
       `)
 
       process.exit(0)

--- a/packages/blitz/src/cli/commands/next/export.ts
+++ b/packages/blitz/src/cli/commands/next/export.ts
@@ -1,0 +1,51 @@
+import arg from "arg"
+import {resolve, join} from "path"
+import chalk from "chalk"
+import {CliCommand} from "../../index"
+import {ServerConfig} from "../../utils/config"
+
+const nextExport: CliCommand = async () => {
+  const nextArgs = arg(
+    {
+      // Types
+      "--help": Boolean,
+      "--outdir": String,
+
+      // Aliases
+      "-h": "--help",
+      "-o": "--outdir",
+    },
+    {
+      permissive: true,
+    },
+  )
+
+  const config: ServerConfig = {
+    rootFolder: process.cwd(),
+    ...(nextArgs["--outdir"] && {outdir: resolve(nextArgs["--outdir"])}),
+    env: process.env.NODE_ENV === "production" ? "prod" : "dev",
+  }
+
+  const getHelp = async () => {
+    if (nextArgs["--help"]) {
+      console.log(`
+        Description
+          Exports the application for production deployment
+        Usage
+          $ next export [options] <dir>
+        <dir> represents the directory of the Blitz.js application.
+        If no directory is provided, the current directory will be used.
+        Options
+          -h - list this help
+          -o - set the output dir (defaults to 'out')
+      `)
+
+      process.exit(0)
+    }
+  }
+
+  await getHelp()
+  await import("../../utils/next-commands").then((i) => i.blitzExport(config))
+}
+
+export {nextExport}

--- a/packages/blitz/src/cli/commands/next/index.ts
+++ b/packages/blitz/src/cli/commands/next/index.ts
@@ -1,5 +1,6 @@
 import {dev} from "./dev"
 import {build} from "./build"
 import {start} from "./start"
+import {nextExport} from "./export"
 
-export {dev, build, start}
+export {dev, build, start, nextExport}

--- a/packages/blitz/src/cli/index.ts
+++ b/packages/blitz/src/cli/index.ts
@@ -30,6 +30,7 @@ const commands = {
   dev: () => import("./commands/next/dev").then((i) => i.dev),
   build: () => import("./commands/next/build").then((i) => i.build),
   start: () => import("./commands/next/start").then((i) => i.start),
+  export: () => import("./commands/next/export").then((i) => i.nextExport),
   new: () => import("./commands/new").then((i) => i.newApp),
   generate: () => import("./commands/generate").then((i) => i.generate),
   codegen: () => import("./commands/codegen").then((i) => i.codegen),
@@ -42,6 +43,7 @@ const aliases: Record<string, keyof typeof commands> = {
   d: "dev",
   b: "build",
   s: "start",
+  e: "export",
   n: "new",
   g: "generate",
   i: "install",
@@ -174,9 +176,10 @@ async function main() {
         $ blitz <command>
   
       Available commands
-        dev, d          Start a development server 🪄
+        dev, d          Start a development server 🦄 
         build, b        Create a production build 🏗️
         start, s        Start the production server 🐎
+        export, e       Export application to static HTML 📁
         new, n          Create a new Blitz project ✨
         generate, g     Generate new files for your Blitz project 🤠
         codegen         Run the blitz codegen 🤖

--- a/packages/blitz/src/cli/utils/config.ts
+++ b/packages/blitz/src/cli/utils/config.ts
@@ -36,6 +36,8 @@ export type ServerConfig = {
   inspect?: boolean
   // –
   env: ServerEnvironment
+  // -
+  outdir?: string
 }
 
 type NormalizedConfig = ServerConfig & {

--- a/packages/blitz/src/cli/utils/next-commands.ts
+++ b/packages/blitz/src/cli/utils/next-commands.ts
@@ -3,6 +3,7 @@ import {
   nextBuild,
   nextStart,
   nextStartDev,
+  nextExport,
   customServerExists,
   startCustomServer,
   buildCustomServer,
@@ -43,4 +44,9 @@ export async function prod(config: ServerConfig) {
   } else {
     await nextStart(nextBin, rootFolder, config)
   }
+}
+
+export async function blitzExport(config: ServerConfig) {
+  const {nextBin} = await normalize(config)
+  await nextExport(nextBin, config)
 }

--- a/packages/blitz/src/cli/utils/next-utils.ts
+++ b/packages/blitz/src/cli/utils/next-utils.ts
@@ -224,10 +224,10 @@ export function nextBuild(
 
 export function nextExport(nextBin: string, config: ServerConfig) {
   const spawnEnv = getSpawnEnv(config)
-  let args = ["export"]
+  const args = ["export"]
 
   if (config.outdir) {
-    args = args.concat(["-o", `${config.outdir}`])
+    args.push("-o", `${config.outdir}`)
   }
 
   return new Promise<void>((res, rej) => {

--- a/packages/blitz/src/cli/utils/next-utils.ts
+++ b/packages/blitz/src/cli/utils/next-utils.ts
@@ -224,9 +224,14 @@ export function nextBuild(
 
 export function nextExport(nextBin: string, config: ServerConfig) {
   const spawnEnv = getSpawnEnv(config)
+  let args = ["export"]
+
+  if (config.outdir) {
+    args = args.concat(["-o", `${config.outdir}`])
+  }
 
   return new Promise<void>((res, rej) => {
-    spawn(nextBin, ["export"], {
+    spawn(nextBin, args, {
       env: spawnEnv,
       stdio: "inherit",
     })


### PR DESCRIPTION
Closes: #3880 
Closes: #3258 

### What are the changes and their implications?

Added `blitz export` to the cli. This command accepts an optional parameter [-o](https://nextjs.org/docs/api-reference/next.config.js/exportPathMap#customizing-the-output-directory) where you can customise the outdir.

`blitz export --help`
<img width="715" alt="image" src="https://user-images.githubusercontent.com/461342/194060376-731ca53a-b0ca-484a-be65-4466a433b174.png">
 
`blitz export`
<img width="1185" alt="image" src="https://user-images.githubusercontent.com/461342/194060538-41c48687-8020-4ad2-90bb-85f8ca8dba5b.png">

`blitz export -o outerino`
<img width="1181" alt="image" src="https://user-images.githubusercontent.com/461342/194060626-9ef854f5-c860-493c-8b8a-635aebeff944.png">

And if you didn't build the project before you export, it will show you an error (this error comes from next).