### PR TITLE
Configure the Verbosity of Blitz RPC Logging

### DIFF
--- a/.changeset/sixty-rockets-count.md
+++ b/.changeset/sixty-rockets-count.md
@@ -1,0 +1,68 @@
+---
+"@blitzjs/rpc": patch
+"blitz": patch
+---
+
+### Now we can configure this in the following way,
+
+In your `[[...blitz]].ts` api file you can see the following settings
+```ts
+logging?: {
+  /**
+   * allowList Represents the list of routes for which logging should be enabled
+   * If whiteList is defined then only those routes will be logged
+   */
+  allowList?: string[]
+  /**
+   * blackList Represents the list of routes for which logging should be disabled
+   * If blackList is defined then all routes except those will be logged
+   */
+  blackList?: string[]
+  /**
+   * verbose Represents the flag to enable/disable logging
+   * If verbose is true then Blitz RPC will log the input and output of each resolver
+   */
+  verbose?: boolean
+  /**
+   * disablelevel Represents the flag to enable/disable logging for a particular level
+   */
+  disablelevel?: "debug" | "info"
+}
+```
+```ts
+import { rpcHandler } from "@blitzjs/rpc"
+import { api } from "src/blitz-server"
+
+export default api(
+  rpcHandler({
+    onError: console.log,
+    formatError: (error) => {
+      error.message = `FormatError handler: ${error.message}`
+      return error
+    },
+   logging: {
+...
+}
+  })
+)
+```
+
+Example:
+```ts
+export default api(
+  rpcHandler({
+    onError: console.log,
+    formatError: (error) => {
+      error.message = `FormatError handler: ${error.message}`
+      return error
+    },
+    logging: {
+      verbose: true,
+      blockList: ["getCurrentUser", ...], //just write the resolver name [which is the resolver file name]
+    },
+  })
+)
+```
+
+This is enable verbose blitz rpc logging for all resolvers except the resolvers `getCurrentUser` and others mentioned in the `blackList`
+

--- a/.changeset/sixty-rockets-count.md
+++ b/.changeset/sixty-rockets-count.md
@@ -14,10 +14,10 @@ logging?: {
    */
   allowList?: string[]
   /**
-   * blackList Represents the list of routes for which logging should be disabled
-   * If blackList is defined then all routes except those will be logged
+   * blockList Represents the list of routes for which logging should be disabled
+   * If blockList is defined then all routes except those will be logged
    */
-  blackList?: string[]
+  blockList?: string[]
   /**
    * verbose Represents the flag to enable/disable logging
    * If verbose is true then Blitz RPC will log the input and output of each resolver

--- a/.changeset/sixty-rockets-count.md
+++ b/.changeset/sixty-rockets-count.md
@@ -3,7 +3,7 @@
 "blitz": patch
 ---
 
-### Now we can configure this in the following way,
+### Now we can configure Blitz RPC in the following way,
 
 In your `[[...blitz]].ts` api file you can see the following settings
 ```ts
@@ -64,5 +64,5 @@ export default api(
 )
 ```
 
-This is enable verbose blitz rpc logging for all resolvers except the resolvers `getCurrentUser` and others mentioned in the `blackList`
+This is enable verbose blitz rpc logging for all resolvers except the resolvers `getCurrentUser` and others mentioned in the `blockList`
 

--- a/apps/toolkit-app/src/pages/api/rpc/[[...blitz]].ts
+++ b/apps/toolkit-app/src/pages/api/rpc/[[...blitz]].ts
@@ -8,5 +8,9 @@ export default api(
       error.message = `FormatError handler: ${error.message}`
       return error
     },
+    logging: {
+      verbose: true,
+      blackList: ["/getCurrentUser"],
+    },
   })
 )

--- a/apps/toolkit-app/src/pages/api/rpc/[[...blitz]].ts
+++ b/apps/toolkit-app/src/pages/api/rpc/[[...blitz]].ts
@@ -10,7 +10,7 @@ export default api(
     },
     // logging: {
     //   verbose: true,
-    //   blackList: ["/getCurrentUser"],
+    //   blockList: ["/getCurrentUser"],
     // },
   })
 )

--- a/apps/toolkit-app/src/pages/api/rpc/[[...blitz]].ts
+++ b/apps/toolkit-app/src/pages/api/rpc/[[...blitz]].ts
@@ -8,9 +8,9 @@ export default api(
       error.message = `FormatError handler: ${error.message}`
       return error
     },
-    logging: {
-      verbose: true,
-      blackList: ["/getCurrentUser"],
-    },
+    // logging: {
+    //   verbose: true,
+    //   blackList: ["/getCurrentUser"],
+    // },
   })
 )

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -170,6 +170,9 @@ interface RpcConfig {
 }
 
 function isBlitzRPCVerbose(routePath: string, config: RpcConfig, level: string) {
+  if (!config.logging) {
+    return true
+  }
   const isLevelDisabled = config.logging?.disablelevel === level
   if (config.logging?.verbose) {
     // If whiteList array is defined then allow only those routes in whiteList
@@ -193,14 +196,7 @@ function isBlitzRPCVerbose(routePath: string, config: RpcConfig, level: string) 
   return false
 }
 
-export function rpcHandler(
-  config: RpcConfig = {
-    // keeping this for backwards compatibility
-    logging: {
-      verbose: true,
-    },
-  },
-) {
+export function rpcHandler(config: RpcConfig) {
   return async function handleRpcRequest(req: NextApiRequest, res: NextApiResponse, ctx: Ctx) {
     const resolverMap = await getResolverMap()
     assert(resolverMap, "No query or mutation resolvers found")

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -148,15 +148,15 @@ interface RpcConfig {
   formatError?: (error: Error) => Error
   logging?: {
     /**
-     * WhiteList Represents the list of routes for which logging should be enabled
-     * If whiteList is defined then only those routes will be logged
+     * allowList Represents the list of routes for which logging should be enabled
+     * If allowList is defined then only those routes will be logged
      */
-    whiteList?: string[]
+    allowList?: string[]
     /**
-     * BlackList Represents the list of routes for which logging should be disabled
-     * If blackList is defined then all routes except those will be logged
+     * blockList Represents the list of routes for which logging should be disabled
+     * If blockList is defined then all routes except those will be logged
      */
-    blackList?: string[]
+    blockList?: string[]
     /**
      * verbose Represents the flag to enable/disable logging
      * If verbose is true then Blitz RPC will log the input and output of each resolver
@@ -176,20 +176,20 @@ function isBlitzRPCVerbose(resolverName: string, config: RpcConfig, level: strin
   }
   const isLevelDisabled = config.logging?.disablelevel === level
   if (config.logging?.verbose) {
-    // If whiteList array is defined then allow only those routes in whiteList
-    if (config.logging?.whiteList) {
-      if (config.logging?.whiteList?.includes(resolverName) && !isLevelDisabled) {
+    // If allowList array is defined then allow only those routes in allowList
+    if (config.logging?.allowList) {
+      if (config.logging?.allowList?.includes(resolverName) && !isLevelDisabled) {
         return true
       }
     }
-    // If blackList array is defined then allow all routes except those in blackList
-    if (config.logging?.blackList) {
-      if (!config.logging?.blackList?.includes(resolverName) && !isLevelDisabled) {
+    // If blockList array is defined then allow all routes except those in blockList
+    if (config.logging?.blockList) {
+      if (!config.logging?.blockList?.includes(resolverName) && !isLevelDisabled) {
         return true
       }
     }
-    // if both whiteList and blackList are not defined, then allow all routes
-    if (!config.logging?.whiteList && !config.logging?.blackList && !isLevelDisabled) {
+    // if both allowList and blockList are not defined, then allow all routes
+    if (!config.logging?.allowList && !config.logging?.blockList && !isLevelDisabled) {
       return true
     }
     return false

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -174,6 +174,10 @@ function isBlitzRPCVerbose(resolverName: string, config: RpcConfig, level: strin
   if (!config.logging) {
     return true
   }
+  //if logging exists and verbose is not defined then default to true
+  if (config.logging && !config.logging.verbose) {
+    return true
+  }
   const isLevelDisabled = config.logging?.disablelevel === level
   if (config.logging?.verbose) {
     // If allowList array is defined then allow only those routes in allowList
@@ -271,7 +275,7 @@ export function rpcHandler(config: RpcConfig) {
         const resolverDuration = Date.now() - startTime
 
         if (isBlitzRPCVerbose(resolverName, config, "info")) {
-          log.info(customChalk.dim("Result:"), result ? result : JSON.stringify(result))
+          log.debug(customChalk.dim("Result:"), result ? result : JSON.stringify(result))
         }
 
         const serializerStartTime = Date.now()

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -175,7 +175,7 @@ function isBlitzRPCVerbose(resolverName: string, config: RpcConfig, level: strin
     return true
   }
   //if logging exists and verbose is not defined then default to true
-  if (config.logging && !config.logging.verbose) {
+  if (config.logging && !("verbose" in config.logging)) {
     return true
   }
   const isLevelDisabled = config.logging?.disablelevel === level

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -170,6 +170,7 @@ interface RpcConfig {
 }
 
 function isBlitzRPCVerbose(resolverName: string, config: RpcConfig, level: string) {
+  // blitz rpc is by default verbose - to keep current behaviour
   if (!config.logging) {
     return true
   }

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -274,7 +274,7 @@ export function rpcHandler(config: RpcConfig) {
         const result = await resolver(data, (res as any).blitzCtx)
         const resolverDuration = Date.now() - startTime
 
-        if (isBlitzRPCVerbose(resolverName, config, "info")) {
+        if (isBlitzRPCVerbose(resolverName, config, "debug")) {
           log.debug(customChalk.dim("Result:"), result ? result : JSON.stringify(result))
         }
 
@@ -301,8 +301,8 @@ export function rpcHandler(config: RpcConfig) {
 
         const serializerDuration = Date.now() - serializerStartTime
         const duration = Date.now() - startTime
-        if (isBlitzRPCVerbose(resolverName, config, "debug")) {
-          log.debug(
+        if (isBlitzRPCVerbose(resolverName, config, "info")) {
+          log.info(
             customChalk.dim(
               `Finished: resolver:${prettyMs(resolverDuration)} serializer:${prettyMs(
                 serializerDuration,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: ?

### What are the changes and their implications?

This PR allows the user to control the verbosity of Blitz RPC Logging.

Previously we printed the `input`, `output` of the resolver by default and understandably with the increasing size of resolver outputs then generates a lot of clutter while debugging or during production.

### Now we can configure Blitz RPC in the following way,

In your `[[...blitz]].ts` api file you can see the following settings
```ts
logging?: {
  /**
   * allowList Represents the list of routes for which logging should be enabled
   * If whiteList is defined then only those routes will be logged
   */
  allowList?: string[]
  /**
   * blockList Represents the list of routes for which logging should be disabled
   * If blockList is defined then all routes except those will be logged
   */
  blockList?: string[]
  /**
   * verbose Represents the flag to enable/disable logging
   * If verbose is true then Blitz RPC will log the input and output of each resolver
   */
  verbose?: boolean
  /**
   * disablelevel Represents the flag to enable/disable logging for a particular level
   */
  disablelevel?: "debug" | "info"
}
```
```ts
import { rpcHandler } from "@blitzjs/rpc"
import { api } from "src/blitz-server"

export default api(
  rpcHandler({
    onError: console.log,
    formatError: (error) => {
      error.message = `FormatError handler: ${error.message}`
      return error
    },
   logging: {
...
}
  })
)
```

Example:
```ts
export default api(
  rpcHandler({
    onError: console.log,
    formatError: (error) => {
      error.message = `FormatError handler: ${error.message}`
      return error
    },
    logging: {
      verbose: true,
      blockList: ["getCurrentUser", ...], //just write the resolver name [which is the resolver file name]
    },
  })
)
```

This is enable verbose blitz rpc logging for all resolvers except the resolvers `getCurrentUser` and others mentioned in the `blockList`

## Feature Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
