### PR TITLE
Fix `cannot find module db error` in JavaScript template

### DIFF
--- a/.changeset/light-squids-draw.md
+++ b/.changeset/light-squids-draw.md
@@ -3,5 +3,4 @@
 "@blitzjs/generator": patch
 ---
 
-Fix `cannot find module db error` in JavaScript template. Replaced requiring the config using `esbuild` instead paring the AST to get the `cliConfig`. Allow added option 
-to find the `blitz-server` file in `src` directory for this logic.
+Fix `cannot find module db error` in JavaScript template. Replace requiring the config using `esbuild` with parsing using `jscodeshift` to get the `cliConfig` values. Added logic to find the `blitz-server` file in `src` directory 

--- a/.changeset/light-squids-draw.md
+++ b/.changeset/light-squids-draw.md
@@ -1,0 +1,7 @@
+---
+"blitz": patch
+"@blitzjs/generator": patch
+---
+
+Fix `cannot find module db error` in JavaScript template. Replaced requiring the config using `esbuild` instead paring the AST to get the `cliConfig`. Allow added option 
+to find the `blitz-server` file in `src` directory for this logic.

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -31,6 +31,7 @@
     "diff": "5.0.0",
     "enquirer": "2.3.6",
     "fs-extra": "10.0.1",
+    "globby": "13.1.2",
     "got": "^11.8.1",
     "jscodeshift": "0.13.0",
     "mem-fs": "1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1065,6 +1065,7 @@ importers:
       enquirer: 2.3.6
       eslint: 7.32.0
       fs-extra: 10.0.1
+      globby: 13.1.2
       got: ^11.8.1
       jscodeshift: 0.13.0
       mem-fs: 1.2.0
@@ -1094,6 +1095,7 @@ importers:
       diff: 5.0.0
       enquirer: 2.3.6
       fs-extra: 10.0.1
+      globby: 13.1.2
       got: 11.8.1
       jscodeshift: 0.13.0_slgjdbbopna4ebnpdn2nkn3v2a
       mem-fs: 1.2.0
@@ -2606,7 +2608,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10
+      "@babel/core": 7.12.10_supports-color@8.1.1
       "@babel/helper-plugin-utils": 7.17.12
     dev: false
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: #3926

### What are the changes and their implications?

- [x] remove esbuild-register dependency to get the `cliConfig` replaced with AST parsing using `jscodeshift`
- [x] allow the `blitz-server.ts` to be present in `src` directory for the `cliConfig` reading logic.

## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
