### PR TITLE
Fix reset token being undefined when passed to the resetPassword mutation

### DIFF
--- a/.changeset/lemon-pillows-switch.md
+++ b/.changeset/lemon-pillows-switch.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Fix reset token being undefined when passed to the resetPassword mutation

--- a/apps/toolkit-app/pages/auth/reset-password.tsx
+++ b/apps/toolkit-app/pages/auth/reset-password.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react"
 import Layout from "app/core/layouts/Layout"
 import { LabeledTextField } from "app/core/components/LabeledTextField"
 import { Form, FORM_ERROR } from "app/core/components/Form"
@@ -9,8 +10,13 @@ import { useMutation } from "@blitzjs/rpc"
 import Link from "next/link"
 
 const ResetPasswordPage: BlitzPage = () => {
+  const [token, setToken] = useState("")
   const router = useRouter()
   const [resetPasswordMutation, { isSuccess }] = useMutation(resetPassword)
+
+  useEffect(() => {
+    setToken(router.query.token as string)
+  }, [router.isReady])
 
   return (
     <div>
@@ -30,11 +36,11 @@ const ResetPasswordPage: BlitzPage = () => {
           initialValues={{
             password: "",
             passwordConfirmation: "",
-            token: router.query.token as string,
+            token,
           }}
           onSubmit={async (values) => {
             try {
-              await resetPasswordMutation(values)
+              await resetPasswordMutation({ ...values, token })
             } catch (error: any) {
               if (error.name === "ResetPasswordError") {
                 return {

--- a/packages/generator/templates/app/pages/auth/reset-password.tsx
+++ b/packages/generator/templates/app/pages/auth/reset-password.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react"
 import Layout from "app/core/layouts/Layout"
 import { LabeledTextField } from "app/core/components/LabeledTextField"
 import { Form, FORM_ERROR } from "app/core/components/Form"
@@ -9,8 +10,13 @@ import { useMutation } from "@blitzjs/rpc"
 import Link from "next/link"
 
 const ResetPasswordPage: BlitzPage = () => {
+  const [token, setToken] = useState("")
   const router = useRouter()
   const [resetPasswordMutation, { isSuccess }] = useMutation(resetPassword)
+
+  useEffect(() => {
+    setToken(router.query.token as string)
+  }, [router.isReady])
 
   return (
     <div>
@@ -27,10 +33,14 @@ const ResetPasswordPage: BlitzPage = () => {
         <Form
           submitText="Reset Password"
           schema={ResetPassword}
-          initialValues={{ password: "", passwordConfirmation: "", token: router.query.token as string }}
+          initialValues={{
+            password: "",
+            passwordConfirmation: "",
+            token,
+          }}
           onSubmit={async (values) => {
             try {
-              await resetPasswordMutation(values)
+              await resetPasswordMutation({...values, token})
             } catch (error: any) {
               if (error.name === "ResetPasswordError") {
                 return {


### PR DESCRIPTION
Closes: https://github.com/blitz-js/blitz/issues/3897
