### PR TITLE
Fix LabeledTextField update on next-ui and chakra-ui recipes

### DIFF
--- a/recipes/chakra-ui/index.ts
+++ b/recipes/chakra-ui/index.ts
@@ -139,7 +139,7 @@ export default RecipeBuilder()
     stepId: "updateLabeledTextField",
     stepName: "Update the `LabeledTextField` with Chakra UI's `Input` component",
     explanation: `The LabeledTextField component uses Chakra UI's input component`,
-    singleFileSearch: "app/core/components/LabeledTextField.tsx",
+    singleFileSearch: "src/core/components/LabeledTextField.tsx",
     transform(program) {
       // Add ComponentPropsWithoutRef import
       program.find(j.ImportDeclaration, {source: {value: "react"}}).forEach((path) => {

--- a/recipes/next-ui/index.ts
+++ b/recipes/next-ui/index.ts
@@ -111,7 +111,7 @@ export default RecipeBuilder()
     stepId: "updateLabeledTextField",
     stepName: "Update the `LabeledTextField` with Next UI's `Input` component",
     explanation: `The LabeledTextField component uses Next UI's input component`,
-    singleFileSearch: "app/core/components/LabeledTextField.tsx",
+    singleFileSearch: "src/core/components/LabeledTextField.tsx",
     transform(program) {
       // Add ComponentPropsWithoutRef import
       program.find(j.ImportDeclaration, {source: {value: "react"}}).forEach((path) => {


### PR DESCRIPTION
Closes: #4105 

### What are the changes and their implications?

`next-ui` and `chakra-ui` recipes are broken, they hang forever at the last step. This fixes it.

## Bug Checklist

- [N/A] Changeset added (run `pnpm changeset` in the root directory)
- [N/A] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [N/A] Changeset added (run `pnpm changeset` in the root directory)
- [N/A] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [N/A] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
