### PR TITLE
feat: allow extra args to be passed to nextjs cli

### DIFF
--- a/.changeset/metal-icons-talk.md
+++ b/.changeset/metal-icons-talk.md
@@ -1,0 +1,5 @@
+---
+"blitz": major
+---
+
+Allow extra args to be passed to the nextjs cli

--- a/packages/blitz/src/cli/commands/next/build.ts
+++ b/packages/blitz/src/cli/commands/next/build.ts
@@ -12,10 +12,13 @@ const build: CliCommand = async () => {
     },
   )
 
+  const extraArgs = nextArgs["_"].filter((arg) => arg !== "build")
+
   const config: ServerConfig = {
     rootFolder: process.cwd(),
     inspect: nextArgs["--inspect"],
     env: "prod",
+    extraArgs,
   }
 
   await import("../../utils/next-commands").then((i) => i.build(config))

--- a/packages/blitz/src/cli/commands/next/dev.ts
+++ b/packages/blitz/src/cli/commands/next/dev.ts
@@ -17,12 +17,15 @@ const dev: CliCommand = async () => {
     },
   )
 
+  const extraArgs = nextArgs["_"].filter((arg) => arg !== "dev")
+
   const config: ServerConfig = {
     rootFolder: process.cwd(),
     port: nextArgs["--port"],
     hostname: nextArgs["--hostname"],
     inspect: nextArgs["--inspect"],
     env: process.env.NODE_ENV === "production" ? "prod" : "dev",
+    extraArgs,
   }
 
   await import("../../utils/next-commands").then((i) => i.dev(config))

--- a/packages/blitz/src/cli/commands/next/export.ts
+++ b/packages/blitz/src/cli/commands/next/export.ts
@@ -19,10 +19,13 @@ const nextExport: CliCommand = async () => {
     },
   )
 
+  const extraArgs = nextArgs["_"].filter((arg) => arg !== "export")
+
   const config: ServerConfig = {
     rootFolder: process.cwd(),
     ...(nextArgs["--outdir"] && {outdir: resolve(nextArgs["--outdir"])}),
     env: process.env.NODE_ENV === "production" ? "prod" : "dev",
+    extraArgs,
   }
 
   const getHelp = async () => {

--- a/packages/blitz/src/cli/commands/next/start.ts
+++ b/packages/blitz/src/cli/commands/next/start.ts
@@ -17,12 +17,15 @@ const start: CliCommand = async () => {
     },
   )
 
+  const extraArgs = nextArgs["_"].filter((arg) => arg !== "start")
+
   const config: ServerConfig = {
     rootFolder: process.cwd(),
     port: nextArgs["--port"],
     hostname: nextArgs["--hostname"],
     inspect: nextArgs["--inspect"],
     env: process.env.NODE_ENV === "production" ? "prod" : "dev",
+    extraArgs,
   }
 
   await import("../../utils/next-commands").then((i) => i.prod(config))

--- a/packages/blitz/src/cli/utils/config.ts
+++ b/packages/blitz/src/cli/utils/config.ts
@@ -37,6 +37,8 @@ export type ServerConfig = {
   // –
   env: ServerEnvironment
   // -
+  extraArgs: string[]
+  // -
   outdir?: string
 }
 

--- a/packages/blitz/src/cli/utils/next-utils.ts
+++ b/packages/blitz/src/cli/utils/next-utils.ts
@@ -152,7 +152,7 @@ function getSpawnEnv(config: ServerConfig) {
 }
 
 async function createCommandAndPort(config: ServerConfig, command: string) {
-  let spawnCommand: string[] = [command]
+  let spawnCommand: string[] = [command, ...config.extraArgs]
   let availablePort: number
 
   availablePort = await detect({port: config.port ? config.port : 3000})


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: -

### What are the changes and their implications?

Allow extra args to be passed to the nextjs CLI. For example in my case: `blitz dev -p 3000 --experimental-https`. The `--experimental-https` will be passed down to he nextjs cli. 

## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
