### PR TITLE
remove error on project load

### DIFF
--- a/apps/toolkit-app/src/auth/components/LoginForm.tsx
+++ b/apps/toolkit-app/src/auth/components/LoginForm.tsx
@@ -40,8 +40,8 @@ export const LoginForm = (props: LoginFormProps) => {
         <LabeledTextField name="email" label="Email" placeholder="Email" />
         <LabeledTextField name="password" label="Password" placeholder="Password" type="password" />
         <div>
-          <Link href={Routes.ForgotPasswordPage()} passHref>
-            <a>Forgot your password?</a>
+          <Link href={Routes.ForgotPasswordPage()}>
+            Forgot your password?
           </Link>
         </div>
       </Form>

--- a/apps/toolkit-app/src/pages/index.tsx
+++ b/apps/toolkit-app/src/pages/index.tsx
@@ -37,11 +37,11 @@ const UserInfo = () => {
   } else {
     return (
       <>
-        <Link href={Routes.SignupPage()} className={styles.button}>
-          <strong>Sign Up</strong>
+        <Link href={Routes.SignupPage()}>
+          <strong className={styles.button}>Sign Up</strong>
         </Link>
-        <Link href={Routes.LoginPage()} className={styles.loginButton}>
-          <strong>Login</strong>
+        <Link href={Routes.LoginPage()}>
+          <strong className={styles.loginButton}>Login</strong>
         </Link>
       </>
     )


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: ?

### What are the changes and their implications?

Currently when a new Blitz project is crated with the recommended template and error page pops up on clicking login. This is because of the Next 13 behaviour with `Link` tag 
https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor

<img width="1147" alt="Screenshot 2023-01-31 at 17 27 51" src="https://user-images.githubusercontent.com/35943047/215842669-5b105446-71d4-41e6-afe7-99afdaaf0523.png">

This PR updates the `Link` behaviour to Next13

## Bug Checklist


- [ ] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
