### PR TITLE
fix (minor): Replace console.log with debug

### DIFF
--- a/packages/blitz/src/cli/utils/routes-manifest.ts
+++ b/packages/blitz/src/cli/utils/routes-manifest.ts
@@ -8,6 +8,7 @@ import resolveFrom from "resolve-from"
 import Watchpack from "watchpack"
 import {isInternalBlitzMonorepoDevelopment} from "./helpers"
 import {findNodeModulesRoot} from "./find-node-modules"
+const debug = require("debug")("blitz")
 export const CONFIG_FILE = ".blitz.config.compiled.js"
 export const NEXT_CONFIG_FILE = "next.config.js"
 export const PHASE_PRODUCTION_SERVER = "phase-production-server"
@@ -160,7 +161,7 @@ export const loadConfig = (pagesDir: string) => {
     // eslint-disable-next-line no-eval -- block webpack from following this module path
     userConfigModule = eval("require")(path)
   } catch {
-    console.log("Did not find custom config file")
+    debug("Did not find custom config file")
     // In case user does not have custom config
     userConfigModule = {}
   }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

### What are the changes and their implications?

Replace `console.log` with `debug` when custom `next.config.js` is not being used
