### PR TITLE
add `currentPassword` to default masked fields in the logger

### DIFF
--- a/.changeset/swift-poets-travel.md
+++ b/.changeset/swift-poets-travel.md
@@ -1,0 +1,5 @@
+---
+"blitz": minor
+---
+
+add `currentPassword` to the default fields that are masked in the logger

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,5 @@
+# .kodiak.toml
+# Minimal config. version is the only required field.
+version = 1
+merge.automerge_label = "0 - <(^_^)> -  merge it! ✌️"
+approve.auto_approve_usernames = ["flybayer", "depfu"]

--- a/packages/blitz/src/logging.ts
+++ b/packages/blitz/src/logging.ts
@@ -41,7 +41,7 @@ export const BlitzLogger = (settings: BlitzLoggerSettings = {}) => {
       bigint: "blue",
       boolean: "blue",
     },
-    maskValuesOfKeys: ["password", "passwordConfirmation"],
+    maskValuesOfKeys: ["password", "passwordConfirmation", "currentPassword"],
     exposeErrorCodeFrame: process.env.NODE_ENV !== "production",
     ...settings,
   })


### PR DESCRIPTION


### What are the changes and their implications?

filter out `currentPassword` fields by default in our logger

## Feature Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
