### PR TITLE
3806 - Optional chaining from @blitzjs/auth crashes app on old devices

### DIFF
--- a/packages/blitz-auth/build.config.ts
+++ b/packages/blitz-auth/build.config.ts
@@ -6,6 +6,7 @@ const config: BuildConfig = {
   declaration: true,
   rollup: {
     emitCJS: true,
+    esbuild: {target: "es2017"},
   },
 }
 export default config


### PR DESCRIPTION
Closes: #3806 

### What are the changes and their implications?

This one was a quite interesting issue to solve. Even though it's only one line it gave a lot of work of "investigation".

So basically what happens (I had to check unbuild code to check what they were doing there):

When we build the lib using unbuild, by default they use es2020 (https://github.com/unjs/unbuild/blob/main/src/build.ts#L67)
to build the lib. es2020 does not convert the optional chaining syntax and this was triggering the error. When I changed to es2017 it works because it compiles to an older version, and that's ok. As you can see from the image (I used browserstack) 
<img width="1264" alt="Screenshot 2022-10-07 at 01 28 29" src="https://user-images.githubusercontent.com/461342/194432357-504fc54e-0c70-41c4-b1a5-1a74316387fd.png">
the login and signup button appeared. **_So it works!!!_** 💯 

If you want to go deeper xD as you can see from this code:
https://github.com/unjs/unbuild/blob/main/src/builder/rollup.ts#L220 is where they use the version
and the function comes from https://github.com/unjs/unbuild/blob/main/src/builder/rollup.ts#L9 - rollup-plugin-esbuild and this guy does all the hard work.

GG!

OBS: But one thing that I didn't understand quite well is that unbuild is skipping all our ts config...and only taking in consideration the build.config file. So one thing that we could start to think about is: maybe we could build the lib using tsc only? One good thing is that we would not depend on this unbuild lib (tbh I don't know if they will maintain this lib).

OBS2: I really like blitz-js. I really like the project and will try to help as much as I can =) on my spare time. Thanks peeps. All of you rock \,,/. I have been learning a lot from this code.