### PR TITLE
modify parseDefaultExportName so it does not grab an HOC, but the fir…

### DIFF
--- a/.changeset/little-boats-rest.md
+++ b/.changeset/little-boats-rest.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Improved parsing of default export names to handle higher-order components (HOCs) in the `parseDefaultExportName` function.

--- a/packages/blitz/src/cli/utils/routes-manifest.ts
+++ b/packages/blitz/src/cli/utils/routes-manifest.ts
@@ -504,12 +504,13 @@ const pascalCase = (value: string): string => {
   return val.substr(0, 1).toUpperCase() + val.substr(1)
 }
 export function parseDefaultExportName(contents: string): string | null {
-  const result = contents.match(/export\s+default(?:\s+(?:const|let|class|var|function))?\s+(\w+)/)
+  const result = contents.match(/export\s+default(?:\s+(const|let|class|var|function))?\s+(\w+)(?:\(([a-zA-Z_$][a-zA-Z0-9_$]*\b).*\))?/)
   if (!result) {
     return null
   }
-
-  return result[1] ?? null
+  const [,declaration,compOrHOCName,comp] = result
+  if(declaration||!comp) return compOrHOCName ?? null;
+  return comp ?? null
 }
 export async function generateManifest() {
   const config = await loadConfig(process.cwd())


### PR DESCRIPTION
…st Argument it takes. presumably the actual component

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: #4358 

### What are the changes and their implications?
- Updated `parseDefaultExportName` to improve parsing of default exports.
- The function now handles cases where the default export is a higher-order component (HOC).
- If a declaration like `export default function ...` exists, it returns the function name as before.
- If no declaration is found but a valid function name inside parentheses exists (e.g., `export default functionName1(functionName2)`), it returns `functionName2` instead, treating `functionName1` as a HOC.

## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
