### PR TITLE
fix: outdated code in npm during migration to stable

### DIFF
--- a/.changeset/curly-masks-give.md
+++ b/.changeset/curly-masks-give.md
@@ -1,0 +1,11 @@
+---
+"blitz": patch
+"@blitzjs/auth": patch
+"@blitzjs/next": patch
+"@blitzjs/rpc": patch
+"@blitzjs/codemod": patch
+"@blitzjs/config": patch
+"@blitzjs/generator": patch
+---
+
+Fix outdated code in npm caused in during exit to stable release


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: https://github.com/blitz-js/blitz/issues/4266

### What are the changes and their implications?
Created new patch `2.0.1` to fix some outdated code in the generator and blitz packages


## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
