### PR TITLE
Use this.rootContext instead of webpack internals

### DIFF
--- a/packages/blitz-rpc/src/server/loader/client/loader-client.ts
+++ b/packages/blitz-rpc/src/server/loader/client/loader-client.ts
@@ -14,11 +14,10 @@ import {getResolverConfig} from "../../parsers/parse-rpc-config"
 // Subset of `import type { LoaderDefinitionFunction } from 'webpack'`
 
 export async function loader(this: Loader, input: string): Promise<string> {
-  const compiler = this._compiler!
   const id = this.resource
-  const root = this._compiler!.context
+  const root = this.rootContext
 
-  const isSSR = compiler.name === "server"
+  const isSSR = this._compiler.name === "server"
   if (!isSSR) {
     return await transformBlitzRpcResolverClient(
       input,

--- a/packages/blitz-rpc/src/server/loader/server/loader-server-resolvers.ts
+++ b/packages/blitz-rpc/src/server/loader/server/loader-server-resolvers.ts
@@ -13,11 +13,10 @@ import {posix} from "path"
 // Subset of `import type { LoaderDefinitionFunction } from 'webpack'`
 
 export async function loader(this: Loader, input: string): Promise<string> {
-  const compiler = this._compiler!
   const id = this.resource
-  const root = this._compiler!.context
+  const root = this.rootContext
 
-  const isSSR = compiler.name === "server"
+  const isSSR = this._compiler.name === "server"
   if (isSSR) {
     return await transformBlitzRpcResolverServer(
       input,

--- a/packages/blitz-rpc/src/server/loader/server/loader-server.ts
+++ b/packages/blitz-rpc/src/server/loader/server/loader-server.ts
@@ -14,12 +14,11 @@ import {
 // Subset of `import type { LoaderDefinitionFunction } from 'webpack'`
 
 export async function loader(this: Loader, input: string): Promise<string> {
-  const compiler = this._compiler!
   const id = this.resource
-  const root = this._compiler!.context
+  const root = this.rootContext
   const rpcFolders = this.query.includeRPCFolders ? this.query.includeRPCFolders : []
 
-  const isSSR = compiler.name === "server"
+  const isSSR = this._compiler.name === "server"
   if (isSSR) {
     this.cacheable(false)
 

--- a/packages/blitz-rpc/src/server/loader/utils/loader-utils.ts
+++ b/packages/blitz-rpc/src/server/loader/utils/loader-utils.ts
@@ -11,8 +11,8 @@ export interface LoaderOptions {
 export interface Loader {
   _compiler?: {
     name: string
-    context: string
   }
+  rootContext: string
   resource: string
   cacheable: (enabled: boolean) => void
   query: LoaderOptions


### PR DESCRIPTION
Ensures the root context is read from the public API that webpack exposes. This is the first step for Turbopack support as Turbopack includes `this.rootContext` as well.

What is unclear to me is why it's checking for `server` only and not for edge, does Blitz support edge runtime? If so you can leverage the `isServer` condition in webpack() to remove the internals usage completely 👍

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: ?

### What are the changes and their implications?

## Bug Checklist

- [ ] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
