### PR TITLE
Migrate Routes Command

### DIFF
--- a/.changeset/few-shrimps-leave.md
+++ b/.changeset/few-shrimps-leave.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Add `blitz routes` CLI command back to toolkit

--- a/packages/blitz/src/cli/commands/routes.ts
+++ b/packages/blitz/src/cli/commands/routes.ts
@@ -2,6 +2,7 @@ import {CliCommand} from "../index"
 import {log, newLine} from "../../logging"
 import {collectAllRoutes, loadConfig} from "../utils/routes-manifest"
 import chalk from "chalk"
+import {prettyMs} from "../../utils"
 
 const getColor = (type: string) => {
   switch (type) {
@@ -49,17 +50,19 @@ const routes: CliCommand = async () => {
     routes.forEach(({filePath, route, verb, type}: any) => {
       table.addRow(
         {
-          [table.table.columns[0].name]: verb.toUpperCase(),
-          [table.table.columns[1].name]: filePath,
-          [table.table.columns[2].name]: route,
-          [table.table.columns[3].name]: type.toUpperCase(),
+          [table.table.columns[0]!.name]: verb.toUpperCase(),
+          [table.table.columns[1]!.name]: filePath,
+          [table.table.columns[2]!.name]: route,
+          [table.table.columns[3]!.name]: type.toUpperCase(),
         },
         {color: getColor(type)},
       )
     })
     console.log(table.render())
     newLine()
-    console.log(`✨ Done ` + chalk.hex("#8a3df0").bold("in ") + `${Date.now() - startTime}ms`)
+    console.log(
+      `✨ Done ` + chalk.hex("#8a3df0").bold("in ") + `${prettyMs(Date.now() - startTime)}`,
+    )
     process.exit(0)
   } catch (err) {
     console.error(err)

--- a/packages/blitz/src/cli/commands/routes.ts
+++ b/packages/blitz/src/cli/commands/routes.ts
@@ -1,0 +1,70 @@
+import {CliCommand} from "../index"
+import {log, newLine} from "../../logging"
+import {collectAllRoutes, loadConfig} from "../utils/routes-manifest"
+import chalk from "chalk"
+
+const getColor = (type: string) => {
+  switch (type) {
+    case "rpc":
+      return "magenta"
+    case "api":
+      return "blue"
+    default:
+      return "green"
+  }
+}
+
+const routes: CliCommand = async () => {
+  const startTime = Date.now()
+  process.env.BLITZ_APP_DIR = process.cwd()
+  try {
+    const config = loadConfig(process.cwd())
+    const routes = await collectAllRoutes(process.cwd(), config)
+    newLine()
+    const table = new log.Table({
+      columns: [
+        {name: "HTTP", alignment: "center"},
+        {name: "Source File", alignment: "left"},
+        {name: "Route Path", alignment: "left"},
+        {name: "Type", alignment: "center"},
+      ],
+      sort: (q, r) => {
+        // Sort pages to the top
+        if (q.Type === "PAGE" && r.Type !== "PAGE") {
+          return -1
+        }
+        if (q.Type !== "PAGE" && r.Type === "PAGE") {
+          return 1
+        }
+
+        if (q.Type > r.Type) {
+          return 1
+        }
+        if (q.Type < r.Type) {
+          return -1
+        }
+        return 0
+      },
+    })
+    routes.forEach(({filePath, route, verb, type}: any) => {
+      table.addRow(
+        {
+          [table.table.columns[0].name]: verb.toUpperCase(),
+          [table.table.columns[1].name]: filePath,
+          [table.table.columns[2].name]: route,
+          [table.table.columns[3].name]: type.toUpperCase(),
+        },
+        {color: getColor(type)},
+      )
+    })
+    console.log(table.render())
+    newLine()
+    console.log(`✨ Done ` + chalk.hex("#8a3df0").bold("in ") + `${Date.now() - startTime}ms`)
+    process.exit(0)
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
+}
+
+export {routes}

--- a/packages/blitz/src/cli/index.ts
+++ b/packages/blitz/src/cli/index.ts
@@ -36,6 +36,7 @@ const commands = {
   db: () => import("./commands/db").then((i) => i.db),
   install: () => import("./commands/install").then((i) => i.install),
   console: () => import("./commands/console").then((i) => i.consoleREPL),
+  routes: () => import("./commands/routes").then((i) => i.routes),
 }
 
 const aliases: Record<string, keyof typeof commands> = {

--- a/packages/blitz/src/cli/index.ts
+++ b/packages/blitz/src/cli/index.ts
@@ -47,6 +47,7 @@ const aliases: Record<string, keyof typeof commands> = {
   g: "generate",
   i: "install",
   c: "console",
+  r: "routes",
 }
 
 type Command = keyof typeof commands

--- a/packages/blitz/src/cli/utils/next-console.ts
+++ b/packages/blitz/src/cli/utils/next-console.ts
@@ -9,9 +9,6 @@ import ProgressBar from "progress"
 import {log} from "../../logging"
 
 export function getDbFolder() {
-  if (fs.existsSync(path.join(process.cwd(), "db"))) {
-    return "db"
-  }
   try {
     const packageJsonPath = path.join(process.cwd(), "package.json")
     const packageJson = fs.readFileSync(packageJsonPath, "utf8")
@@ -30,7 +27,10 @@ export function getDbFolder() {
     const folder = packageJsonObj.prisma.schema.split("/")[0] as string
     return folder
   } catch (e) {
-    throw new Error(e)
+    if (fs.existsSync(path.join(process.cwd(), "db/schema.prisma"))) {
+      return "db"
+    }
+    throw e
   }
 }
 
@@ -39,13 +39,8 @@ export function getProjectRootSync() {
 }
 
 export function getConfigSrcPath() {
-  const tsPath = path.resolve(path.join(process.cwd(), "next.config.ts"))
-  if (fs.existsSync(tsPath)) {
-    return tsPath
-  } else {
-    const jsPath = path.resolve(path.join(process.cwd(), "next.config.js"))
-    return jsPath
-  }
+  const jsPath = path.resolve(path.join(process.cwd(), "next.config.js"))
+  return jsPath
 }
 
 const projectRoot = getProjectRootSync()

--- a/packages/blitz/src/cli/utils/next-console.ts
+++ b/packages/blitz/src/cli/utils/next-console.ts
@@ -15,13 +15,13 @@ export function getDbFolder() {
     const packageJsonObj = JSON.parse(packageJson)
     if (!packageJsonObj.prisma || !packageJsonObj.prisma.schema) {
       throw new Error(
-        "db folder does not exist and Prisma schema not found in package.json. Please either create the db folder or add the prisma schema path to the package.json",
+        "db/schema.prisma does not exist and Prisma configuration not found in package.json. Please either create the db folder or add the prisma schema path to the package.json",
       )
     }
     const prismaSchemaPath = path.join(process.cwd(), packageJsonObj.prisma.schema)
     if (!fs.existsSync(prismaSchemaPath)) {
       throw new Error(
-        "prisma.schema file not found. Please either create the db folder or add the prisma schema path to the package.json",
+        `File not found in ${prismaSchemaPath}. Please either create the db/schema.prisma file or add the prisma schema path to the package.json`,
       )
     }
     const folder = packageJsonObj.prisma.schema.split("/")[0] as string

--- a/packages/blitz/src/cli/utils/routes-manifest.ts
+++ b/packages/blitz/src/cli/utils/routes-manifest.ts
@@ -151,7 +151,7 @@ const normalizeConfig = (phase: string, config: any) => {
   }
   return config
 }
-const loadConfig = (pagesDir: string) => {
+export const loadConfig = (pagesDir: string) => {
   let userConfigModule
 
   try {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:
-->

### What are the changes and their implications?

- [x] migrated ```routes``` cli command from legacy blitz to blitz toolkit
- [x] fix ```getDbFolder``` function in ```packages/blitz/src/cli/utils/next-console.ts``` command  to only check for ```db/schema.prisma``` if schema path defined by ```package.json``` does not exist.
The previous version would return ```db``` regardless if the user stores the schema.prisma file was present or if the user intended another to use the ```db``` folder for any other purpose 
- [x] matched ```blitz routes``` output to the docs https://blitzjs.com/docs/cli-routes

#### Output
![image](https://user-images.githubusercontent.com/83594610/194706463-d114bb64-9644-4837-a622-eb39cedc368f.png)
