### PR TITLE
fix resolverPath:root and make it work with monorepo resolvers

### DIFF
--- a/.changeset/tidy-llamas-compare.md
+++ b/.changeset/tidy-llamas-compare.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/rpc": minor
+---
+
+fix resolverPath:root and make it work with monorepo resolvers

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,13 +52,12 @@ jobs:
         with:
           node-version: 16
           cache: "pnpm"
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm manypkg check
       - name: Turborepo local server
         uses: felixmosh/turborepo-gh-artifacts@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           server-token: ${{ env.TURBO_TOKEN }}
+      - run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm build
       - name: Build Apps
@@ -90,18 +89,15 @@ jobs:
           node-version: 16
           cache: "pnpm"
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-        shell: bash
-
-      - run: pnpm manypkg check
-        shell: bash
-
       - name: Turborepo local server
         uses: felixmosh/turborepo-gh-artifacts@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           server-token: ${{ env.TURBO_TOKEN }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        shell: bash
 
       - name: Build
         run: pnpm build
@@ -158,22 +154,19 @@ jobs:
           node-version: ${{ matrix.NODE_VERSION }}
           cache: "pnpm"
 
-      - name: Link Blitz CLI
-        run: pnpm link ./packages/blitz
-        shell: bash
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-        shell: bash
-
-      - run: pnpm manypkg check
-        shell: bash
-
       - name: Turborepo local server
         uses: felixmosh/turborepo-gh-artifacts@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           server-token: ${{ env.TURBO_TOKEN }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        shell: bash
+
+      - name: Install playwright
+        run: npx playwright install --with-deps
+        shell: bash
 
       - name: Build
         run: pnpm build

--- a/integration-tests/rpc-path-root/app/mutations/setBasic.js
+++ b/integration-tests/rpc-path-root/app/mutations/setBasic.js
@@ -1,0 +1,4 @@
+export default async function setBasic(input, ctx) {
+  global.basic = input
+  return global.basic
+}

--- a/integration-tests/rpc-path-root/app/queries/getBasic.js
+++ b/integration-tests/rpc-path-root/app/queries/getBasic.js
@@ -1,0 +1,12 @@
+if (typeof window !== "undefined") {
+  throw new Error("This should not be loaded on the client")
+}
+
+export default async function getBasic() {
+  if (typeof window !== "undefined") {
+    throw new Error("This should not be loaded on the client")
+  }
+
+  global.basic ??= "basic-result"
+  return global.basic
+}

--- a/integration-tests/rpc-path-root/app/queries/v2/getBasic.js
+++ b/integration-tests/rpc-path-root/app/queries/v2/getBasic.js
@@ -1,0 +1,3 @@
+export default async function getBasic() {
+  return "nested-basic"
+}

--- a/integration-tests/rpc-path-root/next-env.d.ts
+++ b/integration-tests/rpc-path-root/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/integration-tests/rpc-path-root/next.config.js
+++ b/integration-tests/rpc-path-root/next.config.js
@@ -1,0 +1,7 @@
+const {withBlitz} = require("@blitzjs/next")
+module.exports = withBlitz({
+  blitz: {
+    resolverPath: "root",
+    includeRPCFolders: ["../no-suspense/app"],
+  },
+})

--- a/integration-tests/rpc-path-root/package.json
+++ b/integration-tests/rpc-path-root/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-rpc",
+  "name": "test-rpc-path-root",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/integration-tests/rpc-path-root/package.json
+++ b/integration-tests/rpc-path-root/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "test-rpc",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "test": "vitest --config ./vitest.config.ts run",
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf .next"
+  },
+  "dependencies": {
+    "@blitzjs/auth": "workspace:*",
+    "@blitzjs/config": "workspace:*",
+    "@blitzjs/next": "workspace:*",
+    "@blitzjs/rpc": "workspace:*",
+    "blitz": "workspace:*",
+    "next": "12.2.5",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/express": "4.17.13",
+    "@types/fs-extra": "9.0.13",
+    "@types/node-fetch": "2.6.1",
+    "@types/react": "18.0.25",
+    "b64-lite": "1.4.0",
+    "eslint": "8.27.0",
+    "fs-extra": "10.0.1",
+    "typescript": "^4.8.4"
+  }
+}

--- a/integration-tests/rpc-path-root/pages/api/rpc/[[...blitz]].ts
+++ b/integration-tests/rpc-path-root/pages/api/rpc/[[...blitz]].ts
@@ -1,0 +1,3 @@
+import {rpcHandler} from "@blitzjs/rpc"
+
+export default rpcHandler({onError: console.log})

--- a/integration-tests/rpc-path-root/pages/index.js
+++ b/integration-tests/rpc-path-root/pages/index.js
@@ -1,0 +1,4 @@
+const Page = () => {
+  return <div id="page-container">Hello World</div>
+}
+export default Page

--- a/integration-tests/rpc-path-root/pages/query.js
+++ b/integration-tests/rpc-path-root/pages/query.js
@@ -1,0 +1,7 @@
+import getBasic from "../app/queries/getBasic"
+
+const Page = () => {
+  getBasic().then(console.log)
+  return <div id="page-container">Hello World</div>
+}
+export default Page

--- a/integration-tests/rpc-path-root/test/index.test.js
+++ b/integration-tests/rpc-path-root/test/index.test.js
@@ -1,0 +1,125 @@
+import {describe, it, expect, beforeAll, afterAll} from "vitest"
+import fs from "fs-extra"
+import {join} from "path"
+import {
+  killApp,
+  findPort,
+  launchApp,
+  fetchViaHTTP,
+  nextBuild,
+  nextStart,
+} from "../../utils/next-test-utils"
+
+// jest.setTimeout(1000 * 60 * 2)
+const appDir = join(__dirname, "../")
+let appPort
+let mode
+let app
+
+function runTests(dev = false) {
+  describe("api requests", () => {
+    it(
+      "regular query works",
+      async () => {
+        const data = await fetchViaHTTP(appPort, "/api/rpc/app/queries/getBasic", null, {
+          method: "POST",
+          headers: {"Content-Type": "application/json; charset=utf-8"},
+          body: JSON.stringify({params: {}}),
+        }).then((res) => res.ok && res.json())
+
+        expect(data).toEqual({result: "basic-result", error: null, meta: {}})
+      },
+      5000 * 60 * 2,
+    )
+
+    it(
+      "nested query works",
+      async () => {
+        const data = await fetchViaHTTP(appPort, "/api/rpc/app/queries/v2/getBasic", null, {
+          method: "POST",
+          headers: {"Content-Type": "application/json; charset=utf-8"},
+          body: JSON.stringify({params: {}}),
+        }).then((res) => res.ok && res.json())
+
+        expect(data).toEqual({result: "nested-basic", error: null, meta: {}})
+      },
+      5000 * 60 * 2,
+    )
+
+    it(
+      "monorepo query works",
+      async () => {
+        const data = await fetchViaHTTP(appPort, "/api/rpc/queries/getNoSuspenseBasic", null, {
+          method: "POST",
+          headers: {"Content-Type": "application/json; charset=utf-8"},
+          body: JSON.stringify({params: {}}),
+        }).then((res) => res.ok && res.json())
+
+        expect(data).toEqual({result: "basic-result", error: null, meta: {}})
+      },
+      5000 * 60 * 2,
+    )
+  })
+}
+
+describe("RPC", () => {
+  describe(
+    "dev mode",
+    () => {
+      beforeAll(async () => {
+        try {
+          appPort = await findPort()
+          app = await launchApp(appDir, appPort, {cwd: process.cwd()})
+        } catch (err) {
+          console.log(err)
+        }
+      })
+      afterAll(() => killApp(app))
+
+      runTests(true)
+    },
+    5000 * 60 * 2,
+  )
+
+  describe(
+    "server mode",
+    () => {
+      beforeAll(async () => {
+        await nextBuild(appDir)
+        mode = "server"
+        appPort = await findPort()
+        app = await nextStart(appDir, appPort, {cwd: process.cwd()})
+      })
+      afterAll(() => killApp(app))
+
+      runTests()
+    },
+    5000 * 60 * 2,
+  )
+
+  describe(
+    "serverless mode",
+    () => {
+      let nextConfigContent = ""
+      const nextConfigPath = join(appDir, "next.config.js")
+      beforeAll(async () => {
+        nextConfigContent = await fs.readFile(nextConfigPath, "utf8")
+        await fs.writeFile(
+          nextConfigPath,
+          nextConfigContent.replace("// update me", `target: 'experimental-serverless-trace',`),
+        )
+        await nextBuild(appDir)
+        mode = "serverless"
+        appPort = await findPort()
+        app = await nextStart(appDir, appPort, {cwd: process.cwd()})
+      })
+      afterAll(async () => {
+        await killApp(app)
+        await fs.writeFile(nextConfigPath, nextConfigContent)
+      })
+
+      runTests()
+    },
+    5000 * 60 * 2,
+  )
+})

--- a/integration-tests/rpc-path-root/tsconfig.json
+++ b/integration-tests/rpc-path-root/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types"],
+  "exclude": ["node_modules"]
+}

--- a/integration-tests/rpc-path-root/vitest.config.ts
+++ b/integration-tests/rpc-path-root/vitest.config.ts
@@ -1,0 +1,8 @@
+import {defineConfig} from "vitest/config"
+
+export default defineConfig({
+  test: {
+    testTimeout: 5000 * 60 * 2,
+    hookTimeout: 5000 * 60 * 2,
+  },
+})

--- a/integration-tests/rpc/app/queries/v2/getNestedBasic.js
+++ b/integration-tests/rpc/app/queries/v2/getNestedBasic.js
@@ -1,0 +1,3 @@
+export default async function getNestedBasic() {
+  return "nested-basic"
+}

--- a/integration-tests/rpc/app/queries/v2/getNestedBasic.js
+++ b/integration-tests/rpc/app/queries/v2/getNestedBasic.js
@@ -1,3 +1,0 @@
-export default async function getNestedBasic() {
-  return "nested-basic"
-}

--- a/packages/blitz-rpc/src/loader-client.ts
+++ b/packages/blitz-rpc/src/loader-client.ts
@@ -33,10 +33,6 @@ export async function loader(this: Loader, input: string): Promise<string> {
 
 module.exports = loader
 
-function slash(str: string) {
-  return str.replace(/\\/g, "/")
-}
-
 export async function transformBlitzRpcResolverClient(
   _src: string,
   id: string,
@@ -48,8 +44,8 @@ export async function transformBlitzRpcResolverClient(
   const resolverFilePath = "/" + posix.relative(root, id)
   assertPosixPath(resolverFilePath)
   const routePath = convertPageFilePathToRoutePath({
-    appRoot: slash(root),
-    absoluteFilePath: slash(resolverFilePath),
+    appRoot: root,
+    absoluteFilePath: resolverFilePath,
     resolverBasePath: options?.resolverPath,
     extraRpcBasePaths: options?.includeRPCFolders,
   })

--- a/packages/blitz-rpc/src/loader-client.ts
+++ b/packages/blitz-rpc/src/loader-client.ts
@@ -33,6 +33,10 @@ export async function loader(this: Loader, input: string): Promise<string> {
 
 module.exports = loader
 
+function slash(str: string) {
+  return str.replace(/\\/g, "/")
+}
+
 export async function transformBlitzRpcResolverClient(
   _src: string,
   id: string,
@@ -43,7 +47,12 @@ export async function transformBlitzRpcResolverClient(
   assertPosixPath(root)
   const resolverFilePath = "/" + posix.relative(root, id)
   assertPosixPath(resolverFilePath)
-  const routePath = convertPageFilePathToRoutePath(resolverFilePath, options?.resolverPath)
+  const routePath = convertPageFilePathToRoutePath({
+    appRoot: slash(root),
+    absoluteFilePath: slash(resolverFilePath),
+    resolverBasePath: options?.resolverPath,
+    extraRpcBasePaths: options?.includeRPCFolders,
+  })
   const resolverName = convertFilePathToResolverName(resolverFilePath)
   const resolverType = convertFilePathToResolverType(resolverFilePath)
   const resolverConfig: ResolverConfig = {

--- a/packages/blitz-rpc/src/loader-server-resolvers.ts
+++ b/packages/blitz-rpc/src/loader-server-resolvers.ts
@@ -32,6 +32,10 @@ export async function loader(this: Loader, input: string): Promise<string> {
 
 module.exports = loader
 
+function slash(str: string) {
+  return str.replace(/\\/g, "/")
+}
+
 export async function transformBlitzRpcResolverServer(
   src: string,
   id: string,
@@ -43,7 +47,12 @@ export async function transformBlitzRpcResolverServer(
 
   const resolverFilePath = "/" + posix.relative(root, id)
   assertPosixPath(resolverFilePath)
-  const routePath = convertPageFilePathToRoutePath(resolverFilePath, options?.resolverPath)
+  const routePath = convertPageFilePathToRoutePath({
+    appRoot: slash(root),
+    absoluteFilePath: slash(resolverFilePath),
+    resolverBasePath: options?.resolverPath,
+    extraRpcBasePaths: options?.includeRPCFolders,
+  })
   const resolverName = convertFilePathToResolverName(resolverFilePath)
   const resolverType = convertFilePathToResolverType(resolverFilePath)
 

--- a/packages/blitz-rpc/src/loader-server-resolvers.ts
+++ b/packages/blitz-rpc/src/loader-server-resolvers.ts
@@ -32,10 +32,6 @@ export async function loader(this: Loader, input: string): Promise<string> {
 
 module.exports = loader
 
-function slash(str: string) {
-  return str.replace(/\\/g, "/")
-}
-
 export async function transformBlitzRpcResolverServer(
   src: string,
   id: string,
@@ -48,8 +44,8 @@ export async function transformBlitzRpcResolverServer(
   const resolverFilePath = "/" + posix.relative(root, id)
   assertPosixPath(resolverFilePath)
   const routePath = convertPageFilePathToRoutePath({
-    appRoot: slash(root),
-    absoluteFilePath: slash(resolverFilePath),
+    appRoot: root,
+    absoluteFilePath: resolverFilePath,
     resolverBasePath: options?.resolverPath,
     extraRpcBasePaths: options?.includeRPCFolders,
   })

--- a/packages/blitz-rpc/src/loader-server.ts
+++ b/packages/blitz-rpc/src/loader-server.ts
@@ -69,7 +69,7 @@ export async function transformBlitzRpcServer(
     )}'));`
     code += "\n"
   }
-  console.log("NEW CODE", code)
+  // console.log("NEW CODE", code)
   return code
 }
 

--- a/packages/blitz-rpc/src/loader-server.ts
+++ b/packages/blitz-rpc/src/loader-server.ts
@@ -57,14 +57,18 @@ export async function transformBlitzRpcServer(
   let code = blitzImport + src
   code += "\n\n"
   for (let resolverFilePath of resolvers) {
-    const routePath = convertPageFilePathToRoutePath(slash(resolverFilePath), options?.resolverPath)
+    const routePath = convertPageFilePathToRoutePath({
+      appRoot: slash(root),
+      absoluteFilePath: slash(resolverFilePath),
+      resolverBasePath: options?.resolverPath,
+      extraRpcBasePaths: options?.includeRPCFolders,
+    })
 
     code += `__internal_addBlitzRpcResolver('${routePath}',() => import('${slash(
       resolverFilePath,
     )}'));`
     code += "\n"
   }
-  // console.log("NEW CODE", code)
   return code
 }
 

--- a/packages/blitz-rpc/src/loader-server.ts
+++ b/packages/blitz-rpc/src/loader-server.ts
@@ -58,8 +58,8 @@ export async function transformBlitzRpcServer(
   code += "\n\n"
   for (let resolverFilePath of resolvers) {
     const routePath = convertPageFilePathToRoutePath({
-      appRoot: slash(root),
-      absoluteFilePath: slash(resolverFilePath),
+      appRoot: root,
+      absoluteFilePath: resolverFilePath,
       resolverBasePath: options?.resolverPath,
       extraRpcBasePaths: options?.includeRPCFolders,
     })

--- a/packages/blitz-rpc/src/loader-server.ts
+++ b/packages/blitz-rpc/src/loader-server.ts
@@ -69,6 +69,7 @@ export async function transformBlitzRpcServer(
     )}'));`
     code += "\n"
   }
+  console.log("NEW CODE", code)
   return code
 }
 

--- a/packages/blitz-rpc/src/loader-utils.test.ts
+++ b/packages/blitz-rpc/src/loader-utils.test.ts
@@ -1,24 +1,52 @@
 import {describe, expect, it} from "vitest"
 import {convertPageFilePathToRoutePath} from "./loader-utils"
 
-const FILE_PATH = "app/queries/getData.ts"
+const APP_ROOT = "/Users/blitz/project"
+const FILE_PATH = "/Users/blitz/project/app/queries/getData.ts"
+
+const WIN_APP_ROOT = `D:a\\blitz\\project`
+const WIN_FILE_PATH = `D:a\\blitz\\project\\app\\queries\\getData.ts`
 
 describe("convertPageFilePathToRoutePath", () => {
   it("should return the full path when resolverBasePath is set to root", () => {
-    const res = convertPageFilePathToRoutePath(FILE_PATH, "root")
+    const res = convertPageFilePathToRoutePath({
+      absoluteFilePath: FILE_PATH,
+      resolverBasePath: "root",
+      appRoot: APP_ROOT,
+    })
 
-    expect(res).toEqual("app/queries/getData")
+    expect(res).toEqual("/app/queries/getData")
   })
 
   it("should return the relative path when resolverBasePath is set to queries|mutations", () => {
-    const res = convertPageFilePathToRoutePath(FILE_PATH, "queries|mutations")
+    const res = convertPageFilePathToRoutePath({
+      absoluteFilePath: FILE_PATH,
+      resolverBasePath: "queries|mutations",
+      appRoot: APP_ROOT,
+    })
 
     expect(res).toEqual("/getData")
   })
 
   it("should return the relative path when resolverBasePath is set to undefined", () => {
-    const res = convertPageFilePathToRoutePath(FILE_PATH, undefined)
+    const res = convertPageFilePathToRoutePath({
+      absoluteFilePath: FILE_PATH,
+      resolverBasePath: undefined,
+      appRoot: APP_ROOT,
+    })
 
     expect(res).toEqual("/getData")
+  })
+
+  describe("windwos", () => {
+    it("should return the full path when resolverBasePath is set to root", () => {
+      const res = convertPageFilePathToRoutePath({
+        absoluteFilePath: WIN_FILE_PATH,
+        resolverBasePath: "root",
+        appRoot: WIN_APP_ROOT,
+      })
+
+      expect(res).toEqual("/app/queries/getData")
+    })
   })
 })

--- a/packages/blitz-rpc/src/loader-utils.ts
+++ b/packages/blitz-rpc/src/loader-utils.ts
@@ -68,7 +68,7 @@ export function convertPageFilePathToRoutePath({
   } else if (resolverBasePath === "root") {
     path = path.replace(appRoot, "")
     for (const extraPath of extraRpcBasePaths) {
-      path = path.replace(join(appRoot, extraPath), "")
+      path = path.replace(join(appRoot, extraPath.replace("/", sep)), "")
     }
   } else {
     path = path.replace(/^.*?[\\/]queries[\\/]/, "/").replace(/^.*?[\\/]mutations[\\/]/, "/")

--- a/packages/blitz-rpc/src/loader-utils.ts
+++ b/packages/blitz-rpc/src/loader-utils.ts
@@ -1,5 +1,5 @@
 import {assert} from "blitz"
-import {posix, sep, win32, join} from "path"
+import {posix, sep, win32, join, normalize} from "path"
 import {ResolverPathOptions} from "./index-server"
 
 export interface LoaderOptions {
@@ -61,14 +61,14 @@ export function convertPageFilePathToRoutePath({
   resolverBasePath?: ResolverPathOptions
   extraRpcBasePaths?: string[]
 }) {
-  let path = absoluteFilePath
+  let path = normalize(absoluteFilePath)
 
   if (typeof resolverBasePath === "function") {
-    path = resolverBasePath(absoluteFilePath)
+    path = resolverBasePath(path)
   } else if (resolverBasePath === "root") {
-    path = path.replace(appRoot, "")
+    path = path.replace(normalize(appRoot), "")
     for (const extraPath of extraRpcBasePaths) {
-      path = path.replace(join(appRoot, extraPath.replace("/", sep)), "")
+      path = path.replace(join(normalize(appRoot), extraPath.replace("/", sep)), "")
     }
   } else {
     path = path.replace(/^.*?[\\/]queries[\\/]/, "/").replace(/^.*?[\\/]mutations[\\/]/, "/")

--- a/packages/blitz-rpc/src/loader-utils.ts
+++ b/packages/blitz-rpc/src/loader-utils.ts
@@ -61,23 +61,20 @@ export function convertPageFilePathToRoutePath({
   resolverBasePath?: ResolverPathOptions
   extraRpcBasePaths?: string[]
 }) {
-  if (typeof resolverBasePath === "function") {
-    return resolverBasePath(absoluteFilePath).replace(fileExtensionRegex, "")
-  }
+  let path = absoluteFilePath
 
-  if (resolverBasePath === "root") {
-    let path = absoluteFilePath.replace(appRoot, "")
+  if (typeof resolverBasePath === "function") {
+    path = resolverBasePath(absoluteFilePath)
+  } else if (resolverBasePath === "root") {
+    path = path.replace(appRoot, "")
     for (const extraPath of extraRpcBasePaths) {
       path = path.replace(join(appRoot, extraPath), "")
     }
-    return path.replace(fileExtensionRegex, "")
+  } else {
+    path = path.replace(/^.*?[\\/]queries[\\/]/, "/").replace(/^.*?[\\/]mutations[\\/]/, "/")
   }
 
-  return absoluteFilePath
-    .replace(/^.*?[\\/]queries[\\/]/, "/")
-    .replace(/^.*?[\\/]mutations[\\/]/, "/")
-    .replace(/\\/g, "/")
-    .replace(fileExtensionRegex, "")
+  return path.replace(/\\/g, "/").replace(fileExtensionRegex, "")
 }
 
 export function convertFilePathToResolverName(filePathFromAppRoot: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -551,6 +551,43 @@ importers:
       fs-extra: 10.0.1
       typescript: 4.8.4
 
+  integration-tests/rpc-path-root:
+    specifiers:
+      "@blitzjs/auth": workspace:*
+      "@blitzjs/config": workspace:*
+      "@blitzjs/next": workspace:*
+      "@blitzjs/rpc": workspace:*
+      "@types/express": 4.17.13
+      "@types/fs-extra": 9.0.13
+      "@types/node-fetch": 2.6.1
+      "@types/react": 18.0.25
+      b64-lite: 1.4.0
+      blitz: workspace:*
+      eslint: 8.27.0
+      fs-extra: 10.0.1
+      next: 12.2.5
+      react: 18.2.0
+      react-dom: 18.2.0
+      typescript: ^4.8.4
+    dependencies:
+      "@blitzjs/auth": link:../../packages/blitz-auth
+      "@blitzjs/config": link:../../packages/config
+      "@blitzjs/next": link:../../packages/blitz-next
+      "@blitzjs/rpc": link:../../packages/blitz-rpc
+      blitz: link:../../packages/blitz
+      next: 12.2.5_biqbaboplfbrettd7655fr4n2y
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    devDependencies:
+      "@types/express": 4.17.13
+      "@types/fs-extra": 9.0.13
+      "@types/node-fetch": 2.6.1
+      "@types/react": 18.0.25
+      b64-lite: 1.4.0
+      eslint: 8.27.0
+      fs-extra: 10.0.1
+      typescript: 4.8.4
+
   integration-tests/trailing-slash:
     specifiers:
       "@blitzjs/auth": workspace:*
@@ -3487,7 +3524,6 @@ packages:
       semver: 5.7.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/preset-flow/7.17.12_@babel+core@7.18.2:
     resolution:
@@ -6278,7 +6314,6 @@ packages:
       typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/experimental-utils/5.28.0_rmayb2veg2btbq6mbmnyivgasy:
     resolution:
@@ -10082,7 +10117,6 @@ packages:
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
 
   /eslint-config-next/13.0.3_rmayb2veg2btbq6mbmnyivgasy:
     resolution:
@@ -10120,7 +10154,6 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: ">=7.0.0"
-    dev: false
 
   /eslint-config-prettier/8.5.0_eslint@8.27.0:
     resolution:
@@ -13033,7 +13066,7 @@ packages:
       pretty-format: 29.2.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_typescript@4.8.4
+      ts-node: 10.9.1_cbe7ovvae6zqfnmtgctpgpys54
     transitivePeerDependencies:
       - supports-color
 
@@ -18643,7 +18676,6 @@ packages:
       typescript: 4.8.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: false
 
   /ts-node/10.9.1_ieummqxttktzud32hpyrer46t4:
     resolution:
@@ -18710,6 +18742,7 @@ packages:
       typescript: 4.8.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: false
 
   /tsconfig-paths/3.14.1:
     resolution:


### PR DESCRIPTION


### What are the changes and their implications?

fix `resolverPath: "root"` and make it work with monorepo resolvers

## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

