### PR TITLE
internal: remove unneeded useSession from useQuery hooks

### DIFF
--- a/.changeset/brave-zebras-deny.md
+++ b/.changeset/brave-zebras-deny.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/rpc": minor
+---
+
+internal: remove unneeed useSession from useQuery hooks

--- a/packages/blitz-auth/package.json
+++ b/packages/blitz-auth/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "unbuild",
     "predev": "wait-on -d 250 ../blitz/dist/index-server.d.ts",
-    "dev": "pnpm run predev && watch unbuild src --wait=0.2",
+    "dev": "rm -rf dist && pnpm run predev && watch unbuild src --wait=0.2",
     "lint": "eslint . --fix",
     "test": "vitest run",
     "test-watch": "vitest",

--- a/packages/blitz-next/build.config.ts
+++ b/packages/blitz-next/build.config.ts
@@ -2,7 +2,17 @@ import {BuildConfig} from "unbuild"
 
 const config: BuildConfig = {
   entries: ["./src/index-browser", "./src/index-server"],
-  externals: ["index-browser.cjs", "index-browser.mjs", "blitz", ".blitz", "next", "react"],
+  externals: [
+    "index-browser.cjs",
+    "index-browser.mjs",
+    "blitz",
+    ".blitz",
+    "react",
+    "next",
+    "next/head",
+    "next/router",
+    "next/dist/shared/lib/router/router",
+  ],
   declaration: true,
   rollup: {
     emitCJS: true,

--- a/packages/blitz-rpc/build.config.ts
+++ b/packages/blitz-rpc/build.config.ts
@@ -17,6 +17,10 @@ const config: BuildConfig = {
     "blitz",
     "next",
     "zod",
+    "next",
+    "next/router",
+    "next/dist/client/normalize-trailing-slash",
+    "next/dist/client/add-base-path",
   ],
   declaration: true,
   rollup: {

--- a/packages/blitz-rpc/src/data-client/react-query.tsx
+++ b/packages/blitz-rpc/src/data-client/react-query.tsx
@@ -10,7 +10,6 @@ import {
   UseMutationOptions,
   UseMutationResult,
 } from "@tanstack/react-query"
-import {useSession} from "@blitzjs/auth"
 import {isServer, FirstParam, PromiseReturnType, AsyncFunc} from "blitz"
 import {
   emptyQueryFn,
@@ -73,11 +72,6 @@ export function useQuery<
   const suspenseEnabled = Boolean(globalThis.__BLITZ_SUSPENSE_ENABLED)
   let enabled = isServer && suspenseEnabled ? false : options?.enabled ?? options?.enabled !== null
   const suspense = enabled === false ? false : options?.suspense
-  const session = useSession({suspense})
-  if (session.isLoading) {
-    enabled = false
-  }
-
   const routerIsReady = useRouter().isReady || (isServer && suspenseEnabled)
   const enhancedResolverRpcClient = sanitizeQuery(queryFn)
   const queryKey = getQueryKey(queryFn, params)
@@ -157,12 +151,6 @@ export function usePaginatedQuery<
   const suspenseEnabled = Boolean(globalThis.__BLITZ_SUSPENSE_ENABLED)
   let enabled = isServer && suspenseEnabled ? false : options?.enabled ?? options?.enabled !== null
   const suspense = enabled === false ? false : options?.suspense
-
-  const session = useSession({suspense})
-  if (session.isLoading) {
-    enabled = false
-  }
-
   const routerIsReady = useRouter().isReady || (isServer && suspenseEnabled)
   const enhancedResolverRpcClient = sanitizeQuery(queryFn)
   const queryKey = getQueryKey(queryFn, params)
@@ -252,11 +240,6 @@ export function useInfiniteQuery<
   const suspenseEnabled = Boolean(globalThis.__BLITZ_SUSPENSE_ENABLED)
   let enabled = isServer && suspenseEnabled ? false : options?.enabled ?? options?.enabled !== null
   const suspense = enabled === false ? false : options?.suspense
-  const session = useSession({suspense})
-  if (session.isLoading) {
-    enabled = false
-  }
-
   const routerIsReady = useRouter().isReady || (isServer && suspenseEnabled)
   const enhancedResolverRpcClient = sanitizeQuery(queryFn)
   const queryKey = getInfiniteQueryKey(queryFn, getQueryParams)

--- a/packages/blitz/package.json
+++ b/packages/blitz/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-beta.17",
   "scripts": {
     "build": "unbuild",
-    "dev": "pnpm run predev && watch unbuild src --wait=0.2",
+    "dev": "rm -rf dist && pnpm run predev && watch unbuild src --wait=0.2",
     "lint": "eslint . --fix",
     "test": "vitest run",
     "test-watch": "vitest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6404,7 +6404,6 @@ packages:
       typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/scope-manager/5.28.0:
     resolution:


### PR DESCRIPTION
### What are the changes and their implications?

We originally added this to fix https://github.com/blitz-js/legacy-framework/issues/542 because of a bug in react-query. It is no longer needed.
