### PR TITLE
fix<codemod-upgrade-legacy>: provide correct path to template files

### DIFF
--- a/.changeset/famous-worms-grab.md
+++ b/.changeset/famous-worms-grab.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/codemod": patch
+---
+
+codemod: provide correct path to new template paths

--- a/packages/codemod/src/upgrade-legacy.ts
+++ b/packages/codemod/src/upgrade-legacy.ts
@@ -584,7 +584,9 @@ const upgradeLegacy = async () => {
             j.Identifier,
             (node) => node.name === "cookiePrefix",
           )
-          cookieIdentifierBlitzClient.get().parentPath.value.value.value = cookiePrefix
+          if (cookieIdentifierBlitzClient.length) {
+            cookieIdentifierBlitzClient.get().parentPath.value.value.value = cookiePrefix
+          }
 
           fs.writeFileSync(
             `${appDir}/blitz-client.${isTypescript ? "ts" : "js"}`,

--- a/packages/codemod/src/upgrade-legacy.ts
+++ b/packages/codemod/src/upgrade-legacy.ts
@@ -684,7 +684,9 @@ const upgradeLegacy = async () => {
         isInternalBlitzMonorepoDevelopment ? "templates" : "dist/templates",
       )
       const rpcRoute = fs
-        .readFileSync(path.join(templatePath, "app", "pages", "api", "rpc", "blitzrpcroute.ts"))
+        .readFileSync(
+          path.join(templatePath, "app", "src", "pages", "api", "rpc", "blitzrpcroute.ts"),
+        )
         .toString()
 
       if (!fs.existsSync(pagesDir)) {

--- a/packages/codemod/src/upgrade-legacy.ts
+++ b/packages/codemod/src/upgrade-legacy.ts
@@ -536,10 +536,10 @@ const upgradeLegacy = async () => {
           isInternalBlitzMonorepoDevelopment ? "templates" : "dist/templates",
         )
         const blitzServer = fs
-          .readFileSync(path.join(templatePath, "app", "app", "blitz-server.ts"))
+          .readFileSync(path.join(templatePath, "app", "src", "app", "blitz-server.ts"))
           .toString()
         const blitzClient = fs
-          .readFileSync(path.join(templatePath, "app", "app", "blitz-client.ts"))
+          .readFileSync(path.join(templatePath, "app", "src", "app", "blitz-client.ts"))
           .toString()
 
         const replaceTemplateValues = (input: string) => {


### PR DESCRIPTION
Closes: Fixes an issue for the codemod "upgrade-legacy", where an invalid file path is used

--

Following error message is printed to the terminal:

npx @blitzjs/codemod upgrade-legacy
✖ create blitz-server.ts and blitz-client.ts setup files
Error: ENOENT: no such file or directory, open '/Users/admin/.nvm/versions/node/v16.16.0/lib/node_modules/@blitzjs/codemod/node_modules/@blitzjs/generator/dist/templates/app/app/blitz-server.ts'
This is an unexpected error. Please ask for help in the discord #general-help channel. https://discord.blitzjs.com

--

I sadly to not have the time currently to get your project up and running in order to submit a fully fleshed out pull-request, like your guidelines suggest to do.
Therefore please view this pull-request as an issue, where i want to provide the suggested solution directly.

--

Thank you  for your great work on blitzJS, with best regards,
Leon Müller
