### PR TITLE
Fix runaway mutability bug in httpMethod

### DIFF
--- a/.changeset/quick-dots-fetch.md
+++ b/.changeset/quick-dots-fetch.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/rpc": minor
+---
+
+Fix mutability bug in RPC configuration

--- a/packages/blitz-rpc/src/parse-rpc-config.test.ts
+++ b/packages/blitz-rpc/src/parse-rpc-config.test.ts
@@ -1,0 +1,30 @@
+import {describe, expect, it} from "vitest"
+import {getResolverConfig} from "./parse-rpc-config"
+
+describe("getResolverConfig", () => {
+  it("base case: no configuration", async () => {
+    const result = getResolverConfig("")
+    expect(result).toHaveProperty("httpMethod", "POST")
+  })
+
+  it("customized to get", async () => {
+    const result = getResolverConfig(`
+      export const config = {
+        httpMethod: 'GET'
+      }
+    `)
+    expect(result).toHaveProperty("httpMethod", "GET")
+  })
+
+  it("evaluation is hermetic", async () => {
+    expect(
+      getResolverConfig(`
+      export const config = {
+        httpMethod: 'GET'
+      }
+    `),
+    ).toHaveProperty("httpMethod", "GET")
+
+    expect(getResolverConfig(``)).toHaveProperty("httpMethod", "POST")
+  })
+})

--- a/packages/blitz-rpc/src/parse-rpc-config.ts
+++ b/packages/blitz-rpc/src/parse-rpc-config.ts
@@ -3,12 +3,10 @@ import {ResolverConfig} from "blitz"
 
 type _ResolverType = "GET" | "POST"
 
-const defaultResolverConfig: ResolverConfig = {
-  httpMethod: "POST",
-}
-
 export function getResolverConfig(content: string): ResolverConfig {
-  const resolverConfig = defaultResolverConfig
+  const resolverConfig: ResolverConfig = {
+    httpMethod: "POST",
+  }
   const resolver = parseSync(content, {
     syntax: "typescript",
     target: "es2020",


### PR DESCRIPTION
Closes: #3962

### What are the changes and their implications?

This fixes a mutability bug in the rpc configuration system. Previously, any resolver with a custom http method would overwrite the rest.

## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed) - not seeing how the rpc configuration code itself is tested