### PR TITLE
fix: blitz logging formatting

### DIFF
--- a/.changeset/tame-rocks-unite.md
+++ b/.changeset/tame-rocks-unite.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Fix log formatting to not show the path of blitz rpc

--- a/packages/blitz/src/logging.ts
+++ b/packages/blitz/src/logging.ts
@@ -26,7 +26,7 @@ export const BlitzLogger = (settings: BlitzLoggerSettings = {}) => {
     maskValuesOfKeys: ["password", "passwordConfirmation", "currentPassword"],
     type: process.env.NODE_ENV === "production" ? "json" : "pretty",
     prettyLogTemplate:
-      "{{yyyy}}.{{mm}}.{{dd}} {{hh}}:{{MM}}:{{ss}}:{{ms}}\t{{logLevelName}}\t{{name}}]\t",
+      "{{yyyy}}.{{mm}}.{{dd}} {{hh}}:{{MM}}:{{ss}}:{{ms}}\t{{logLevelName}}\t[{{name}}]\t",
     ...settings,
   })
 

--- a/packages/blitz/src/logging.ts
+++ b/packages/blitz/src/logging.ts
@@ -26,7 +26,7 @@ export const BlitzLogger = (settings: BlitzLoggerSettings = {}) => {
     maskValuesOfKeys: ["password", "passwordConfirmation", "currentPassword"],
     type: process.env.NODE_ENV === "production" ? "json" : "pretty",
     prettyLogTemplate:
-      "{{yyyy}}.{{mm}}.{{dd}} {{hh}}:{{MM}}:{{ss}}:{{ms}}\t{{logLevelName}}\t[{{filePathWithLine}}{{name}}]\t",
+      "{{yyyy}}.{{mm}}.{{dd}} {{hh}}:{{MM}}:{{ss}}:{{ms}}\t{{logLevelName}}\t{{name}}]\t",
     ...settings,
   })
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: ?

### What are the changes and their implications?

Stop showing the blitz rpc file path from the log results by default.

## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)