### PR TITLE
Update to `"typescript": "4.9.4"`

### DIFF
--- a/.changeset/angry-actors-greet.md
+++ b/.changeset/angry-actors-greet.md
@@ -1,0 +1,12 @@
+---
+"toolkit-app": patch
+"test-full-auth-with-rpc": patch
+"blitz": patch
+"@blitzjs/auth": patch
+"@blitzjs/next": patch
+"@blitzjs/rpc": patch
+"@blitzjs/generator": patch
+"template": patch
+---
+
+Update TypeScritp from `^4.8.4` to `4.9.4`

--- a/apps/toolkit-app/package.json
+++ b/apps/toolkit-app/package.json
@@ -60,7 +60,7 @@
     "prettier-plugin-prisma": "4.4.0",
     "pretty-quick": "3.1.3",
     "preview-email": "3.0.7",
-    "typescript": "^4.8.4",
+    "typescript": "4.9.4",
     "vite-tsconfig-paths": "3.6.0",
     "vitest": "0.25.3"
   },

--- a/integration-tests/auth-with-rpc/package.json
+++ b/integration-tests/auth-with-rpc/package.json
@@ -55,7 +55,7 @@
     "prettier-plugin-prisma": "4.4.0",
     "pretty-quick": "3.1.3",
     "preview-email": "3.0.7",
-    "typescript": "^4.8.4",
+    "typescript": "4.9.4",
     "vite-tsconfig-paths": "3.6.0",
     "vitest": "0.25.3"
   }

--- a/packages/blitz-auth/package.json
+++ b/packages/blitz-auth/package.json
@@ -53,7 +53,7 @@
     "blitz": "2.0.0-beta.22",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "4.9.4",
     "unbuild": "0.7.6",
     "watch": "1.0.2"
   },

--- a/packages/blitz-next/package.json
+++ b/packages/blitz-next/package.json
@@ -57,7 +57,7 @@
     "react-dom": "18.2.0",
     "resolve-from": "5.0.0",
     "ts-jest": "27.1.4",
-    "typescript": "^4.8.4",
+    "typescript": "4.9.4",
     "unbuild": "0.7.6",
     "watch": "1.0.2"
   },

--- a/packages/blitz-rpc/package.json
+++ b/packages/blitz-rpc/package.json
@@ -44,7 +44,7 @@
     "next": "12.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "4.9.4",
     "unbuild": "0.7.6",
     "watch": "1.0.2",
     "zod": "3.20.2"

--- a/packages/blitz/package.json
+++ b/packages/blitz/package.json
@@ -95,7 +95,7 @@
     "express": "4.17.3",
     "react": "18.2.0",
     "test-listen": "1.1.0",
-    "typescript": "^4.8.4",
+    "typescript": "4.9.4",
     "unbuild": "0.7.6",
     "watch": "1.0.2",
     "zod": "3.20.2"

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -66,7 +66,7 @@
     "debug": "4.3.3",
     "eslint": "8.27.0",
     "react": "18.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "4.9.4",
     "unbuild": "0.6.9",
     "watch": "1.0.2"
   },

--- a/packages/generator/templates/app/package.ts.json
+++ b/packages/generator/templates/app/package.ts.json
@@ -53,7 +53,7 @@
     "prettier-plugin-prisma": "4.4.0",
     "pretty-quick": "3.1.3",
     "preview-email": "3.0.7",
-    "typescript": "^4.8.4",
+    "typescript": "4.9.4",
     "vite-tsconfig-paths": "3.6.0",
     "vitest": "0.25.3"
   },

--- a/packages/generator/templates/minimalapp/package.ts.json
+++ b/packages/generator/templates/minimalapp/package.ts.json
@@ -40,7 +40,7 @@
     "lint-staged": "13.0.3",
     "prettier": "^2.7.1",
     "pretty-quick": "3.1.3",
-    "typescript": "^4.8.4",
+    "typescript": "4.9.4",
     "vite-tsconfig-paths": "3.6.0",
     "vitest": "0.25.3"
   },

--- a/packages/pkg-template/package.json
+++ b/packages/pkg-template/package.json
@@ -29,7 +29,7 @@
     "@types/react": "18.0.25",
     "@types/react-dom": "17.0.14",
     "react": "18.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "4.9.4",
     "unbuild": "0.7.6",
     "watch": "1.0.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
       react-dom: 18.2.0
       react-hook-form: 7.39.1
       ts-node: 10.9.1
-      typescript: ^4.8.4
+      typescript: 4.9.4
       vite-tsconfig-paths: 3.6.0
       vitest: 0.25.3
       zod: 3.20.2
@@ -86,7 +86,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-hook-form: 7.39.1_react@18.2.0
-      ts-node: 10.9.1_cbe7ovvae6zqfnmtgctpgpys54
+      ts-node: 10.9.1_3v2cms72gsblw7jmali7btb3pu
       zod: 3.20.2
     devDependencies:
       "@next/bundle-analyzer": 12.0.8
@@ -96,10 +96,10 @@ importers:
       "@types/node": 18.11.9
       "@types/preview-email": 2.0.1
       "@types/react": 18.0.25
-      "@typescript-eslint/eslint-plugin": 5.42.1_rmayb2veg2btbq6mbmnyivgasy
+      "@typescript-eslint/eslint-plugin": 5.42.1_fqmqyeinda7panflsqpj5zauc4
       "@vitejs/plugin-react": 2.2.0
       eslint: 8.27.0
-      eslint-config-next: 12.3.1_rmayb2veg2btbq6mbmnyivgasy
+      eslint-config-next: 12.3.1_fqmqyeinda7panflsqpj5zauc4
       eslint-config-prettier: 8.5.0_eslint@8.27.0
       husky: 8.0.2
       jsdom: 20.0.3
@@ -108,7 +108,7 @@ importers:
       prettier-plugin-prisma: 4.4.0_prettier@2.7.1
       pretty-quick: 3.1.3_prettier@2.7.1
       preview-email: 3.0.7
-      typescript: 4.8.4
+      typescript: 4.9.4
       vite-tsconfig-paths: 3.6.0
       vitest: 0.25.3_jsdom@20.0.3
 
@@ -324,7 +324,7 @@ importers:
       react-dom: 18.2.0
       react-hook-form: 7.39.1
       ts-node: 10.9.1
-      typescript: ^4.8.4
+      typescript: 4.9.4
       vite-tsconfig-paths: 3.6.0
       vitest: 0.25.3
       zod: 3.20.2
@@ -343,7 +343,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-hook-form: 7.39.1_react@18.2.0
-      ts-node: 10.9.1_cbe7ovvae6zqfnmtgctpgpys54
+      ts-node: 10.9.1_3v2cms72gsblw7jmali7btb3pu
       zod: 3.20.2
     devDependencies:
       "@next/bundle-analyzer": 12.0.8
@@ -353,10 +353,10 @@ importers:
       "@types/node": 18.11.9
       "@types/preview-email": 2.0.1
       "@types/react": 18.0.25
-      "@typescript-eslint/eslint-plugin": 5.42.1_rmayb2veg2btbq6mbmnyivgasy
+      "@typescript-eslint/eslint-plugin": 5.42.1_fqmqyeinda7panflsqpj5zauc4
       "@vitejs/plugin-react": 2.2.0
       eslint: 8.27.0
-      eslint-config-next: 12.3.1_rmayb2veg2btbq6mbmnyivgasy
+      eslint-config-next: 12.3.1_fqmqyeinda7panflsqpj5zauc4
       eslint-config-prettier: 8.5.0_eslint@8.27.0
       husky: 8.0.2
       jsdom: 20.0.3
@@ -366,7 +366,7 @@ importers:
       prettier-plugin-prisma: 4.4.0_prettier@2.7.1
       pretty-quick: 3.1.3_prettier@2.7.1
       preview-email: 3.0.7
-      typescript: 4.8.4
+      typescript: 4.9.4
       vite-tsconfig-paths: 3.6.0
       vitest: 0.25.3_jsdom@20.0.3
 
@@ -547,7 +547,7 @@ importers:
       "@vitejs/plugin-react": 1.3.0
       delay: 5.0.0
       eslint: 8.27.0
-      eslint-config-next: 13.1.1_rmayb2veg2btbq6mbmnyivgasy
+      eslint-config-next: 13.1.2_rmayb2veg2btbq6mbmnyivgasy
       eslint-plugin-testing-library: 5.0.1_rmayb2veg2btbq6mbmnyivgasy
       jsdom: 19.0.0
       typescript: 4.8.4
@@ -845,7 +845,7 @@ importers:
       ts-node: 10.9.1
       tsconfig-paths: 4.0.0
       tslog: 3.3.4
-      typescript: ^4.8.4
+      typescript: 4.9.4
       unbuild: 0.7.6
       watch: 1.0.2
       watchpack: 2.1.1
@@ -894,7 +894,7 @@ importers:
       superjson: 1.11.0
       supports-color: 8.1.1
       tar: 6.1.11
-      ts-node: 10.9.1_typescript@4.8.4
+      ts-node: 10.9.1_typescript@4.9.4
       tsconfig-paths: 4.0.0
       tslog: 3.3.4
       watchpack: 2.1.1
@@ -920,7 +920,7 @@ importers:
       express: 4.17.3_supports-color@8.1.1
       react: 18.2.0
       test-listen: 1.1.0
-      typescript: 4.8.4
+      typescript: 4.9.4
       unbuild: 0.7.6_supports-color@8.1.1
       watch: 1.0.2
       zod: 3.20.2
@@ -954,7 +954,7 @@ importers:
       react-dom: 18.2.0
       secure-password: 4.0.0
       supports-color: 8.1.1
-      typescript: ^4.8.4
+      typescript: 4.9.4
       unbuild: 0.7.6
       url: 0.11.0
       watch: 1.0.2
@@ -988,7 +988,7 @@ importers:
       blitz: link:../blitz
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      typescript: 4.8.4
+      typescript: 4.9.4
       unbuild: 0.7.6_supports-color@8.1.1
       watch: 1.0.2
 
@@ -1020,7 +1020,7 @@ importers:
       superjson: 1.11.0
       supports-color: 8.1.1
       ts-jest: 27.1.4
-      typescript: ^4.8.4
+      typescript: 4.9.4
       unbuild: 0.7.6
       watch: 1.0.2
     dependencies:
@@ -1050,8 +1050,8 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       resolve-from: 5.0.0
-      ts-jest: 27.1.4_typescript@4.8.4
-      typescript: 4.8.4
+      ts-jest: 27.1.4_typescript@4.9.4
+      typescript: 4.9.4
       unbuild: 0.7.6_supports-color@8.1.1
       watch: 1.0.2
 
@@ -1074,7 +1074,7 @@ importers:
       react-dom: 18.2.0
       superjson: 1.11.0
       supports-color: 8.1.1
-      typescript: ^4.8.4
+      typescript: 4.9.4
       unbuild: 0.7.6
       watch: 1.0.2
       zod: 3.20.2
@@ -1097,7 +1097,7 @@ importers:
       next: 12.2.5_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      typescript: 4.8.4
+      typescript: 4.9.4
       unbuild: 0.7.6_supports-color@8.1.1
       watch: 1.0.2
       zod: 3.20.2
@@ -1208,7 +1208,7 @@ importers:
       recast: 0.20.5
       supports-color: 8.1.1
       tslog: 3.3.4
-      typescript: ^4.8.4
+      typescript: 4.9.4
       unbuild: 0.6.9
       username: 5.1.0
       vinyl: 2.2.1
@@ -1253,13 +1253,13 @@ importers:
       "@types/react": 18.0.25
       "@types/react-dom": 17.0.14
       "@types/vinyl": 2.0.6
-      "@typescript-eslint/eslint-plugin": 5.42.1_6dla7skwulzvrxac2nj7jbunfa
-      "@typescript-eslint/parser": 5.9.1_nw6v2wse7au2evadw7vu3hneg4
+      "@typescript-eslint/eslint-plugin": 5.42.1_uqqm44q4emosylboqlcggapbbi
+      "@typescript-eslint/parser": 5.9.1_hbslhhjcqrbqb6dsmbxexsqt5y
       babylon: 6.18.0
       debug: 4.3.3_supports-color@8.1.1
       eslint: 8.27.0_supports-color@8.1.1
       react: 18.2.0
-      typescript: 4.8.4
+      typescript: 4.9.4
       unbuild: 0.6.9_supports-color@8.1.1
       watch: 1.0.2
 
@@ -1271,18 +1271,18 @@ importers:
       "@typescript-eslint/eslint-plugin": 5.42.1
       "@typescript-eslint/parser": 5.9.1
       react: 18.2.0
-      typescript: ^4.8.4
+      typescript: 4.9.4
       unbuild: 0.7.6
       watch: 1.0.2
     dependencies:
-      "@typescript-eslint/eslint-plugin": 5.42.1_z4ocgzhfuku3ho6vky337zbopm
-      "@typescript-eslint/parser": 5.9.1_typescript@4.8.4
+      "@typescript-eslint/eslint-plugin": 5.42.1_ab5ki6nksrfbhi7tj7va4zamxa
+      "@typescript-eslint/parser": 5.9.1_typescript@4.9.4
     devDependencies:
       "@blitzjs/config": link:../config
       "@types/react": 18.0.25
       "@types/react-dom": 17.0.14
       react: 18.2.0
-      typescript: 4.8.4
+      typescript: 4.9.4
       unbuild: 0.7.6
       watch: 1.0.2
 
@@ -5091,10 +5091,10 @@ packages:
     dependencies:
       glob: 7.1.7
 
-  /@next/eslint-plugin-next/13.1.1:
+  /@next/eslint-plugin-next/13.1.2:
     resolution:
       {
-        integrity: sha512-SBrOFS8PC3nQ5aeZmawJkjKkWjwK9RoxvBSv/86nZp0ubdoVQoko8r8htALd9ufp16NhacCdqhu9bzZLDWtALQ==,
+        integrity: sha512-WGaNVvIYphdriesP6r7jq/8l7u38tzotnVQuxc1RYKLqYYApSsrebti3OCPoT3Gx0pw2smPIFHH98RzcsgW5GQ==,
       }
     dependencies:
       glob: 7.1.7
@@ -6741,7 +6741,7 @@ packages:
       }
     dev: false
 
-  /@typescript-eslint/eslint-plugin/5.42.1_6dla7skwulzvrxac2nj7jbunfa:
+  /@typescript-eslint/eslint-plugin/5.42.1_ab5ki6nksrfbhi7tj7va4zamxa:
     resolution:
       {
         integrity: sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==,
@@ -6755,18 +6755,46 @@ packages:
       typescript:
         optional: true
     dependencies:
-      "@typescript-eslint/parser": 5.9.1_nw6v2wse7au2evadw7vu3hneg4
+      "@typescript-eslint/parser": 5.9.1_typescript@4.9.4
       "@typescript-eslint/scope-manager": 5.42.1
-      "@typescript-eslint/type-utils": 5.42.1_nw6v2wse7au2evadw7vu3hneg4
-      "@typescript-eslint/utils": 5.42.1_nw6v2wse7au2evadw7vu3hneg4
-      debug: 4.3.4_supports-color@8.1.1
-      eslint: 8.27.0_supports-color@8.1.1
+      "@typescript-eslint/type-utils": 5.42.1_typescript@4.9.4
+      "@typescript-eslint/utils": 5.42.1_typescript@4.9.4
+      debug: 4.3.4
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/eslint-plugin/5.42.1_fqmqyeinda7panflsqpj5zauc4:
+    resolution:
+      {
+        integrity: sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      "@typescript-eslint/parser": ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@typescript-eslint/scope-manager": 5.42.1
+      "@typescript-eslint/type-utils": 5.42.1_fqmqyeinda7panflsqpj5zauc4
+      "@typescript-eslint/utils": 5.42.1_fqmqyeinda7panflsqpj5zauc4
+      debug: 4.3.4
+      eslint: 8.27.0
+      ignore: 5.2.0
+      natural-compare-lite: 1.4.0
+      regexpp: 3.2.0
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6796,6 +6824,36 @@ packages:
       semver: 7.3.7
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/eslint-plugin/5.42.1_uqqm44q4emosylboqlcggapbbi:
+    resolution:
+      {
+        integrity: sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      "@typescript-eslint/parser": ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@typescript-eslint/parser": 5.9.1_hbslhhjcqrbqb6dsmbxexsqt5y
+      "@typescript-eslint/scope-manager": 5.42.1
+      "@typescript-eslint/type-utils": 5.42.1_hbslhhjcqrbqb6dsmbxexsqt5y
+      "@typescript-eslint/utils": 5.42.1_hbslhhjcqrbqb6dsmbxexsqt5y
+      debug: 4.3.4_supports-color@8.1.1
+      eslint: 8.27.0_supports-color@8.1.1
+      ignore: 5.2.0
+      natural-compare-lite: 1.4.0
+      regexpp: 3.2.0
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6845,6 +6903,28 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/parser/5.43.0_fqmqyeinda7panflsqpj5zauc4:
+    resolution:
+      {
+        integrity: sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@typescript-eslint/scope-manager": 5.43.0
+      "@typescript-eslint/types": 5.43.0
+      "@typescript-eslint/typescript-estree": 5.43.0_typescript@4.9.4
+      debug: 4.3.4
+      eslint: 8.27.0
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+
   /@typescript-eslint/parser/5.43.0_rmayb2veg2btbq6mbmnyivgasy:
     resolution:
       {
@@ -6866,6 +6946,7 @@ packages:
       typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/parser/5.43.0_typescript@4.8.4:
     resolution:
@@ -6889,7 +6970,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser/5.9.1_nw6v2wse7au2evadw7vu3hneg4:
+  /@typescript-eslint/parser/5.9.1_hbslhhjcqrbqb6dsmbxexsqt5y:
     resolution:
       {
         integrity: sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==,
@@ -6904,10 +6985,10 @@ packages:
     dependencies:
       "@typescript-eslint/scope-manager": 5.9.1
       "@typescript-eslint/types": 5.9.1
-      "@typescript-eslint/typescript-estree": 5.9.1_rlpflyxsp53dgdidn3vadezrry
+      "@typescript-eslint/typescript-estree": 5.9.1_uksqigk62dhqorev5gqtq62rta
       debug: 4.3.4_supports-color@8.1.1
       eslint: 8.27.0_supports-color@8.1.1
-      typescript: 4.8.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6930,6 +7011,28 @@ packages:
       "@typescript-eslint/typescript-estree": 5.9.1_typescript@4.8.4
       debug: 4.3.4
       typescript: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/parser/5.9.1_typescript@4.9.4:
+    resolution:
+      {
+        integrity: sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@typescript-eslint/scope-manager": 5.9.1
+      "@typescript-eslint/types": 5.9.1
+      "@typescript-eslint/typescript-estree": 5.9.1_typescript@4.9.4
+      debug: 4.3.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6975,7 +7078,7 @@ packages:
       "@typescript-eslint/types": 5.9.1
       "@typescript-eslint/visitor-keys": 5.9.1
 
-  /@typescript-eslint/type-utils/5.42.1_nw6v2wse7au2evadw7vu3hneg4:
+  /@typescript-eslint/type-utils/5.42.1_fqmqyeinda7panflsqpj5zauc4:
     resolution:
       {
         integrity: sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==,
@@ -6988,12 +7091,35 @@ packages:
       typescript:
         optional: true
     dependencies:
-      "@typescript-eslint/typescript-estree": 5.42.1_rlpflyxsp53dgdidn3vadezrry
-      "@typescript-eslint/utils": 5.42.1_nw6v2wse7au2evadw7vu3hneg4
+      "@typescript-eslint/typescript-estree": 5.42.1_typescript@4.9.4
+      "@typescript-eslint/utils": 5.42.1_fqmqyeinda7panflsqpj5zauc4
+      debug: 4.3.4
+      eslint: 8.27.0
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/type-utils/5.42.1_hbslhhjcqrbqb6dsmbxexsqt5y:
+    resolution:
+      {
+        integrity: sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: "*"
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@typescript-eslint/typescript-estree": 5.42.1_uksqigk62dhqorev5gqtq62rta
+      "@typescript-eslint/utils": 5.42.1_hbslhhjcqrbqb6dsmbxexsqt5y
       debug: 4.3.4_supports-color@8.1.1
       eslint: 8.27.0_supports-color@8.1.1
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7039,6 +7165,28 @@ packages:
       debug: 4.3.4
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/type-utils/5.42.1_typescript@4.9.4:
+    resolution:
+      {
+        integrity: sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: "*"
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@typescript-eslint/typescript-estree": 5.42.1_typescript@4.9.4
+      "@typescript-eslint/utils": 5.42.1_typescript@4.9.4
+      debug: 4.3.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7096,30 +7244,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.42.1_rlpflyxsp53dgdidn3vadezrry:
-    resolution:
-      {
-        integrity: sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==,
-      }
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: "*"
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      "@typescript-eslint/types": 5.42.1
-      "@typescript-eslint/visitor-keys": 5.42.1
-      debug: 4.3.4_supports-color@8.1.1
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/typescript-estree/5.42.1_typescript@4.8.4:
     resolution:
       {
@@ -7142,6 +7266,53 @@ packages:
       typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
+
+  /@typescript-eslint/typescript-estree/5.42.1_typescript@4.9.4:
+    resolution:
+      {
+        integrity: sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@typescript-eslint/types": 5.42.1
+      "@typescript-eslint/visitor-keys": 5.42.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  /@typescript-eslint/typescript-estree/5.42.1_uksqigk62dhqorev5gqtq62rta:
+    resolution:
+      {
+        integrity: sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@typescript-eslint/types": 5.42.1
+      "@typescript-eslint/visitor-keys": 5.42.1
+      debug: 4.3.4_supports-color@8.1.1
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@typescript-eslint/typescript-estree/5.43.0_typescript@4.8.4:
     resolution:
@@ -7166,10 +7337,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree/5.9.1_rlpflyxsp53dgdidn3vadezrry:
+  /@typescript-eslint/typescript-estree/5.43.0_typescript@4.9.4:
     resolution:
       {
-        integrity: sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==,
+        integrity: sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==,
       }
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7178,17 +7349,16 @@ packages:
       typescript:
         optional: true
     dependencies:
-      "@typescript-eslint/types": 5.9.1
-      "@typescript-eslint/visitor-keys": 5.9.1
-      debug: 4.3.4_supports-color@8.1.1
+      "@typescript-eslint/types": 5.43.0
+      "@typescript-eslint/visitor-keys": 5.43.0
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/typescript-estree/5.9.1_typescript@4.8.4:
     resolution:
@@ -7214,6 +7384,54 @@ packages:
       - supports-color
     dev: false
 
+  /@typescript-eslint/typescript-estree/5.9.1_typescript@4.9.4:
+    resolution:
+      {
+        integrity: sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@typescript-eslint/types": 5.9.1
+      "@typescript-eslint/visitor-keys": 5.9.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/typescript-estree/5.9.1_uksqigk62dhqorev5gqtq62rta:
+    resolution:
+      {
+        integrity: sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@typescript-eslint/types": 5.9.1
+      "@typescript-eslint/visitor-keys": 5.9.1
+      debug: 4.3.4_supports-color@8.1.1
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/utils/5.28.0_rmayb2veg2btbq6mbmnyivgasy:
     resolution:
       {
@@ -7235,7 +7453,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils/5.42.1_nw6v2wse7au2evadw7vu3hneg4:
+  /@typescript-eslint/utils/5.42.1_fqmqyeinda7panflsqpj5zauc4:
     resolution:
       {
         integrity: sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==,
@@ -7248,7 +7466,30 @@ packages:
       "@types/semver": 7.3.13
       "@typescript-eslint/scope-manager": 5.42.1
       "@typescript-eslint/types": 5.42.1
-      "@typescript-eslint/typescript-estree": 5.42.1_rlpflyxsp53dgdidn3vadezrry
+      "@typescript-eslint/typescript-estree": 5.42.1_typescript@4.9.4
+      eslint: 8.27.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.27.0
+      semver: 7.3.7
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils/5.42.1_hbslhhjcqrbqb6dsmbxexsqt5y:
+    resolution:
+      {
+        integrity: sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      "@types/json-schema": 7.0.11
+      "@types/semver": 7.3.13
+      "@typescript-eslint/scope-manager": 5.42.1
+      "@typescript-eslint/types": 5.42.1
+      "@typescript-eslint/typescript-estree": 5.42.1_uksqigk62dhqorev5gqtq62rta
       eslint: 8.27.0_supports-color@8.1.1
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.27.0
@@ -7295,6 +7536,28 @@ packages:
       "@typescript-eslint/scope-manager": 5.42.1
       "@typescript-eslint/types": 5.42.1
       "@typescript-eslint/typescript-estree": 5.42.1_typescript@4.8.4
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0
+      semver: 7.3.7
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
+  /@typescript-eslint/utils/5.42.1_typescript@4.9.4:
+    resolution:
+      {
+        integrity: sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==,
+      }
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      "@types/json-schema": 7.0.11
+      "@types/semver": 7.3.13
+      "@typescript-eslint/scope-manager": 5.42.1
+      "@typescript-eslint/types": 5.42.1
+      "@typescript-eslint/typescript-estree": 5.42.1_typescript@4.9.4
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0
       semver: 7.3.7
@@ -10897,6 +11160,34 @@ packages:
     optionalDependencies:
       source-map: 0.6.1
 
+  /eslint-config-next/12.3.1_fqmqyeinda7panflsqpj5zauc4:
+    resolution:
+      {
+        integrity: sha512-EN/xwKPU6jz1G0Qi6Bd/BqMnHLyRAL0VsaQaWA7F3KkjAgZHi4f1uL1JKGWNxdQpHTW/sdGONBd0bzxUka/DJg==,
+      }
+    peerDependencies:
+      eslint: ^7.23.0 || ^8.0.0
+      typescript: ">=3.3.1"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      "@next/eslint-plugin-next": 12.3.1
+      "@rushstack/eslint-patch": 1.1.3
+      "@typescript-eslint/parser": 5.43.0_fqmqyeinda7panflsqpj5zauc4
+      eslint: 8.27.0
+      eslint-import-resolver-node: 0.3.6
+      eslint-import-resolver-typescript: 2.7.1_dcpv4nbdr5ks2h5677xdltrk6e
+      eslint-plugin-import: 2.26.0_ttnp75sbivpcvanbhjbkcsh3ly
+      eslint-plugin-jsx-a11y: 6.5.1_eslint@8.27.0
+      eslint-plugin-react: 7.31.8_eslint@8.27.0
+      eslint-plugin-react-hooks: 4.5.0_eslint@8.27.0
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
   /eslint-config-next/12.3.1_rmayb2veg2btbq6mbmnyivgasy:
     resolution:
       {
@@ -10952,10 +11243,10 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-config-next/13.1.1_rmayb2veg2btbq6mbmnyivgasy:
+  /eslint-config-next/13.1.2_rmayb2veg2btbq6mbmnyivgasy:
     resolution:
       {
-        integrity: sha512-/5S2XGWlGaiqrRhzpn51ux5JUSLwx8PVK2keLi5xk7QmhfYB8PqE6R6SlVw6hgnf/VexvUXSrlNJ/su00NhtHQ==,
+        integrity: sha512-zdRAQOr8v69ZwJRtBrGqAqm160ONqKxU/pV1FB1KlgfyqveGsLZmlQ7l31otwtw763901J7xdiTVkj2y3YxXZA==,
       }
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -10964,7 +11255,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      "@next/eslint-plugin-next": 13.1.1
+      "@next/eslint-plugin-next": 13.1.2
       "@rushstack/eslint-patch": 1.1.3
       "@typescript-eslint/parser": 5.43.0_rmayb2veg2btbq6mbmnyivgasy
       eslint: 8.27.0
@@ -11127,7 +11418,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      "@typescript-eslint/parser": 5.43.0_rmayb2veg2btbq6mbmnyivgasy
+      "@typescript-eslint/parser": 5.43.0_fqmqyeinda7panflsqpj5zauc4
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-typescript: 2.7.1_dcpv4nbdr5ks2h5677xdltrk6e
@@ -11215,7 +11506,7 @@ packages:
       "@typescript-eslint/parser":
         optional: true
     dependencies:
-      "@typescript-eslint/parser": 5.43.0_rmayb2veg2btbq6mbmnyivgasy
+      "@typescript-eslint/parser": 5.43.0_fqmqyeinda7panflsqpj5zauc4
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -13976,7 +14267,7 @@ packages:
       pretty-format: 29.2.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_cbe7ovvae6zqfnmtgctpgpys54
+      ts-node: 10.9.1_typescript@4.8.4
     transitivePeerDependencies:
       - supports-color
 
@@ -15801,7 +16092,7 @@ packages:
     engines: {node: ">=10"}
     hasBin: true
 
-  /mkdist/0.3.13_typescript@4.8.4:
+  /mkdist/0.3.13_typescript@4.9.4:
     resolution:
       {
         integrity: sha512-+eCPpkr8l2X630y5PIlkts2tzYEsb+aGIgXdrQv9ZGtWE2bLlD6kVIFfI6FJwFpjjw4dPPyorxQc6Uhm/oXlvg==,
@@ -15820,7 +16111,7 @@ packages:
       jiti: 1.14.0
       mri: 1.2.0
       pathe: 0.2.0
-      typescript: 4.8.4
+      typescript: 4.9.4
     dev: true
 
   /mlly/0.4.3:
@@ -18226,7 +18517,7 @@ packages:
       sprintf-js: 1.1.2
     dev: false
 
-  /rollup-plugin-dts/4.2.2_rpktusa5o437llwxsnrngyem64:
+  /rollup-plugin-dts/4.2.2_gguhhve2dns2gmxm3no5fryfqa:
     resolution:
       {
         integrity: sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==,
@@ -18238,7 +18529,7 @@ packages:
     dependencies:
       magic-string: 0.26.2
       rollup: 2.77.2
-      typescript: 4.8.4
+      typescript: 4.9.4
     optionalDependencies:
       "@babel/code-frame": 7.18.6
     dev: true
@@ -19687,7 +19978,7 @@ packages:
       }
     dev: true
 
-  /ts-jest/27.1.4_typescript@4.8.4:
+  /ts-jest/27.1.4_typescript@4.9.4:
     resolution:
       {
         integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==,
@@ -19718,9 +20009,43 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.7
-      typescript: 4.8.4
+      typescript: 4.9.4
       yargs-parser: 20.2.9
     dev: true
+
+  /ts-node/10.9.1_3v2cms72gsblw7jmali7btb3pu:
+    resolution:
+      {
+        integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==,
+      }
+    hasBin: true
+    peerDependencies:
+      "@swc/core": ">=1.2.50"
+      "@swc/wasm": ">=1.2.50"
+      "@types/node": "*"
+      typescript: ">=2.7"
+    peerDependenciesMeta:
+      "@swc/core":
+        optional: true
+      "@swc/wasm":
+        optional: true
+    dependencies:
+      "@cspotcode/source-map-support": 0.8.1
+      "@tsconfig/node10": 1.0.9
+      "@tsconfig/node12": 1.0.10
+      "@tsconfig/node14": 1.0.2
+      "@tsconfig/node16": 1.0.3
+      "@types/node": 18.11.9
+      acorn: 8.8.1
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: false
 
   /ts-node/10.9.1_cbe7ovvae6zqfnmtgctpgpys54:
     resolution:
@@ -19754,6 +20079,7 @@ packages:
       typescript: 4.8.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: false
 
   /ts-node/10.9.1_ieummqxttktzud32hpyrer46t4:
     resolution:
@@ -19820,6 +20146,38 @@ packages:
       typescript: 4.8.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  /ts-node/10.9.1_typescript@4.9.4:
+    resolution:
+      {
+        integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==,
+      }
+    hasBin: true
+    peerDependencies:
+      "@swc/core": ">=1.2.50"
+      "@swc/wasm": ">=1.2.50"
+      "@types/node": "*"
+      typescript: ">=2.7"
+    peerDependenciesMeta:
+      "@swc/core":
+        optional: true
+      "@swc/wasm":
+        optional: true
+    dependencies:
+      "@cspotcode/source-map-support": 0.8.1
+      "@tsconfig/node10": 1.0.9
+      "@tsconfig/node12": 1.0.10
+      "@tsconfig/node14": 1.0.2
+      "@tsconfig/node16": 1.0.3
+      acorn: 8.8.1
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
     dev: false
 
   /tsconfig-paths/3.14.1:
@@ -19884,6 +20242,18 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.8.4
+
+  /tsutils/3.21.0_typescript@4.9.4:
+    resolution:
+      {
+        integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==,
+      }
+    engines: {node: ">= 6"}
+    peerDependencies:
+      typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.9.4
 
   /tty-table/2.8.13:
     resolution:
@@ -20176,6 +20546,14 @@ packages:
     engines: {node: ">=4.2.0"}
     hasBin: true
 
+  /typescript/4.9.4:
+    resolution:
+      {
+        integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==,
+      }
+    engines: {node: ">=4.2.0"}
+    hasBin: true
+
   /uc.micro/1.0.6:
     resolution:
       {
@@ -20215,7 +20593,7 @@ packages:
       jiti: 1.14.0
       magic-string: 0.25.9
       mkdirp: 1.0.4
-      mkdist: 0.3.13_typescript@4.8.4
+      mkdist: 0.3.13_typescript@4.9.4
       mlly: 0.4.3
       mri: 1.2.0
       pathe: 0.2.0
@@ -20223,10 +20601,10 @@ packages:
       pretty-bytes: 5.6.0
       rimraf: 3.0.2
       rollup: 2.77.2
-      rollup-plugin-dts: 4.2.2_rpktusa5o437llwxsnrngyem64
+      rollup-plugin-dts: 4.2.2_gguhhve2dns2gmxm3no5fryfqa
       rollup-plugin-esbuild: 4.9.1_omx4rqyluc7ex52umwalnnwm7m
       scule: 0.2.1
-      typescript: 4.8.4
+      typescript: 4.9.4
       untyped: 0.3.0
     transitivePeerDependencies:
       - supports-color
@@ -20253,7 +20631,7 @@ packages:
       jiti: 1.14.0
       magic-string: 0.26.2
       mkdirp: 1.0.4
-      mkdist: 0.3.13_typescript@4.8.4
+      mkdist: 0.3.13_typescript@4.9.4
       mlly: 0.5.5
       mri: 1.2.0
       pathe: 0.3.2
@@ -20261,10 +20639,10 @@ packages:
       pretty-bytes: 6.0.0
       rimraf: 3.0.2
       rollup: 2.77.2
-      rollup-plugin-dts: 4.2.2_rpktusa5o437llwxsnrngyem64
+      rollup-plugin-dts: 4.2.2_gguhhve2dns2gmxm3no5fryfqa
       rollup-plugin-esbuild: 4.9.1_ecpsl2p7zl5puhr4xxlpah6uzm
       scule: 0.2.1
-      typescript: 4.8.4
+      typescript: 4.9.4
       untyped: 0.4.4
     transitivePeerDependencies:
       - supports-color
@@ -20291,7 +20669,7 @@ packages:
       jiti: 1.14.0
       magic-string: 0.26.2
       mkdirp: 1.0.4
-      mkdist: 0.3.13_typescript@4.8.4
+      mkdist: 0.3.13_typescript@4.9.4
       mlly: 0.5.5
       mri: 1.2.0
       pathe: 0.3.2
@@ -20299,10 +20677,10 @@ packages:
       pretty-bytes: 6.0.0
       rimraf: 3.0.2
       rollup: 2.77.2
-      rollup-plugin-dts: 4.2.2_rpktusa5o437llwxsnrngyem64
+      rollup-plugin-dts: 4.2.2_gguhhve2dns2gmxm3no5fryfqa
       rollup-plugin-esbuild: 4.9.1_omx4rqyluc7ex52umwalnnwm7m
       scule: 0.2.1
-      typescript: 4.8.4
+      typescript: 4.9.4
       untyped: 0.4.4_supports-color@8.1.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Closes: -

### What are the changes and their implications?

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html; Version 4.9 introduces the new `satisfies` operator.

## Feature Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [-] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [-] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
