### PR TITLE
chore(rpcHandler): onError ctx

### DIFF
--- a/.changeset/rare-squids-brake.md
+++ b/.changeset/rare-squids-brake.md
@@ -2,4 +2,4 @@
 "@blitzjs/rpc": minor
 ---
 
-provide ctx to rpcHandler error callbacks
+expose `ctx` to `rpcHandler` error callbacks in [[...blitz]].ts files

--- a/.changeset/rare-squids-brake.md
+++ b/.changeset/rare-squids-brake.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/rpc": minor
+---
+
+provide ctx to rpcHandler error callbacks

--- a/apps/next13/src/pages/api/rpc/[[...blitz]].ts
+++ b/apps/next13/src/pages/api/rpc/[[...blitz]].ts
@@ -1,4 +1,4 @@
 import {rpcHandler} from "@blitzjs/rpc"
 import {api} from "../../../blitz-server"
 
-export default api(rpcHandler({onError: console.log}))
+export default api(rpcHandler({onError: (error, ctx) => console.log(error)}))

--- a/apps/toolkit-app-passportjs/src/pages/api/rpc/[[...blitz]].ts
+++ b/apps/toolkit-app-passportjs/src/pages/api/rpc/[[...blitz]].ts
@@ -1,4 +1,4 @@
 import { rpcHandler } from "@blitzjs/rpc"
 import { api } from "src/blitz-server"
 
-export default api(rpcHandler({ onError: console.log }))
+export default api(rpcHandler({ onError: (error, ctx) => console.log(error) }))

--- a/apps/toolkit-app/src/pages/api/rpc/[[...blitz]].ts
+++ b/apps/toolkit-app/src/pages/api/rpc/[[...blitz]].ts
@@ -3,8 +3,8 @@ import { api } from "src/blitz-server"
 
 export default api(
   rpcHandler({
-    onError: console.log,
-    formatError: (error) => {
+    onError: (error, ctx) => console.log(error),
+    formatError: (error, ctx) => {
       error.message = `FormatError handler: ${error.message}`
       return error
     },

--- a/apps/web/src/pages/api/rpc/[[...blitz]].ts
+++ b/apps/web/src/pages/api/rpc/[[...blitz]].ts
@@ -1,4 +1,4 @@
 import {rpcHandler} from "@blitzjs/rpc"
 import {api} from "src/blitz-server"
 
-export default api(rpcHandler({onError: console.log}))
+export default api(rpcHandler({onError: (error, ctx) => console.log(error)}))

--- a/integration-tests/auth-with-rpc/src/pages/api/rpc/[[...blitz]].ts
+++ b/integration-tests/auth-with-rpc/src/pages/api/rpc/[[...blitz]].ts
@@ -1,4 +1,4 @@
 import {rpcHandler} from "@blitzjs/rpc"
 import {api} from "../../../blitz-server"
 
-export default api(rpcHandler({onError: console.log}))
+export default api(rpcHandler({onError: (error, ctx) => console.log(error)}))

--- a/integration-tests/get-initial-props/pages/api/rpc/[[...blitz]].ts
+++ b/integration-tests/get-initial-props/pages/api/rpc/[[...blitz]].ts
@@ -1,4 +1,4 @@
 import {rpcHandler} from "@blitzjs/rpc"
 import {api} from "../../../app/blitz-server"
 
-export default api(rpcHandler({onError: console.log}))
+export default api(rpcHandler({onError: (error, ctx) => console.log(error)}))

--- a/integration-tests/middleware/pages/api/rpc/[[...blitz]].ts
+++ b/integration-tests/middleware/pages/api/rpc/[[...blitz]].ts
@@ -1,3 +1,3 @@
 import {rpcHandler} from "@blitzjs/rpc"
 
-export default rpcHandler({onError: console.log})
+export default rpcHandler({onError: (error, ctx) => console.log(error)})

--- a/integration-tests/next-13-app-dir/pages/api/rpc/[[...blitz]].ts
+++ b/integration-tests/next-13-app-dir/pages/api/rpc/[[...blitz]].ts
@@ -1,4 +1,4 @@
 import {rpcHandler} from "@blitzjs/rpc"
 import {api} from "../../../src/blitz-server"
 
-export default api(rpcHandler({onError: console.log}))
+export default api(rpcHandler({onError: (error, ctx) => console.log(error)}))

--- a/integration-tests/no-suspense/pages/api/rpc/[[...blitz]].ts
+++ b/integration-tests/no-suspense/pages/api/rpc/[[...blitz]].ts
@@ -1,4 +1,4 @@
 import {rpcHandler} from "@blitzjs/rpc"
 import {api} from "../../../app/blitz-server"
 
-export default api(rpcHandler({onError: console.log}))
+export default api(rpcHandler({onError: (error, ctx) => console.log(error)}))

--- a/integration-tests/react-query-utils/pages/api/rpc/[[...blitz]].ts
+++ b/integration-tests/react-query-utils/pages/api/rpc/[[...blitz]].ts
@@ -1,4 +1,4 @@
 import {rpcHandler} from "@blitzjs/rpc"
 import {api} from "../../../app/blitz-server"
 
-export default api(rpcHandler({onError: console.log}))
+export default api(rpcHandler({onError: (error, ctx) => console.log(error)}))

--- a/integration-tests/rpc-path-root/pages/api/rpc/[[...blitz]].ts
+++ b/integration-tests/rpc-path-root/pages/api/rpc/[[...blitz]].ts
@@ -1,3 +1,3 @@
 import {rpcHandler} from "@blitzjs/rpc"
 
-export default rpcHandler({onError: console.log})
+export default rpcHandler({onError: (error, ctx) => console.log(error)})

--- a/integration-tests/rpc/pages/api/rpc/[[...blitz]].ts
+++ b/integration-tests/rpc/pages/api/rpc/[[...blitz]].ts
@@ -1,3 +1,3 @@
 import {rpcHandler} from "@blitzjs/rpc"
 
-export default rpcHandler({onError: console.log})
+export default rpcHandler({onError: (error, ctx) => console.log(error)})

--- a/integration-tests/trailing-slash/pages/api/rpc/[[...blitz]].ts
+++ b/integration-tests/trailing-slash/pages/api/rpc/[[...blitz]].ts
@@ -1,4 +1,4 @@
 import {rpcHandler} from "@blitzjs/rpc"
 import {api} from "../../../app/blitz-server"
 
-export default api(rpcHandler({onError: console.log}))
+export default api(rpcHandler({onError: (error, ctx) => console.log(error)}))

--- a/packages/generator/templates/app/src/pages/api/rpc/blitzrpcroute.ts
+++ b/packages/generator/templates/app/src/pages/api/rpc/blitzrpcroute.ts
@@ -1,4 +1,4 @@
 import { rpcHandler } from "@blitzjs/rpc"
 import { api } from "src/blitz-server"
 
-export default api(rpcHandler({ onError: console.log }))
+export default api(rpcHandler({ onError: (error, ctx) => console.log(error) }))


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

### What are the changes and their implications?

`rpcHandler` now provides `ctx` on its Error callbacks. 
For this reason, shorthands 
```ts
onError: console.log
```
were converted to:
```ts
onError: (error, ctx) => console.log(error)
``` 
indicating `ctx` existence but avoiding its logging on default

### Why all this?
[discord convo](https://discord.com/channels/802917734999523368/1179722406236000308/1179722406236000308)

## Feature Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
