### PR TITLE
maybe fix anon session CSRF issue + add ability to customize anon session expiry time

### DIFF
--- a/.changeset/heavy-students-buy.md
+++ b/.changeset/heavy-students-buy.md
@@ -1,0 +1,6 @@
+---
+"@blitzjs/auth": minor
+"@blitzjs/rpc": minor
+---
+
+maybe fix anon session CSRF issue + add ability to customize anon session expiry time

--- a/packages/blitz-auth/src/client/index.tsx
+++ b/packages/blitz-auth/src/client/index.tsx
@@ -116,10 +116,17 @@ export const getPublicDataStore = (): PublicDataStore => {
   return (window as any).__publicDataStore
 }
 
-export const getAntiCSRFToken = () => {
+// because safari automatically deletes non-httponly cookies after 7 days
+export const backupAntiCSRFTokenToLocalStorage = () => {
   const cookieValue = readCookie(COOKIE_CSRF_TOKEN())
   if (cookieValue) {
     localStorage.setItem(LOCALSTORAGE_CSRF_TOKEN(), cookieValue)
+  }
+}
+
+export const getAntiCSRFToken = () => {
+  const cookieValue = readCookie(COOKIE_CSRF_TOKEN())
+  if (cookieValue) {
     return cookieValue
   } else {
     return localStorage.getItem(LOCALSTORAGE_CSRF_TOKEN())

--- a/packages/blitz-auth/src/global.ts
+++ b/packages/blitz-auth/src/global.ts
@@ -1,7 +1,8 @@
-import {SessionConfig} from "./shared/types"
+import {AuthPluginOptions} from "./server"
+import {SessionConfigMethods} from "./shared"
 
 declare global {
-  var sessionConfig: SessionConfig
+  var sessionConfig: AuthPluginOptions & SessionConfigMethods
   var __BLITZ_SESSION_COOKIE_PREFIX: string | undefined
   var __BLITZ_SUSPENSE_ENABLED: boolean
 }

--- a/packages/blitz-auth/src/server/auth-plugin.ts
+++ b/packages/blitz-auth/src/server/auth-plugin.ts
@@ -7,6 +7,7 @@ import {getSession} from "./auth-sessions"
 interface SessionConfigOptions {
   cookiePrefix?: string
   sessionExpiryMinutes?: number
+  anonSessionExpiryMinutes?: number
   method?: "essential" | "advanced"
   sameSite?: "none" | "lax" | "strict"
   secureCookies?: boolean
@@ -69,6 +70,7 @@ export const PrismaStorage = <Client extends PrismaClientWithSession>(
 
 const defaultConfig_: SessionConfigOptions = {
   sessionExpiryMinutes: 30 * 24 * 60, // Sessions expire after 30 days of being idle
+  anonSessionExpiryMinutes: 5 * 365 * 24 * 60, // Sessions expire after 5 years of being idle
   method: "essential",
   sameSite: "lax",
   publicDataKeysToSyncAcrossSessions: ["role", "roles"],

--- a/packages/blitz-auth/src/server/auth-plugin.ts
+++ b/packages/blitz-auth/src/server/auth-plugin.ts
@@ -77,7 +77,7 @@ const defaultConfig_: SessionConfigOptions = {
   secureCookies: !process.env.DISABLE_SECURE_COOKIES && process.env.NODE_ENV === "production",
 }
 
-interface AuthPluginOptions extends Partial<SessionConfigOptions>, IsAuthorized {
+export interface AuthPluginOptions extends Partial<SessionConfigOptions>, IsAuthorized {
   storage: SessionConfigMethods
 }
 

--- a/packages/blitz-auth/src/server/auth-sessions.ts
+++ b/packages/blitz-auth/src/server/auth-sessions.ts
@@ -690,7 +690,7 @@ async function createNewSession(
     const anonymousSessionToken = createAnonymousSessionToken(payload)
     const publicDataToken = createPublicDataToken(args.publicData)
 
-    const expiresAt = addYears(new Date(), 30)
+    const expiresAt = addMinutes(new Date(), global.sessionConfig.anonSessionExpiryMinutes)
     setAnonymousSessionCookie(req, res, anonymousSessionToken, expiresAt)
     setCSRFCookie(req, res, antiCSRFToken, expiresAt)
     setPublicDataCookie(req, res, publicDataToken, expiresAt)

--- a/packages/blitz-auth/src/server/auth-sessions.ts
+++ b/packages/blitz-auth/src/server/auth-sessions.ts
@@ -690,7 +690,10 @@ async function createNewSession(
     const anonymousSessionToken = createAnonymousSessionToken(payload)
     const publicDataToken = createPublicDataToken(args.publicData)
 
-    const expiresAt = addMinutes(new Date(), global.sessionConfig.anonSessionExpiryMinutes)
+    const expiresAt = addMinutes(
+      new Date(),
+      global.sessionConfig.anonSessionExpiryMinutes as number,
+    )
     setAnonymousSessionCookie(req, res, anonymousSessionToken, expiresAt)
     setCSRFCookie(req, res, antiCSRFToken, expiresAt)
     setPublicDataCookie(req, res, publicDataToken, expiresAt)

--- a/packages/blitz-auth/src/shared/types.ts
+++ b/packages/blitz-auth/src/shared/types.ts
@@ -50,17 +50,6 @@ export interface SessionConfigMethods {
   deleteSession: (handle: string) => Promise<SessionModel | undefined>
 }
 
-export interface SessionConfig extends SessionConfigMethods {
-  cookiePrefix?: string
-  sessionExpiryMinutes?: number
-  method?: "essential" | "advanced"
-  sameSite?: "none" | "lax" | "strict"
-  secureCookies?: boolean
-  domain?: string
-  publicDataKeysToSyncAcrossSessions?: string[]
-  isAuthorized: (data: {ctx: BlitzCtx; args: any}) => boolean
-}
-
 export interface SessionContextBase {
   $handle: string | null
   $publicData: unknown

--- a/packages/blitz-rpc/src/data-client/rpc.ts
+++ b/packages/blitz-rpc/src/data-client/rpc.ts
@@ -8,6 +8,7 @@ import {stringify} from "superjson"
 import {
   getAntiCSRFToken,
   getPublicDataStore,
+  backupAntiCSRFTokenToLocalStorage,
   HEADER_CSRF,
   HEADER_CSRF_ERROR,
   HEADER_PUBLIC_DATA_TOKEN,
@@ -121,6 +122,7 @@ export function __internal_buildRpcClient({
       .then(async (response) => {
         debug("Received request for", routePath)
         if (response.headers) {
+          backupAntiCSRFTokenToLocalStorage()
           if (response.headers.get(HEADER_PUBLIC_DATA_TOKEN)) {
             getPublicDataStore().updateState()
             debug("Public data updated")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2608,7 +2608,7 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
     dependencies:
-      "@babel/core": 7.12.10_supports-color@8.1.1
+      "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.17.12
     dev: false
 


### PR DESCRIPTION

### What are the changes and their implications?

a user was reporting an odd csrf mismatch error with anon sessions. I can see one possible scenario to cause that and this fixes it.

Possible error case was:

1. anon session created
2. no other rpc requests made
3. 7 days pass
4. user returns
   - anon session still is in httponly cookie so csrf token required
   - but csrf token that was in a js cookie has been auto removed by browser
   - so no csrf token available to pass in the request

I fix that by ensuring that the anti csrf token is backed up to local storage **immediately on request** instead of previous behavior of waiting for the next **read.**

Lastly, this adds a new `anonSessionExpiryMinutes` option for people to customize anon expiry time (defaults to 5 years)

## Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [x] docs: https://github.com/blitz-js/blitzjs.com/pull/788