### PR TITLE
fix: add framer-motion to NextUI recipe dependencies list

### DIFF
--- a/recipes/next-ui/index.ts
+++ b/recipes/next-ui/index.ts
@@ -86,12 +86,17 @@ export default RecipeBuilder()
   .addAddDependenciesStep({
     stepId: "install",
     stepName: "Install Next UI",
-    explanation: `Import the Next UI provider into _app, so it is accessible in the whole app`,
+    explanation: `Install Next UI and its dependencies`,
     packages: [
       {
         name: "@nextui-org/react",
         version: "latest",
         isDevDep: true,
+      },
+      {
+        name: "framer-motion",
+        version: "latest",
+        isDevDep: false,
       },
     ],
   })


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

### What are the changes and their implications?

- Added `framer-motion` to dependencies step.

NextUI requires the `framer-motion` package, as stated in [their documentation](https://nextui.org/docs/guide/installation).

Installing a fresh recipe without this change yields a missing dependency error upon compilation.