### PR TITLE
fix: enormous memory consumption of the dev server

### DIFF
--- a/.changeset/good-oranges-pretend.md
+++ b/.changeset/good-oranges-pretend.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/rpc": patch
+---
+
+Fixes enormous memory consumption of the dev server

--- a/.changeset/good-oranges-pretend.md
+++ b/.changeset/good-oranges-pretend.md
@@ -19,7 +19,7 @@ const config = {
 }
 ```
 
-When `resolversDynamicImport` is set to `true`, the default import strategy will be "import" instead of "require".
+When `resolversDynamicImport` is set to `true`, the import strategy will be "import" instead of "require".
 
 ### On Vercel
 

--- a/.changeset/good-oranges-pretend.md
+++ b/.changeset/good-oranges-pretend.md
@@ -2,4 +2,25 @@
 "@blitzjs/rpc": patch
 ---
 
-Fixes enormous memory consumption of the dev server
+Fixes enormous memory consumption of the dev server by changing the default import strategy to "require" instead of "import" which in webpack causes multiple chunks to be created for each import.
+
+## Blitz Configuration
+
+To configure this behaviour, you can add the following to your next.config.js:
+
+```js
+/**
+ * @type {import('@blitzjs/next').BlitzConfig}
+ **/
+const config = {
+  blitz: {
+    resolversDynamicImport: true,
+  },
+}
+```
+
+When `resolversDynamicImport` is set to `true`, the default import strategy will be "import" instead of "require".
+
+### On Vercel
+
+If you are using Vercel, `resolversDynamicImport` will be set to `true` by default, since it is better for the separate chunks to be create for serverless lambdas.

--- a/apps/toolkit-app/next.config.js
+++ b/apps/toolkit-app/next.config.js
@@ -6,6 +6,9 @@ const { withBlitz } = require("@blitzjs/next")
  **/
 const config = {
   reactStrictMode: true,
+  blitz: {
+    resolversDynamicImport: true,
+  },
 }
 
 module.exports = withBlitz(withNextAuthAdapter(config))

--- a/packages/blitz-next/src/index-server.ts
+++ b/packages/blitz-next/src/index-server.ts
@@ -230,6 +230,7 @@ export const setupBlitzServer = <TPlugins extends readonly BlitzServerPlugin<obj
 export interface BlitzConfig extends NextConfig {
   blitz?: {
     resolverPath?: ResolverPathOptions
+    resolversDynamicImport: boolean
     includeRPCFolders?: string[]
     customServer?: {
       hotReload?: boolean

--- a/packages/blitz-next/src/index-server.ts
+++ b/packages/blitz-next/src/index-server.ts
@@ -230,7 +230,7 @@ export const setupBlitzServer = <TPlugins extends readonly BlitzServerPlugin<obj
 export interface BlitzConfig extends NextConfig {
   blitz?: {
     resolverPath?: ResolverPathOptions
-    resolversDynamicImport: boolean
+    resolversDynamicImport?: boolean
     includeRPCFolders?: string[]
     customServer?: {
       hotReload?: boolean
@@ -262,6 +262,8 @@ export function withBlitz(nextConfig: BlitzConfig = {}): NextConfig {
         webpackConfig: config,
         webpackRuleOptions: {
           resolverPath: nextConfig.blitz?.resolverPath,
+          resolversDynamicImport:
+            nextConfig.blitz?.resolversDynamicImport ?? Boolean(process.env.VERCEL),
           includeRPCFolders: nextConfig.blitz?.includeRPCFolders,
         },
       })

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -3,6 +3,7 @@ import {NextApiRequest, NextApiResponse} from "next"
 import {deserialize, parse, serialize as superjsonSerialize} from "superjson"
 import {resolve} from "path"
 import chalk from "chalk"
+import {LoaderOptions} from "./server/loader/utils/loader-utils"
 
 // TODO - optimize end user server bundles by not exporting all client stuff here
 export * from "./index-browser"
@@ -60,16 +61,11 @@ const loaderClient = resolve(dir, "./loader-client.cjs")
 const loaderServer = resolve(dir, "./loader-server.cjs")
 const loaderServerResolvers = resolve(dir, "./loader-server-resolvers.cjs")
 
-interface WebpackRuleOptions {
-  resolverPath: ResolverPathOptions | undefined
-  includeRPCFolders: string[] | undefined
-}
-
 interface WebpackRule {
   test: RegExp
   use: Array<{
     loader: string
-    options: WebpackRuleOptions
+    options: LoaderOptions
   }>
 }
 
@@ -84,7 +80,7 @@ export interface InstallWebpackConfigOptions {
       rules: WebpackRule[]
     }
   }
-  webpackRuleOptions: WebpackRuleOptions
+  webpackRuleOptions: LoaderOptions
 }
 
 export function installWebpackConfig({

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -165,6 +165,7 @@ export function rpcHandler(config: RpcConfig) {
     const routePath = "/" + relativeRoutePath
 
     const log = baseLogger().getSubLogger({
+      name: "blitz-rpc",
       prefix: [routePath.replace(/(\/api\/rpc)?\//, "") + "()"],
     })
     const customChalk = new chalk.Instance({
@@ -220,7 +221,7 @@ export function rpcHandler(config: RpcConfig) {
         const startTime = Date.now()
         const result = await resolver(data, (res as any).blitzCtx)
         const resolverDuration = Date.now() - startTime
-        log.debug(customChalk.dim("Result:"), result ? result : JSON.stringify(result))
+        log.info(customChalk.dim("Result:"), result ? result : JSON.stringify(result))
 
         const serializerStartTime = Date.now()
         const serializedResult = superjsonSerialize(result)
@@ -242,7 +243,7 @@ export function rpcHandler(config: RpcConfig) {
         const serializerDuration = Date.now() - serializerStartTime
         const duration = Date.now() - startTime
 
-        log.info(
+        log.debug(
           customChalk.dim(
             `Finished: resolver:${prettyMs(resolverDuration)} serializer:${prettyMs(
               serializerDuration,

--- a/packages/blitz-rpc/src/server/loader/server/loader-server.ts
+++ b/packages/blitz-rpc/src/server/loader/server/loader-server.ts
@@ -64,6 +64,11 @@ export async function transformBlitzRpcServer(
       extraRpcBasePaths: options?.includeRPCFolders,
     })
 
+    if (options && !options?.resolversDynamicImport) {
+      //set resolverDynamicImport to default be true if on vercel
+      options.resolversDynamicImport = process.env.VERCEL ? true : false
+    }
+
     const importStrategy = options?.resolversDynamicImport ? "import" : "require"
 
     code += `__internal_addBlitzRpcResolver('${routePath}',() => ${importStrategy}('${slash(

--- a/packages/blitz-rpc/src/server/loader/server/loader-server.ts
+++ b/packages/blitz-rpc/src/server/loader/server/loader-server.ts
@@ -64,12 +64,11 @@ export async function transformBlitzRpcServer(
       extraRpcBasePaths: options?.includeRPCFolders,
     })
 
-    if (options && !options?.resolversDynamicImport) {
-      //set resolverDynamicImport to default be true if on vercel
-      options.resolversDynamicImport = process.env.VERCEL ? true : false
-    }
-
-    const importStrategy = options?.resolversDynamicImport ? "import" : "require"
+    const importStrategy = process.env.VERCEL
+      ? "import"
+      : options?.resolversDynamicImport
+      ? "import"
+      : "require"
 
     code += `__internal_addBlitzRpcResolver('${routePath}',() => ${importStrategy}('${slash(
       resolverFilePath,

--- a/packages/blitz-rpc/src/server/loader/server/loader-server.ts
+++ b/packages/blitz-rpc/src/server/loader/server/loader-server.ts
@@ -64,12 +64,12 @@ export async function transformBlitzRpcServer(
       extraRpcBasePaths: options?.includeRPCFolders,
     })
 
-    code += `__internal_addBlitzRpcResolver('${routePath}',() => import('${slash(
+    code += `__internal_addBlitzRpcResolver('${routePath}',() => require('${slash(
       resolverFilePath,
     )}'));`
     code += "\n"
   }
-  // console.log("NEW CODE", code)
+
   return code
 }
 

--- a/packages/blitz-rpc/src/server/loader/server/loader-server.ts
+++ b/packages/blitz-rpc/src/server/loader/server/loader-server.ts
@@ -64,7 +64,9 @@ export async function transformBlitzRpcServer(
       extraRpcBasePaths: options?.includeRPCFolders,
     })
 
-    code += `__internal_addBlitzRpcResolver('${routePath}',() => require('${slash(
+    const importStrategy = options?.resolversDynamicImport ? "import" : "require"
+
+    code += `__internal_addBlitzRpcResolver('${routePath}',() => ${importStrategy}('${slash(
       resolverFilePath,
     )}'));`
     code += "\n"

--- a/packages/blitz-rpc/src/server/loader/server/loader-server.ts
+++ b/packages/blitz-rpc/src/server/loader/server/loader-server.ts
@@ -64,11 +64,7 @@ export async function transformBlitzRpcServer(
       extraRpcBasePaths: options?.includeRPCFolders,
     })
 
-    const importStrategy = process.env.VERCEL
-      ? "import"
-      : options?.resolversDynamicImport
-      ? "import"
-      : "require"
+    const importStrategy = options?.resolversDynamicImport ? "import" : "require"
 
     code += `__internal_addBlitzRpcResolver('${routePath}',() => ${importStrategy}('${slash(
       resolverFilePath,

--- a/packages/blitz-rpc/src/server/loader/utils/loader-utils.ts
+++ b/packages/blitz-rpc/src/server/loader/utils/loader-utils.ts
@@ -3,7 +3,7 @@ import {posix, sep, win32, join, normalize} from "path"
 import {ResolverPathOptions} from "../../../index-server"
 
 export interface LoaderOptions {
-  resolverPath: ResolverPathOptions
+  resolverPath?: ResolverPathOptions
   includeRPCFolders?: string[]
   resolversDynamicImport?: boolean
 }

--- a/packages/blitz-rpc/src/server/loader/utils/loader-utils.ts
+++ b/packages/blitz-rpc/src/server/loader/utils/loader-utils.ts
@@ -5,6 +5,7 @@ import {ResolverPathOptions} from "../../../index-server"
 export interface LoaderOptions {
   resolverPath: ResolverPathOptions
   includeRPCFolders?: string[]
+  resolversDynamicImport?: boolean
 }
 
 export interface Loader {

--- a/packages/blitz/src/logging.ts
+++ b/packages/blitz/src/logging.ts
@@ -22,15 +22,11 @@ export const baseLogger = (options: BlitzLoggerSettings = {}): Logger<ILogObj> =
 
 export const BlitzLogger = (settings: BlitzLoggerSettings = {}) => {
   const baseLogger = new Logger({
-    minLevel: 3,
-    type: "pretty",
-    prettyLogTemplate:
-      process.env.NODE_ENV === "production"
-        ? "{{yyyy}}-{{mm}}-{{dd}} {{hh}}:{{MM}}:{{ss}}:{{ms}}"
-        : "{{hh}}:{{MM}}:{{ss}}:{{ms}}",
     prettyLogTimeZone: process.env.NODE_ENV === "production" ? "UTC" : "local",
     maskValuesOfKeys: ["password", "passwordConfirmation", "currentPassword"],
-    // exposeErrorCodeFrame: process.env.NODE_ENV !== "production",
+    type: process.env.NODE_ENV === "production" ? "json" : "pretty",
+    prettyLogTemplate:
+      "{{yyyy}}.{{mm}}.{{dd}} {{hh}}:{{MM}}:{{ss}}:{{ms}}\t{{logLevelName}}\t[{{filePathWithLine}}{{name}}]\t",
     ...settings,
   })
 


### PR DESCRIPTION
There was not issue for that, I've decided to fix the problem right away

### Context

We have a blitz v2 app with ~290 queries and mutations. 

Each query/mutation indirectly imports up to 900 source code files. 
We use dependency injection and as a result each endpoint imports the whole backend code.

We use next@12 and have SWC enabled.

Our dev server used to take up to 18GB or RAM, which is enormous amount of memory for parsing and merging together 900 source code files + compiling the font-end.

The memory was allocated for short period of time, and then reduced to 6-8GB.

It was killing 2020 MacBook Pro with 16BG of Ram.

![image](https://github.com/blitz-js/blitz/assets/11561585/0bde7ce7-4fd6-41a1-93de-4b00ff94dc85)


### What are the changes and their implications?

I dig into the problem for quite a while and I found out that the issue was basically using dynamic imports for importing routes code.

Dynamic imports in Webpack automatically creates a separate chunk. 

Separate chunk means a separate isolated compilation of code. Chunking backend code does not make any sense unless it's run as lambda function.

With dynamic imports and the size of our app, Webpack was bundling the same code ~290 times instead of doing it once. 

That created huge memory peaks in quite random moments, eg. a 30 seconds after `pages/api/rpc/[[...blitz]].ts` finished to compile.

To fix that I simply changed the dynamic import into `require` call, which do not create separate chunk in Webpack.

We are using the patched version  for more than a week now and everything works fine. Compilation is faster, there are no more memory peaks and most importantly we reduced the team frustration. 

Preparing a reproducible demo that showcase the memory usage might not be easy without real production code, but at least I can prove that the chunks are created for each query/mutation file when using dynamic imports. Let me know if that's needed.


## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [ ] ~~Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)~~
  - I believe existing tests should cover this change, cos it only changes how to code is bundled without affecting runtime
