### PR TITLE
Add helpful error message when RPC resolvers have the same path

### DIFF
--- a/.changeset/cyan-rings-play.md
+++ b/.changeset/cyan-rings-play.md
@@ -1,0 +1,6 @@
+---
+"@blitzjs/rpc": patch
+"blitz": patch
+---
+
+Add helpful error message when RPC resolvers have the same path

--- a/packages/blitz-rpc/src/index-server.ts
+++ b/packages/blitz-rpc/src/index-server.ts
@@ -62,7 +62,6 @@ export function __internal_addBlitzRpcResolver(
   g.blitzRpcResolverFilesLoaded = g.blitzRpcResolverFilesLoaded || {}
   const existingResolver = g.blitzRpcResolverFilesLoaded[routePath]
   if (existingResolver && existingResolver.absoluteResolverPath !== absoluteResolverPath) {
-    console.log("existingResolver", existingResolver)
     const logger = new RpcLogger(routePath)
     const errorMessage = `\nThe following resolver files resolve to the same path: ${routePath}\n\n1.  ${absoluteResolverPath}\n2.  ${
       existingResolver.absoluteResolverPath

--- a/packages/blitz-rpc/src/rpc-logger.ts
+++ b/packages/blitz-rpc/src/rpc-logger.ts
@@ -163,9 +163,7 @@ export class RpcLogger {
     newLine()
   }
   public error(e: any) {
-    if (typeof e === "string") {
-      this.#logger.error(e)
-    } else if (e instanceof Error) {
+    if (typeof e === "string" || e instanceof Error) {
       this.#logger.error(e)
     } else {
       this.#logger.error(new Error(e))

--- a/packages/blitz-rpc/src/rpc-logger.ts
+++ b/packages/blitz-rpc/src/rpc-logger.ts
@@ -165,8 +165,11 @@ export class RpcLogger {
   public error(e: any) {
     if (typeof e === "string") {
       this.#logger.error(e)
+    } else if (e instanceof Error) {
+      this.#logger.error(e)
+    } else {
+      this.#logger.error(new Error(e))
     }
-    this.#logger.error(new Error(e))
     newLine()
   }
   public warn(e: string) {

--- a/packages/blitz-rpc/src/server/loader/server/loader-server.ts
+++ b/packages/blitz-rpc/src/server/loader/server/loader-server.ts
@@ -66,7 +66,7 @@ export async function transformBlitzRpcServer(
 
     const importStrategy = options?.resolversDynamicImport ? "import" : "require"
 
-    code += `__internal_addBlitzRpcResolver('${routePath}',() => ${importStrategy}('${slash(
+    code += `__internal_addBlitzRpcResolver('${routePath}','${resolverFilePath}',() => ${importStrategy}('${slash(
       resolverFilePath,
     )}'));`
     code += "\n"


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

### What are the changes and their implications?

- [x] display the following error when two resolvers resolve to the same path, previously the second or following resolvers with the same just override the previous
- [x] In development, replace the resolver with this error for better visibility. 

<img width="816" alt="image" src="https://github.com/blitz-js/blitz/assets/83594610/7e3e5a77-19b8-401e-885d-134ff391f6ac">


## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
