### PR TITLE
Add missing MockRouter prop in generated test utils

### DIFF
--- a/.changeset/purple-jars-begin.md
+++ b/.changeset/purple-jars-begin.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Fix missing MockRouter prop in test utils

--- a/packages/generator/templates/app/test/utils.tsx
+++ b/packages/generator/templates/app/test/utils.tsx
@@ -84,6 +84,7 @@ export const mockRouter: NextRouter = {
   isReady: true,
   isLocaleDomain: false,
   isPreview: false,
+  forward: vi.fn(),
   push: vi.fn(),
   replace: vi.fn(),
   reload: vi.fn(),


### PR DESCRIPTION
### What are the changes and their implications?

Currently, `test/utils.tsx` in a newly generated app is producing a type error due to missing `forward` prop. This change adds that prop.
