### PR TITLE
Added codemod support for legacy projects with a /src folder

### DIFF
--- a/.changeset/serious-impalas-guess.md
+++ b/.changeset/serious-impalas-guess.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/codemod": patch
+---
+
+Added support to codemod upgrade-legacy for projects that have their pages folder nested in a src/ folder

--- a/packages/codemod/src/upgrade-legacy.ts
+++ b/packages/codemod/src/upgrade-legacy.ts
@@ -32,6 +32,12 @@ class ExpectedError extends Error {
   }
 }
 
+const findPagesDirectory = () => {
+  const srcPagesDir = path.join("src", "pages")
+  const pagesDir = path.join("pages")
+  return fs.existsSync(srcPagesDir) ? srcPagesDir : pagesDir
+}
+
 const isInternalBlitzMonorepoDevelopment = fs.existsSync(
   path.join(__dirname, "../../../blitz-next"),
 )
@@ -678,7 +684,7 @@ const upgradeLegacy = async () => {
   steps.push({
     name: "create pages/api/rpc directory and add [[...blitz]].ts wildecard API route",
     action: async () => {
-      const pagesDir = path.resolve("pages/api/rpc")
+      const pagesDir = path.resolve(`${findPagesDirectory}/api/rpc`)
       const templatePath = path.join(
         require.resolve("@blitzjs/generator"),
         "..",
@@ -929,7 +935,7 @@ const upgradeLegacy = async () => {
     name: "convert useRouterQuery to useRouter",
     action: async () => {
       //First check ./pages
-      const pagesDir = path.resolve("pages")
+      const pagesDir = findPagesDirectory()
       getAllFiles(pagesDir, [], [], [".ts", ".tsx", ".js", ".jsx"]).forEach((file) => {
         try {
           const filepath = path.resolve(pagesDir, file)
@@ -1061,7 +1067,7 @@ const upgradeLegacy = async () => {
   steps.push({
     name: "wrap App component with withBlitz HOC",
     action: async () => {
-      const pagesDir = path.resolve("pages")
+      const pagesDir = findPagesDirectory()
 
       const program = getCollectionFromSource(
         path.join(pagesDir, `_app.${isTypescript ? "tsx" : "jsx"}`),
@@ -1111,7 +1117,7 @@ const upgradeLegacy = async () => {
   steps.push({
     name: "update imports in the _document file",
     action: async () => {
-      const pagesDir = path.resolve("pages")
+      const pagesDir = findPagesDirectory()
 
       if (fs.existsSync(path.join(pagesDir, `_document.${isTypescript ? "tsx" : "jsx"}`))) {
         const program = getCollectionFromSource(
@@ -1191,7 +1197,7 @@ const upgradeLegacy = async () => {
   steps.push({
     name: "wrap getServerSideProps, getStaticProps and API handlers with gSSP, gSP, and api",
     action: async () => {
-      const pagesDir = path.resolve("pages")
+      const pagesDir = findPagesDirectory()
       getAllFiles(pagesDir, [], ["api"], [".ts", ".tsx", ".js", ".jsx"]).forEach((file) => {
         try {
           const program = getCollectionFromSource(file)

--- a/packages/codemod/src/upgrade-legacy.ts
+++ b/packages/codemod/src/upgrade-legacy.ts
@@ -34,8 +34,8 @@ class ExpectedError extends Error {
 
 const findPagesDirectory = () => {
   const srcPagesDir = path.join("src", "pages")
-  const pagesDir = path.join("pages")
-  return fs.existsSync(srcPagesDir) ? srcPagesDir : pagesDir
+  const pagesDir = path.resolve("pages")
+  return fs.existsSync(srcPagesDir) ? path.resolve(srcPagesDir) : pagesDir
 }
 
 const isInternalBlitzMonorepoDevelopment = fs.existsSync(
@@ -684,7 +684,7 @@ const upgradeLegacy = async () => {
   steps.push({
     name: "create pages/api/rpc directory and add [[...blitz]].ts wildecard API route",
     action: async () => {
-      const pagesDir = path.resolve(`${findPagesDirectory}/api/rpc`)
+      const pagesDir = path.resolve(`${findPagesDirectory()}/api/rpc`)
       const templatePath = path.join(
         require.resolve("@blitzjs/generator"),
         "..",


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

### What are the changes and their implications?
Changes the codemod upgrade-legacy tool to add support for legacy projects which have folders nested inside a /src directory
## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)

## Feature Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)

