### PR TITLE
Patch Next13 for suspense error

### DIFF
--- a/.changeset/serious-mugs-leave.md
+++ b/.changeset/serious-mugs-leave.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Patch next13 for suspense error

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12800,7 +12800,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.7.0_typescript@4.6.3
+      ts-node: 10.7.0_6sxvnwysvlo53egjnie7htsx5a
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -18307,7 +18307,6 @@ packages:
       typescript: 4.7.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: false
 
   /ts-node/10.7.0_fxg3r7oju3tntkxsvleuiot4fa:
     resolution:
@@ -18374,6 +18373,7 @@ packages:
       typescript: 4.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: false
 
   /ts-node/10.9.1_kakyiqi62sfonxvjmz3ft5vt7y:
     resolution:


### PR DESCRIPTION
### What are the changes and their implications?

Check package.json for the nextjs version. If nextjs 13 string replace `_client.default.hydrateRoot` else keep the previous patch for nextjs 12

## Feature Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
