### PR TITLE
Upgrade CI Syntax

### DIFF
--- a/.github/workflows/changeset_check.yml
+++ b/.github/workflows/changeset_check.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   changeset:
-    if: ${{ github.event.label.name != 'no-changeset' }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changeset') && github.event.pull_request.merged == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
           cd ./integration-tests
           tree -J -d -L 1 | jq -c  '.[0].contents | map(.name | tostring) | map(select(. != "utils"))'
           folders=$(tree -J -d -L 1 | jq -c  '.[0].contents | map(.name | tostring) | map(select(. != "utils"))')
-          echo "::set-output name=folders::$folders"
+          echo "folders=$folders" >> $GITHUB_OUTPUT
 
   Integration-Tests:
     name: "Integration Test: ${{matrix.folder}} @ ${{ matrix.os }} "

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
       "@types/preview-email": 2.0.1
       "@types/react": 18.0.17
       "@typescript-eslint/eslint-plugin": 5.9.1
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       eslint: 7.32.0
       eslint-config-next: 12.2.0
       eslint-config-prettier: 8.5.0
@@ -120,7 +120,7 @@ importers:
       "@types/preview-email": 2.0.1
       "@types/react": 18.0.17
       "@typescript-eslint/eslint-plugin": 5.9.1
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       eslint: 7.32.0
       eslint-config-next: 12.2.0
       eslint-config-prettier: 8.5.0
@@ -235,7 +235,7 @@ importers:
       "@types/node-fetch": 2.6.1
       "@types/react": 18.0.17
       b64-lite: 1.4.0
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       eslint: 7.32.0
       fs-extra: 10.0.1
       get-port: 6.1.2
@@ -650,8 +650,8 @@ importers:
 
   packages/blitz:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-beta.11
-      "@blitzjs/generator": 2.0.0-beta.11
+      "@blitzjs/config": workspace:2.0.0-beta.12
+      "@blitzjs/generator": 2.0.0-beta.12
       "@mrleebo/prisma-ast": 0.2.6
       "@types/cookie": 0.4.1
       "@types/cross-spawn": 6.0.2
@@ -795,7 +795,7 @@ importers:
 
   packages/blitz-auth:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-beta.11
+      "@blitzjs/config": workspace:2.0.0-beta.12
       "@testing-library/react": 13.0.0
       "@testing-library/react-hooks": 7.0.2
       "@types/b64-lite": 1.3.0
@@ -809,7 +809,7 @@ importers:
       "@types/secure-password": 3.1.1
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-beta.11
+      blitz: 2.0.0-beta.12
       cookie: 0.4.1
       cookie-session: 2.0.0
       debug: 4.3.3
@@ -862,8 +862,8 @@ importers:
 
   packages/blitz-next:
     specifiers:
-      "@blitzjs/config": workspace:2.0.0-beta.11
-      "@blitzjs/rpc": 2.0.0-beta.11
+      "@blitzjs/config": workspace:2.0.0-beta.12
+      "@blitzjs/rpc": 2.0.0-beta.12
       "@tanstack/react-query": 4.0.10
       "@testing-library/dom": 8.13.0
       "@testing-library/jest-dom": 5.16.3
@@ -875,7 +875,7 @@ importers:
       "@types/react": 18.0.17
       "@types/react-dom": 17.0.14
       "@types/testing-library__react-hooks": 4.0.0
-      blitz: 2.0.0-beta.11
+      blitz: 2.0.0-beta.12
       cross-spawn: 7.0.3
       debug: 4.3.3
       find-up: 4.1.0
@@ -925,15 +925,15 @@ importers:
 
   packages/blitz-rpc:
     specifiers:
-      "@blitzjs/auth": 2.0.0-beta.11
-      "@blitzjs/config": workspace:2.0.0-beta.11
+      "@blitzjs/auth": 2.0.0-beta.12
+      "@blitzjs/config": workspace:2.0.0-beta.12
       "@tanstack/react-query": 4.0.10
       "@types/debug": 4.1.7
       "@types/react": 18.0.17
       "@types/react-dom": 17.0.14
       b64-lite: 1.4.0
       bad-behavior: 1.0.1
-      blitz: 2.0.0-beta.11
+      blitz: 2.0.0-beta.12
       chalk: ^4.1.0
       debug: 4.3.3
       next: 12.2.5
@@ -976,12 +976,12 @@ importers:
       "@babel/plugin-syntax-typescript": 7.17.12
       "@babel/preset-env": 7.12.10
       "@blitzjs/config": workspace:*
-      "@blitzjs/generator": 2.0.0-beta.11
+      "@blitzjs/generator": 2.0.0-beta.12
       "@types/jscodeshift": 0.11.2
       "@types/node": 17.0.16
       arg: 5.0.1
       ast-types: 0.14.2
-      blitz: 2.0.0-beta.11
+      blitz: 2.0.0-beta.12
       chalk: ^4.1.0
       cross-spawn: 7.0.3
       debug: 4.3.3
@@ -1036,7 +1036,7 @@ importers:
       "@babel/plugin-transform-typescript": 7.12.1
       "@babel/preset-env": 7.12.10
       "@babel/types": 7.12.10
-      "@blitzjs/config": 2.0.0-beta.11
+      "@blitzjs/config": 2.0.0-beta.12
       "@juanm04/cpx": 2.0.1
       "@mrleebo/prisma-ast": 0.4.1
       "@types/babel__core": 7.1.19
@@ -1129,7 +1129,7 @@ importers:
 
   packages/pkg-template:
     specifiers:
-      "@blitzjs/config": 2.0.0-beta.11
+      "@blitzjs/config": 2.0.0-beta.12
       "@types/react": 18.0.17
       "@types/react-dom": 17.0.14
       "@typescript-eslint/eslint-plugin": 5.9.1
@@ -1153,7 +1153,7 @@ importers:
   recipes/base-web:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1164,7 +1164,7 @@ importers:
   recipes/bulma:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1176,7 +1176,7 @@ importers:
     specifiers:
       "@types/jscodeshift": 0.11.2
       ast-types: 0.14.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1189,7 +1189,7 @@ importers:
     specifiers:
       "@types/jscodeshift": 0.11.2
       ast-types: 0.14.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1201,7 +1201,7 @@ importers:
   recipes/emotion:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1211,20 +1211,20 @@ importers:
 
   recipes/gh-action-yarn-mariadb:
     specifiers:
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
     dependencies:
       blitz: link:../../packages/blitz
 
   recipes/gh-action-yarn-postgres:
     specifiers:
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
     dependencies:
       blitz: link:../../packages/blitz
 
   recipes/ghost:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1235,7 +1235,7 @@ importers:
   recipes/graphql-apollo-server:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
       uuid: ^8.3.1
     dependencies:
@@ -1247,14 +1247,14 @@ importers:
 
   recipes/logrocket:
     specifiers:
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
     dependencies:
       blitz: link:../../packages/blitz
 
   recipes/material-ui:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1266,7 +1266,7 @@ importers:
     specifiers:
       "@types/jscodeshift": 0.11.2
       ast-types: 0.14.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1277,13 +1277,13 @@ importers:
 
   recipes/passenger:
     specifiers:
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
     dependencies:
       blitz: link:../../packages/blitz
 
   recipes/quirrel:
     specifiers:
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
     dependencies:
       blitz: link:../../packages/blitz
 
@@ -1291,7 +1291,7 @@ importers:
     specifiers:
       "@types/jscodeshift": 0.11.2
       ast-types: 0.14.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1302,14 +1302,14 @@ importers:
 
   recipes/render:
     specifiers:
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
     dependencies:
       blitz: link:../../packages/blitz
 
   recipes/secureheaders:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
       uuid: ^8.3.1
     dependencies:
@@ -1322,7 +1322,7 @@ importers:
   recipes/stitches:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1334,7 +1334,7 @@ importers:
     specifiers:
       "@types/jscodeshift": 0.11.2
       ast-types: 0.14.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1346,7 +1346,7 @@ importers:
   recipes/tailwind:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1358,7 +1358,7 @@ importers:
     specifiers:
       "@types/jscodeshift": 0.11.2
       ast-types: 0.14.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -1370,7 +1370,7 @@ importers:
   recipes/vanilla-extract:
     specifiers:
       "@types/jscodeshift": 0.11.2
-      blitz: workspace:2.0.0-beta.11
+      blitz: workspace:2.0.0-beta.12
       jscodeshift: 0.13.0
     dependencies:
       blitz: link:../../packages/blitz
@@ -12920,7 +12920,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.7.0_typescript@4.6.3
+      ts-node: 10.7.0_fxg3r7oju3tntkxsvleuiot4fa
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -18461,7 +18461,6 @@ packages:
       typescript: 4.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: false
 
   /ts-node/10.7.0_typescript@4.6.3:
     resolution:
@@ -18494,6 +18493,7 @@ packages:
       typescript: 4.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: false
 
   /ts-node/10.9.1_kakyiqi62sfonxvjmz3ft5vt7y:
     resolution:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

- [x] upgrade to the latest Github Action syntax from `set-output` to environment variables to set the integration test folders 
```bash
::set-output name=folders::["auth","get-initial-props","middleware","no-suspense","qm","react-query-utils","rpc","trailing-slash"]
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
![image](https://user-images.githubusercontent.com/83594610/196111190-b240be31-f4c7-4685-91a4-5f3d718b329f.png)

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

- [x] improve the detection of `no-changeset` for internal repository changes and stop changeset workflow to run after the PR is merged.

Previously it checked the latest label event, now it will check for the `no-changeset` label in all the labels that have been assigned to the PR

