### PR TITLE
Use `npx` and `pnpx` in CLI next steps instead of `npm` and `pnpm`

### DIFF
--- a/packages/blitz/src/cli/commands/new.ts
+++ b/packages/blitz/src/cli/commands/new.ts
@@ -274,7 +274,7 @@ const newApp: CliCommand = async () => {
       )
     }
 
-    postInstallSteps.push(`${projectPkgManger} blitz dev`)
+    postInstallSteps.push(`${projectPkgManger.replace("npm", "npx").replace("pnpm", "pnpm dlx")} blitz dev`)
 
     console.log("\n Your new Blitz app is ready! Next steps:")
     postInstallSteps.forEach((step, index) => {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: #4272 

### What are the changes and their implications?

This PR changes the `blitz new` CLI to mention the correct run commands once the app is built:

```sh
npx blitz dev
pnpx blitz dev

// instead of

npm blitz dev
pnpm blitz dev
```

It does this by using `replace()`.

## Bug Checklist

- [ ] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
