### PR TITLE
fix: use correct bash syntax

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -32,7 +32,9 @@ jobs:
           head_sha="$(echo "$pr" | jq -r .head.sha)"
           updated_at="$(echo "$pr" | jq -r .updated_at)"
 
-          if [[ $(date -d $updated_at) > $(date -d $COMMENT_AT) ]]; exit 1; fi
+          if [[ $(date -d "$updated_at" +%s) -gt $(date -d "$COMMENT_AT" +%s) ]]; then
+              exit 1
+          fi
           
           echo "head_sha=$head_sha" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
This PR fixes the syntax to use the `then` keyword with bash in the SHA calculation.
