### PR TITLE
fix: type error in reset-password.tsx

### DIFF
--- a/.changeset/chatty-fireants-leave.md
+++ b/.changeset/chatty-fireants-leave.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Fix a type error in reset password templates.

--- a/packages/generator/templates/app/src/pages/auth/reset-password.tsx
+++ b/packages/generator/templates/app/src/pages/auth/reset-password.tsx
@@ -7,6 +7,7 @@ import { BlitzPage, Routes } from "@blitzjs/next"
 import { useRouter } from "next/router"
 import { useMutation } from "@blitzjs/rpc"
 import Link from "next/link"
+import { assert } from "blitz"
 
 const ResetPasswordPage: BlitzPage = () => {
   const router = useRouter()
@@ -35,7 +36,8 @@ const ResetPasswordPage: BlitzPage = () => {
           }}
           onSubmit={async (values) => {
             try {
-              token && await resetPasswordMutation({ ...values, token })
+              assert(token, "token is required.")
+              await resetPasswordMutation({ ...values, token })
             } catch (error: any) {
               if (error.name === "ResetPasswordError") {
                 return {

--- a/packages/generator/templates/app/src/pages/auth/reset-password.tsx
+++ b/packages/generator/templates/app/src/pages/auth/reset-password.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react"
 import Layout from "src/core/layouts/Layout"
 import { LabeledTextField } from "src/core/components/LabeledTextField"
 import { Form, FORM_ERROR } from "src/core/components/Form"
@@ -36,7 +35,7 @@ const ResetPasswordPage: BlitzPage = () => {
           }}
           onSubmit={async (values) => {
             try {
-              await resetPasswordMutation({ ...values, token })
+              token && await resetPasswordMutation({ ...values, token })
             } catch (error: any) {
               if (error.name === "ResetPasswordError") {
                 return {


### PR DESCRIPTION
Follow up: #4051

### What are the changes and their implications?

Changes in #4051 cause an type error since `token` may be null.
This PR also removes unused an import statement.

## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [ ] ~~Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)~~
