### PR TITLE
fix: add missing host in next-auth adapter

### DIFF
--- a/.changeset/red-masks-drop.md
+++ b/.changeset/red-masks-drop.md
@@ -3,4 +3,4 @@
 "blitz": patch
 ---
 
-fix: add missing host in next-auth adapter
+fix: add missing host while initialising the next-auth adapter

--- a/.changeset/red-masks-drop.md
+++ b/.changeset/red-masks-drop.md
@@ -1,0 +1,6 @@
+---
+"@blitzjs/auth": patch
+"blitz": patch
+---
+
+fix: add missing host in next-auth adapter

--- a/packages/blitz-auth/src/server/adapters/next-auth/adapter.ts
+++ b/packages/blitz-auth/src/server/adapters/next-auth/adapter.ts
@@ -109,11 +109,11 @@ export function NextAuthAdapter<P extends Provider[]>(
     const {options, cookies} = await init({
       // @ts-ignore
       url: new URL(
-        // @ts-ignore
-        internalRequest.url!,
+        internalRequest.url,
         process.env.APP_ORIGIN || process.env.BLITZ_DEV_SERVER_ORIGIN,
       ),
       authOptions: config as unknown as AuthOptions,
+      host: internalRequest.url.host,
       action,
       providerId,
       callbackUrl: req.body?.callbackUrl ?? (req.query?.callbackUrl as string),

--- a/packages/blitz-auth/src/server/adapters/next-auth/internals/utils/web.ts
+++ b/packages/blitz-auth/src/server/adapters/next-auth/internals/utils/web.ts
@@ -47,7 +47,12 @@ async function readJSONBody(
 // prettier-ignore
 const actions = [ "providers", "session", "csrf", "login", "signout", "callback", "verify-request", "error", "_log"]
 
-export async function toInternalRequest(req: Request): Promise<RequestInternal | Error> {
+export async function toInternalRequest(req: Request): Promise<
+  | (RequestInternal & {
+      url: URL
+    })
+  | Error
+> {
   try {
     // TODO: url.toString() should not include action and providerId
     // see init.ts
@@ -70,7 +75,6 @@ export async function toInternalRequest(req: Request): Promise<RequestInternal |
     }
 
     return {
-      //@ts-ignore
       url,
       action,
       providerId,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: ?

### What are the changes and their implications?

- [x] add missing `host` property when initializing next-auth

## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
