### PR TITLE
fix: process.kill("SIGABRT") not supported on windows

### DIFF
--- a/.changeset/clever-insects-shave.md
+++ b/.changeset/clever-insects-shave.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Use process.kill("SIGINT") instead of process.kill("SIGABRT") on startCustomServer() for better compatibility with operative systems

--- a/.changeset/clever-insects-shave.md
+++ b/.changeset/clever-insects-shave.md
@@ -2,4 +2,4 @@
 "blitz": patch
 ---
 
-Use process.kill("SIGINT") instead of process.kill("SIGABRT") on startCustomServer() for better compatibility with operative systems
+Use `SIGINT` signal instead of `SIGABRT` to stop the process, when using custom server for better compatibility with operative systems

--- a/packages/blitz/src/cli/utils/next-utils.ts
+++ b/packages/blitz/src/cli/utils/next-utils.ts
@@ -1,5 +1,6 @@
 import {ChildProcess} from "child_process"
 import {spawn} from "cross-spawn"
+import os from "os"
 import detect from "detect-port"
 import path from "path"
 import {existsSync, readJSONSync} from "fs-extra"
@@ -127,7 +128,13 @@ export function startCustomServer(
               console.log("\n")
               //@ts-ignore -- incorrect TS type from node
               process.exitCode = RESTART_CODE
-              process.kill("SIGABRT")
+              // Check if the system is Windows
+              if (os.platform() === "win32") {
+                // Windows doesn't support SIGABRT, use SIGINT instead
+                process.kill("SIGINT")
+              } else {
+                process.kill("SIGABRT")
+              }
             }
           },
         }

--- a/packages/blitz/src/cli/utils/next-utils.ts
+++ b/packages/blitz/src/cli/utils/next-utils.ts
@@ -1,6 +1,5 @@
 import {ChildProcess} from "child_process"
 import {spawn} from "cross-spawn"
-import os from "os"
 import detect from "detect-port"
 import path from "path"
 import {existsSync, readJSONSync} from "fs-extra"
@@ -128,13 +127,7 @@ export function startCustomServer(
               console.log("\n")
               //@ts-ignore -- incorrect TS type from node
               process.exitCode = RESTART_CODE
-              // Check if the system is Windows
-              if (os.platform() === "win32") {
-                // Windows doesn't support SIGABRT, use SIGINT instead
-                process.kill("SIGINT")
-              } else {
-                process.kill("SIGABRT")
-              }
+              process.kill("SIGINT")
             }
           },
         }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: #4307

### What are the changes and their implications?
- Use `process.kill("SIGINT")` instead of `process.kill("SIGABRT")` on `startCustomServer()` at **next-utils.ts** on blitz package.
- This solves a minor Windows compatibility issue because `process.kill("SIGABRT")` is not supported on Windows.

## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory) (patch bump)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
