### PR TITLE
Downgrade `tslog` dependency from `4.8.2` to `4.7.4`

### DIFF
--- a/.changeset/clever-hornets-talk.md
+++ b/.changeset/clever-hornets-talk.md
@@ -1,0 +1,7 @@
+---
+"blitz": patch
+"@blitzjs/next": patch
+"@blitzjs/generator": patch
+---
+
+Downgrade tslog to `4.7.4`

--- a/packages/blitz-next/package.json
+++ b/packages/blitz-next/package.json
@@ -64,7 +64,7 @@
     "react-dom": "18.2.0",
     "resolve-from": "5.0.0",
     "ts-jest": "27.1.4",
-    "tslog": "4.8.2",
+    "tslog": "4.7.4",
     "typescript": "^4.8.4",
     "unbuild": "0.7.6",
     "watch": "1.0.2"

--- a/packages/blitz/package.json
+++ b/packages/blitz/package.json
@@ -76,7 +76,7 @@
     "tar": "6.1.11",
     "ts-node": "10.9.1",
     "tsconfig-paths": "4.0.0",
-    "tslog": "4.8.2",
+    "tslog": "4.7.4",
     "watchpack": "2.1.1"
   },
   "devDependencies": {

--- a/packages/blitz/src/logging.ts
+++ b/packages/blitz/src/logging.ts
@@ -1,4 +1,4 @@
-import {ILogObj, ISettingsParam, Logger, IMeta} from "tslog"
+import {ILogObj, ISettingsParam, Logger} from "tslog"
 import c from "chalk"
 import {Table} from "console-table-printer"
 import ora from "ora"

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -48,7 +48,7 @@
     "prettier": "^2.7.1",
     "recast": "0.20.5",
     "supports-color": "8.1.1",
-    "tslog": "4.8.2",
+    "tslog": "4.7.4",
     "username": "5.1.0",
     "vinyl": "2.2.1",
     "zod": "3.20.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,7 +956,7 @@ importers:
         version: 8.27.0(supports-color@8.1.1)
       eslint-config-next:
         specifier: latest
-        version: 13.4.10(eslint@8.27.0)(typescript@4.8.4)
+        version: 13.4.4(eslint@8.27.0)(typescript@4.8.4)
       eslint-plugin-testing-library:
         specifier: 5.0.1
         version: 5.0.1(eslint@8.27.0)(typescript@4.8.4)
@@ -1427,8 +1427,8 @@ importers:
         specifier: 4.0.0
         version: 4.0.0
       tslog:
-        specifier: 4.8.2
-        version: 4.8.2
+        specifier: 4.7.4
+        version: 4.7.4
       watchpack:
         specifier: 2.1.1
         version: 2.1.1
@@ -1715,8 +1715,8 @@ importers:
         specifier: 27.1.4
         version: 27.1.4(@babel/core@7.12.10)(esbuild@0.14.51)(jest@27.5.1)(typescript@4.8.4)
       tslog:
-        specifier: 4.8.2
-        version: 4.8.2
+        specifier: 4.7.4
+        version: 4.7.4
       typescript:
         specifier: ^4.8.4
         version: 4.8.4
@@ -1955,8 +1955,8 @@ importers:
         specifier: 8.1.1
         version: 8.1.1
       tslog:
-        specifier: 4.8.2
-        version: 4.8.2
+        specifier: 4.7.4
+        version: 4.7.4
       username:
         specifier: 5.1.0
         version: 5.1.0
@@ -5574,10 +5574,10 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /@next/eslint-plugin-next@13.4.10:
+  /@next/eslint-plugin-next@13.4.4:
     resolution:
       {
-        integrity: sha512-YJqyq6vk39JQfvaNtN83t/p5Jy45+bazRL+V4QI8FPd3FBqFYMEsULiwRLgSJMgFqkk4t4JbeZurz+gILEAFpA==,
+        integrity: sha512-5jnh7q6I15efnjR/rR+/TGTc9hn53g3JTbEjAMjmeQiExKqEUgIXqrHI5zlTNlNyzCPkBB860/ctxXheZaF2Vw==,
       }
     dependencies:
       glob: 7.1.7
@@ -11356,10 +11356,10 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-config-next@13.4.10(eslint@8.27.0)(typescript@4.8.4):
+  /eslint-config-next@13.4.4(eslint@8.27.0)(typescript@4.8.4):
     resolution:
       {
-        integrity: sha512-+JjcM6lQmFR5Mw0ORm9o1CR29+z/uajgSfYAPEGIBxOhTHBgCMs7ysuwi72o7LkMmA8E3N7/h09pSGZxs0s85g==,
+        integrity: sha512-z/PMbm6L0iC/fwISULxe8IVy4DtNqZk2wQY711o35klenq70O6ns82A8yuMVCFjHC0DIyB2lyugesRtuk9u8dQ==,
       }
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -11368,7 +11368,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      "@next/eslint-plugin-next": 13.4.10
+      "@next/eslint-plugin-next": 13.4.4
       "@rushstack/eslint-patch": 1.1.3
       "@typescript-eslint/parser": 5.43.0(eslint@8.27.0)(typescript@4.8.4)
       eslint: 8.27.0(supports-color@8.1.1)
@@ -11377,7 +11377,7 @@ packages:
       eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.43.0)(eslint-import-resolver-typescript@3.5.2)(eslint@8.27.0)
       eslint-plugin-jsx-a11y: 6.5.1(eslint@8.27.0)
       eslint-plugin-react: 7.31.8(eslint@8.27.0)
-      eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.27.0)
+      eslint-plugin-react-hooks: 4.5.0(eslint@8.27.0)
       typescript: 4.8.4
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
@@ -11698,18 +11698,6 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
       eslint: 8.27.0(supports-color@8.1.1)
-
-  /eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@8.27.0):
-    resolution:
-      {
-        integrity: sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==,
-      }
-    engines: {node: ">=10"}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    dependencies:
-      eslint: 8.27.0(supports-color@8.1.1)
-    dev: true
 
   /eslint-plugin-react@7.31.8(eslint@8.26.0):
     resolution:
@@ -20640,10 +20628,10 @@ packages:
         integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==,
       }
 
-  /tslog@4.8.2:
+  /tslog@4.7.4:
     resolution:
       {
-        integrity: sha512-eAKIRjxfSKYLs06r1wT7oou6Uv9VN6NW9g0JPidBlqQwPBBl5+84dm7r8zSOPVq1kyfEw1P6B3/FLSpZCorAgA==,
+        integrity: sha512-/hz7E1ahN9KXNywEGJZ8SL4s3YLu9fKYBHOXsKgXwk73qZ7Y5NCkqktP6Y+0MQNfnqOdH8eRE0Rw0spmyTWLPg==,
       }
     engines: {node: ">=16"}
 


### PR DESCRIPTION
Closes #4179

### What are the changes and their implications?
Downgrades `tslog` to a version where the issue described in https://github.com/fullstack-build/tslog/issues/227 does not occur.
## Bug Checklist

- [X] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [X] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
