### PR TITLE
fix failed localstorage access to not crash the application

### DIFF
--- a/.changeset/soft-fans-carry.md
+++ b/.changeset/soft-fans-carry.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/auth": minor
+---
+
+fix failed localStorage access to not crash the application

--- a/packages/blitz-auth/src/client/index.tsx
+++ b/packages/blitz-auth/src/client/index.tsx
@@ -90,7 +90,11 @@ class PublicDataStore {
 
   clear() {
     deleteCookie(COOKIE_PUBLIC_DATA_TOKEN())
-    localStorage.removeItem(LOCALSTORAGE_PUBLIC_DATA_TOKEN())
+    try {
+      localStorage.removeItem(LOCALSTORAGE_PUBLIC_DATA_TOKEN())
+    } catch (err) {
+      console.error("LocalStorage is not available", err)
+    }
     this.updateState(emptyPublicData)
   }
 
@@ -105,12 +109,17 @@ class PublicDataStore {
   }
 
   private getToken() {
-    const cookieValue = readCookie(COOKIE_PUBLIC_DATA_TOKEN())
-    if (cookieValue) {
-      localStorage.setItem(LOCALSTORAGE_PUBLIC_DATA_TOKEN(), cookieValue)
-      return cookieValue
-    } else {
-      return localStorage.getItem(LOCALSTORAGE_PUBLIC_DATA_TOKEN())
+    try {
+      const cookieValue = readCookie(COOKIE_PUBLIC_DATA_TOKEN())
+      if (cookieValue) {
+        localStorage.setItem(LOCALSTORAGE_PUBLIC_DATA_TOKEN(), cookieValue)
+        return cookieValue
+      } else {
+        return localStorage.getItem(LOCALSTORAGE_PUBLIC_DATA_TOKEN())
+      }
+    } catch (err) {
+      console.error("LocalStorage is not available", err)
+      return undefined
     }
   }
 }


### PR DESCRIPTION


### What are the changes and their implications?

fix failed localstorage access to not crash the application. This can happen when running the app inside an iframe

## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)