### PR TITLE
Fix missing `blitz/installer` dependency in recipes

### DIFF
--- a/.changeset/hungry-pens-collect.md
+++ b/.changeset/hungry-pens-collect.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Fix `blitz install` not working due to missing `blitz/installer` dependency

--- a/packages/blitz/package.json
+++ b/packages/blitz/package.json
@@ -17,6 +17,7 @@
   "sideEffects": false,
   "license": "MIT",
   "files": [
+    "installer.*",
     "dist/**",
     "bin/**"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
       "@types/preview-email": 2.0.1
       "@types/react": 18.0.17
       "@typescript-eslint/eslint-plugin": 5.9.1
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       eslint: 7.32.0
       eslint-config-next: 12.2.0
       eslint-config-prettier: 8.5.0
@@ -120,7 +120,7 @@ importers:
       "@types/preview-email": 2.0.1
       "@types/react": 18.0.17
       "@typescript-eslint/eslint-plugin": 5.9.1
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       eslint: 7.32.0
       eslint-config-next: 12.2.0
       eslint-config-prettier: 8.5.0
@@ -235,7 +235,7 @@ importers:
       "@types/node-fetch": 2.6.1
       "@types/react": 18.0.17
       b64-lite: 1.4.0
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       eslint: 7.32.0
       fs-extra: 10.0.1
       get-port: 6.1.2
@@ -650,8 +650,8 @@ importers:
 
   packages/blitz:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-beta.10
-      "@blitzjs/generator": 2.0.0-beta.10
+      "@blitzjs/config": workspace:2.0.0-beta.11
+      "@blitzjs/generator": 2.0.0-beta.11
       "@mrleebo/prisma-ast": 0.2.6
       "@types/cookie": 0.4.1
       "@types/cross-spawn": 6.0.2
@@ -795,7 +795,7 @@ importers:
 
   packages/blitz-auth:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-beta.10
+      "@blitzjs/config": workspace:2.0.0-beta.11
       "@testing-library/react": 13.0.0
       "@testing-library/react-hooks": 7.0.2
       "@types/b64-lite": 1.3.0
@@ -809,7 +809,7 @@ importers:
       "@types/secure-password": 3.1.1
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-beta.5
+      blitz: 2.0.0-beta.11
       cookie: 0.4.1
       cookie-session: 2.0.0
       debug: 4.3.3
@@ -862,8 +862,8 @@ importers:
 
   packages/blitz-next:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-beta.10
-      "@blitzjs/rpc": 2.0.0-beta.10
+      "@blitzjs/config": workspace:2.0.0-beta.11
+      "@blitzjs/rpc": 2.0.0-beta.11
       "@tanstack/react-query": 4.0.10
       "@testing-library/dom": 8.13.0
       "@testing-library/jest-dom": 5.16.3
@@ -875,7 +875,7 @@ importers:
       "@types/react": 18.0.17
       "@types/react-dom": 17.0.14
       "@types/testing-library__react-hooks": 4.0.0
-      blitz: 2.0.0-beta.5
+      blitz: 2.0.0-beta.11
       cross-spawn: 7.0.3
       debug: 4.3.3
       find-up: 4.1.0
@@ -925,15 +925,15 @@ importers:
 
   packages/blitz-rpc:
     specifiers:
-      "@blitzjs/auth": 2.0.0-beta.10
-      "@blitzjs/config": workspace:2.0.0-beta.10
+      "@blitzjs/auth": 2.0.0-beta.11
+      "@blitzjs/config": workspace:2.0.0-beta.11
       "@tanstack/react-query": 4.0.10
       "@types/debug": 4.1.7
       "@types/react": 18.0.17
       "@types/react-dom": 17.0.14
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-beta.5
+      blitz: 2.0.0-beta.11
       chalk: ^4.1.0
       debug: 4.3.3
       next: 12.2.5
@@ -976,12 +976,12 @@ importers:
       "@babel/plugin-syntax-typescript": 7.17.12
       "@babel/preset-env": 7.12.10
       "@blitzjs/config": workspace:*
-      "@blitzjs/generator": 2.0.0-beta.10
+      "@blitzjs/generator": 2.0.0-beta.11
       "@types/jscodeshift": 0.11.2
       "@types/node": 17.0.16
       arg: 5.0.1
       ast-types: 0.14.2
-      blitz: 2.0.0-beta.5
+      blitz: 2.0.0-beta.11
       chalk: ^4.1.0
       cross-spawn: 7.0.3
       debug: 4.3.3
@@ -1036,7 +1036,7 @@ importers:
       "@babel/plugin-transform-typescript": 7.12.1
       "@babel/preset-env": 7.12.10
       "@babel/types": 7.12.10
-      "@blitzjs/config": 2.0.0-beta.10
+      "@blitzjs/config": 2.0.0-beta.11
       "@juanm04/cpx": 2.0.1
       "@mrleebo/prisma-ast": 0.4.1
       "@types/babel__core": 7.1.19
@@ -1129,7 +1129,7 @@ importers:
 
   packages/pkg-template:
     specifiers:
-      "@blitzjs/config": 2.0.0-beta.10
+      "@blitzjs/config": 2.0.0-beta.11
       "@types/react": 18.0.17
       "@types/react-dom": 17.0.14
       "@typescript-eslint/eslint-plugin": 5.9.1
@@ -1153,7 +1153,7 @@ importers:
   recipes/base-web:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1164,7 +1164,7 @@ importers:
   recipes/bulma:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1176,7 +1176,7 @@ importers:
     specifiers:
       "@types/jscodeshift": 0.11.2
       ast-types: 0.14.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1189,7 +1189,7 @@ importers:
     specifiers:
       "@types/jscodeshift": 0.11.2
       ast-types: 0.14.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1201,7 +1201,7 @@ importers:
   recipes/emotion:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1211,20 +1211,20 @@ importers:
 
   recipes/gh-action-yarn-mariadb:
     specifiers:
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
     dependencies:
       blitz: link:../../packages/blitz
 
   recipes/gh-action-yarn-postgres:
     specifiers:
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
     dependencies:
       blitz: link:../../packages/blitz
 
   recipes/ghost:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1235,7 +1235,7 @@ importers:
   recipes/graphql-apollo-server:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
       uuid: ^8.3.1
     dependencies:
@@ -1247,14 +1247,14 @@ importers:
 
   recipes/logrocket:
     specifiers:
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
     dependencies:
       blitz: link:../../packages/blitz
 
   recipes/material-ui:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1266,7 +1266,7 @@ importers:
     specifiers:
       "@types/jscodeshift": 0.11.2
       ast-types: 0.14.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1277,13 +1277,13 @@ importers:
 
   recipes/passenger:
     specifiers:
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
     dependencies:
       blitz: link:../../packages/blitz
 
   recipes/quirrel:
     specifiers:
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
     dependencies:
       blitz: link:../../packages/blitz
 
@@ -1291,7 +1291,7 @@ importers:
     specifiers:
       "@types/jscodeshift": 0.11.2
       ast-types: 0.14.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1302,14 +1302,14 @@ importers:
 
   recipes/render:
     specifiers:
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
     dependencies:
       blitz: link:../../packages/blitz
 
   recipes/secureheaders:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
       uuid: ^8.3.1
     dependencies:
@@ -1322,7 +1322,7 @@ importers:
   recipes/stitches:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1334,7 +1334,7 @@ importers:
     specifiers:
       "@types/jscodeshift": 0.11.2
       ast-types: 0.14.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1346,7 +1346,7 @@ importers:
   recipes/tailwind:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1358,7 +1358,7 @@ importers:
     specifiers:
       "@types/jscodeshift": 0.11.2
       ast-types: 0.14.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1370,7 +1370,7 @@ importers:
   recipes/vanilla-extract:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.5
+      blitz: workspace:2.0.0-beta.11
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -12920,7 +12920,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.7.0_6sxvnwysvlo53egjnie7htsx5a
+      ts-node: 10.7.0_typescript@4.6.3
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -18427,6 +18427,7 @@ packages:
       typescript: 4.7.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: false
 
   /ts-node/10.7.0_fxg3r7oju3tntkxsvleuiot4fa:
     resolution:
@@ -18493,7 +18494,6 @@ packages:
       typescript: 4.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: false
 
   /ts-node/10.9.1_kakyiqi62sfonxvjmz3ft5vt7y:
     resolution:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: https://github.com/blitz-js/blitz/issues/3894

### What are the changes and their implications?

The installer entry point wasn't being added to the bundled code.
