### PR TITLE
fix: vulnerabilities in @blitz/auth

### DIFF
--- a/.changeset/strong-chicken-study.md
+++ b/.changeset/strong-chicken-study.md
@@ -2,4 +2,4 @@
 "@blitzjs/auth": patch
 ---
 
-Fixed vulnerabilities for passport and jsonwebtoken
+Fixed security vulnerabilities in passport-adapter by upgrading `passport` and `jsonwebtoken`

--- a/.changeset/strong-chicken-study.md
+++ b/.changeset/strong-chicken-study.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/auth": patch
+---
+
+Fixed vulnerabilities for passport and jsonwebtoken

--- a/packages/blitz-auth/package.json
+++ b/packages/blitz-auth/package.json
@@ -35,9 +35,9 @@
     "cookie-session": "2.0.0",
     "debug": "4.3.3",
     "http": "0.0.1-security",
-    "jsonwebtoken": "8.5.1",
+    "jsonwebtoken": "9.0.0",
     "nanoid": "3.2.0",
-    "passport": "0.5.2",
+    "passport": "0.6.0",
     "path": "0.12.7",
     "supports-color": "8.1.1",
     "url": "0.11.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -946,9 +946,9 @@ importers:
       cookie-session: 2.0.0
       debug: 4.3.3
       http: 0.0.1-security
-      jsonwebtoken: 8.5.1
+      jsonwebtoken: 9.0.0
       nanoid: 3.2.0
-      passport: 0.5.2
+      passport: 0.6.0
       path: 0.12.7
       react: 18.2.0
       react-dom: 18.2.0
@@ -969,9 +969,9 @@ importers:
       cookie-session: 2.0.0_supports-color@8.1.1
       debug: 4.3.3_supports-color@8.1.1
       http: 0.0.1-security
-      jsonwebtoken: 8.5.1
+      jsonwebtoken: 9.0.0
       nanoid: 3.2.0
-      passport: 0.5.2
+      passport: 0.6.0
       path: 0.12.7
       supports-color: 8.1.1
       url: 0.11.0
@@ -1640,7 +1640,7 @@ packages:
       "@babel/traverse": 7.18.2
       "@babel/types": 7.18.4
       convert-source-map: 1.8.0
-      debug: 4.3.4
+      debug: 4.3.3
       gensync: 1.0.0-beta.2
       json5: 2.2.1
       semver: 6.3.0
@@ -1665,7 +1665,7 @@ packages:
       "@babel/traverse": 7.18.2_supports-color@8.1.1
       "@babel/types": 7.18.4
       convert-source-map: 1.8.0
-      debug: 4.3.4_supports-color@8.1.1
+      debug: 4.3.3_supports-color@8.1.1
       gensync: 1.0.0-beta.2
       json5: 2.2.1
       semver: 6.3.0
@@ -1690,7 +1690,7 @@ packages:
       "@babel/traverse": 7.20.1
       "@babel/types": 7.20.2
       convert-source-map: 1.8.0
-      debug: 4.3.4
+      debug: 4.3.3
       gensync: 1.0.0-beta.2
       json5: 2.2.1
       semver: 6.3.0
@@ -4092,7 +4092,7 @@ packages:
       "@babel/helper-split-export-declaration": 7.16.7
       "@babel/parser": 7.18.4
       "@babel/types": 7.18.4
-      debug: 4.3.4
+      debug: 4.3.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -4112,7 +4112,7 @@ packages:
       "@babel/helper-split-export-declaration": 7.16.7
       "@babel/parser": 7.18.4
       "@babel/types": 7.18.4
-      debug: 4.3.4_supports-color@8.1.1
+      debug: 4.3.3_supports-color@8.1.1
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -4132,7 +4132,7 @@ packages:
       "@babel/helper-split-export-declaration": 7.18.6
       "@babel/parser": 7.20.3
       "@babel/types": 7.20.2
-      debug: 4.3.4
+      debug: 4.3.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -4511,7 +4511,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.3
       espree: 9.4.1
       globals: 13.15.0
       ignore: 5.2.0
@@ -4530,7 +4530,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4_supports-color@8.1.1
+      debug: 4.3.3_supports-color@8.1.1
       espree: 9.4.1
       globals: 13.15.0
       ignore: 5.2.0
@@ -4592,7 +4592,7 @@ packages:
     engines: {node: ">=10.10.0"}
     dependencies:
       "@humanwhocodes/object-schema": 1.2.1
-      debug: 4.3.4
+      debug: 4.3.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4605,7 +4605,7 @@ packages:
     engines: {node: ">=10.10.0"}
     dependencies:
       "@humanwhocodes/object-schema": 1.2.1
-      debug: 4.3.4_supports-color@8.1.1
+      debug: 4.3.3_supports-color@8.1.1
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5385,7 +5385,7 @@ packages:
       glob: 7.2.0
       is-reference: 1.2.1
       magic-string: 0.25.9
-      resolve: 1.22.0
+      resolve: 1.22.1
       rollup: 2.77.2
     dev: true
 
@@ -5415,7 +5415,7 @@ packages:
       deepmerge: 4.2.2
       is-builtin-module: 3.1.0
       is-module: 1.0.0
-      resolve: 1.22.0
+      resolve: 1.22.1
       rollup: 2.77.2
     dev: true
 
@@ -7089,7 +7089,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.3.8
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -7113,7 +7113,7 @@ packages:
       debug: 4.3.4_supports-color@8.1.1
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.3.8
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -7137,7 +7137,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.3.8
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -7160,7 +7160,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.3.8
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -7180,10 +7180,10 @@ packages:
     dependencies:
       "@typescript-eslint/types": 5.9.1
       "@typescript-eslint/visitor-keys": 5.9.1
-      debug: 4.3.4_supports-color@8.1.1
+      debug: 4.3.3_supports-color@8.1.1
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.3.8
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -7204,10 +7204,10 @@ packages:
     dependencies:
       "@typescript-eslint/types": 5.9.1
       "@typescript-eslint/visitor-keys": 5.9.1
-      debug: 4.3.4
+      debug: 4.3.3
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.3.8
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -7252,7 +7252,7 @@ packages:
       eslint: 8.27.0_supports-color@8.1.1
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.27.0
-      semver: 7.3.7
+      semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7275,7 +7275,7 @@ packages:
       eslint: 8.27.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.27.0
-      semver: 7.3.7
+      semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7297,7 +7297,7 @@ packages:
       "@typescript-eslint/typescript-estree": 5.42.1_typescript@4.8.4
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0
-      semver: 7.3.7
+      semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7481,7 +7481,7 @@ packages:
       }
     engines: {node: ">= 6.0.0"}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8310,7 +8310,10 @@ packages:
     dev: true
 
   /buffer-equal-constant-time/1.0.1:
-    resolution: {integrity: sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=}
+    resolution:
+      {
+        integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==,
+      }
     dev: false
 
   /buffer-from/1.1.2:
@@ -8935,7 +8938,10 @@ packages:
     dev: false
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution:
+      {
+        integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
+      }
 
   /consola/2.15.3:
     resolution:
@@ -9337,7 +9343,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: false
 
   /debug/4.3.3_supports-color@8.1.1:
     resolution:
@@ -11926,7 +11931,7 @@ packages:
     engines: {node: ">= 10.17.0"}
     hasBin: true
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.3
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -12974,7 +12979,7 @@ packages:
     dependencies:
       "@tootallnate/once": 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13004,7 +13009,7 @@ packages:
     engines: {node: ">= 6"}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13344,15 +13349,6 @@ packages:
       }
     dependencies:
       has: 1.0.3
-
-  /is-core-module/2.8.1:
-    resolution:
-      {
-        integrity: sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==,
-      }
-    dependencies:
-      has: 1.0.3
-    dev: true
 
   /is-data-descriptor/0.1.4:
     resolution:
@@ -13807,7 +13803,7 @@ packages:
       }
     engines: {node: ">=10"}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.3
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -14316,7 +14312,7 @@ packages:
       jest-util: 29.2.1
       natural-compare: 1.4.0
       pretty-format: 29.2.1
-      semver: 7.3.7
+      semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
 
@@ -14825,23 +14821,17 @@ packages:
     optionalDependencies:
       graceful-fs: 4.2.10
 
-  /jsonwebtoken/8.5.1:
+  /jsonwebtoken/9.0.0:
     resolution:
       {
-        integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==,
+        integrity: sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==,
       }
-    engines: {node: ">=4", npm: ">=1.4.28"}
+    engines: {node: ">=12", npm: ">=6"}
     dependencies:
       jws: 3.2.2
-      lodash.includes: 4.3.0
-      lodash.isboolean: 3.0.3
-      lodash.isinteger: 4.0.4
-      lodash.isnumber: 3.0.3
-      lodash.isplainobject: 4.0.6
-      lodash.isstring: 4.0.1
-      lodash.once: 4.1.1
-      ms: 2.1.2
-      semver: 5.7.1
+      lodash: 4.17.21
+      ms: 2.1.3
+      semver: 7.3.8
     dev: false
 
   /jstransformer/1.0.0:
@@ -15172,48 +15162,6 @@ packages:
     dependencies:
       p-locate: 5.0.0
 
-  /lodash.includes/4.3.0:
-    resolution:
-      {
-        integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==,
-      }
-    dev: false
-
-  /lodash.isboolean/3.0.3:
-    resolution:
-      {
-        integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==,
-      }
-    dev: false
-
-  /lodash.isinteger/4.0.4:
-    resolution:
-      {
-        integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==,
-      }
-    dev: false
-
-  /lodash.isnumber/3.0.3:
-    resolution:
-      {
-        integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==,
-      }
-    dev: false
-
-  /lodash.isplainobject/4.0.6:
-    resolution:
-      {
-        integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==,
-      }
-    dev: false
-
-  /lodash.isstring/4.0.1:
-    resolution:
-      {
-        integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==,
-      }
-    dev: false
-
   /lodash.memoize/4.1.2:
     resolution:
       {
@@ -15226,13 +15174,6 @@ packages:
       {
         integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
       }
-
-  /lodash.once/4.1.1:
-    resolution:
-      {
-        integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==,
-      }
-    dev: false
 
   /lodash.startcase/4.4.0:
     resolution:
@@ -16905,15 +16846,16 @@ packages:
       pause: 0.0.1
     dev: false
 
-  /passport/0.5.2:
+  /passport/0.6.0:
     resolution:
       {
-        integrity: sha512-w9n/Ot5I7orGD4y+7V3EFJCQEznE5RxHamUxcqLT2QoJY0f2JdN8GyHonYFvN0Vz+L6lUJfVhrk2aZz2LbuREw==,
+        integrity: sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==,
       }
     engines: {node: ">= 0.4.0"}
     dependencies:
       passport-strategy: 1.0.0
       pause: 0.0.1
+      utils-merge: 1.0.1
     dev: false
 
   /patch-console/1.0.0:
@@ -17031,7 +16973,10 @@ packages:
       }
 
   /pause/0.0.1:
-    resolution: {integrity: sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=}
+    resolution:
+      {
+        integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==,
+      }
     dev: false
 
   /pend/1.2.0:
@@ -18119,7 +18064,7 @@ packages:
       }
     hasBin: true
     dependencies:
-      is-core-module: 2.8.1
+      is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -18254,7 +18199,7 @@ packages:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
       "@rollup/pluginutils": 4.2.1
-      debug: 4.3.4
+      debug: 4.3.3
       es-module-lexer: 0.9.3
       esbuild: 0.14.51
       joycon: 3.1.1
@@ -18275,7 +18220,7 @@ packages:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
       "@rollup/pluginutils": 4.2.1
-      debug: 4.3.4_supports-color@8.1.1
+      debug: 4.3.3_supports-color@8.1.1
       es-module-lexer: 0.9.3
       esbuild: 0.14.51
       joycon: 3.1.1
@@ -18493,7 +18438,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: false
 
   /send/0.17.2:
     resolution:


### PR DESCRIPTION
Closes: ?

### What are the changes and their implications?

I just bumped the versions for `passport` and `jsonwebtoken` to fix the existing vulnerability `CVE-2022-23529`

## Bug Checklist

- [X] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
