### PR TITLE
fix: Reject db.() with an error object

### DIFF
--- a/.changeset/calm-papayas-protect.md
+++ b/.changeset/calm-papayas-protect.md
@@ -1,0 +1,5 @@
+---
+"blitz": minor
+---
+
+When db.\$reset() rejects, reject with an Error object

--- a/packages/blitz/src/utils/enhance-prisma.ts
+++ b/packages/blitz/src/utils/enhance-prisma.ts
@@ -40,7 +40,7 @@ export const enhancePrisma = <TPrismaClientCtor extends Constructor>(
             const process = spawn(prismaBin, ["migrate", "reset", "--force", "--skip-generate"], {
               stdio: "ignore",
             })
-            process.on("exit", (code) => (code === 0 ? res(0) : rej(code)))
+            process.on("exit", (code) => (code === 0 ? res(0) : rej(new Error(`db.$reset() failed with code ${code}`))))
           })
           globalThis._blitz_prismaClient.$disconnect()
         }


### PR DESCRIPTION
Closes: #4005

### What are the changes and their implications?

This replaces the error case of `db.$reset()` from rejecting with the value `1` to the value    `Error(`db.$reset() failed with code 1`)`

## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [x] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed) (this file has no tests so far)