### PR TITLE
Fix: BlitzCliConfig does not work when blitz-server.ts is in /src/app directory

### DIFF
--- a/.changeset/giant-knives-wonder.md
+++ b/.changeset/giant-knives-wonder.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Fix: search inside any subdirectory to inside `src|app` directories to find `blitz-server.ts` to use the `BlitzCliConfig` configurations.

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -35,7 +35,7 @@ export const customTemplatesBlitzConfig = async (
   codemod = false,
 ) => {
   const {globby} = await import("globby")
-  const blitzServer = await globby(["{app,src}/**/blitz-server.{ts,js}"], {
+  const blitzServer = await globby(["{app,src}/**/**/blitz-server.(ts,js)"], {
     cwd: getProjectRootSync(),
   })
   if (blitzServer.length === 0) {

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -35,7 +35,7 @@ export const customTemplatesBlitzConfig = async (
   codemod = false,
 ) => {
   const {globby} = await import("globby")
-  const blitzServer = await globby(["{app,src}/**/**/blitz-server.(ts,js)"], {
+  const blitzServer = await globby(["{app,src}/**/**/blitz-server.{ts,js}"], {
     cwd: getProjectRootSync(),
   })
   if (blitzServer.length === 0) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: https://github.com/blitz-js/blitz/issues/4278

### What are the changes and their implications?

- [x] search for any subsdirectory inside the `app|src` directories to find `blitz-sever.ts` since we don't need to have a fixed location for it.

## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
