### PR TITLE
chore: update prisma-ast version in blitz package

### DIFF
--- a/.changeset/lucky-bottles-breathe.md
+++ b/.changeset/lucky-bottles-breathe.md
@@ -1,5 +1,5 @@
 ---
-"@blitzjs/config": patch
+"blitz": patch
 ---
 
 Update prisma-ast dependency to prevent Blitz generator from failing when Prisma keywords are used as model names

--- a/.changeset/rare-geckos-fly.md
+++ b/.changeset/rare-geckos-fly.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/config": patch
+---
+
+Update prisma-ast dependency to prevent Blitz generator from failing when Prisma keywords are used as model names

--- a/packages/blitz/package.json
+++ b/packages/blitz/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@blitzjs/generator": "2.1.2",
-    "@mrleebo/prisma-ast": "0.2.6",
+    "@mrleebo/prisma-ast": "0.4.1",
     "@types/global-agent": "2.1.1",
     "arg": "5.0.1",
     "ast-types": "0.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1304,8 +1304,8 @@ importers:
         specifier: 2.1.2
         version: link:../generator
       "@mrleebo/prisma-ast":
-        specifier: 0.2.6
-        version: 0.2.6
+        specifier: 0.4.1
+        version: 0.4.1
       "@types/global-agent":
         specifier: 2.1.1
         version: 2.1.1
@@ -6047,16 +6047,6 @@ packages:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
-    dev: false
-
-  /@mrleebo/prisma-ast@0.2.6:
-    resolution:
-      {
-        integrity: sha512-Df0gAGmws3sxNMmLviTarBL9znf84QVlVhlx4EPgArrnaVBy8tNQZAI9aSTJHzH0JGj9BVGa0Qz1g3hPt12Kxw==,
-      }
-    engines: {node: ">=10"}
-    dependencies:
-      chevrotain: 9.1.0
     dev: false
 
   /@mrleebo/prisma-ast@0.4.1:


### PR DESCRIPTION
Follow-up to: https://github.com/blitz-js/blitz/pull/3882

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Choose & follow the right checklist for the change that you're making:

Please make sure to add a changeset. Run `pnpm changeset` in the root directory to do so.
Then select updated Blitz packages when prompted, and add a short message describing the changes. 
The message should be user-facing — explain **what** was changed, not **how**.
Ignore if there are no user-facing changes.
-->

Closes: https://github.com/blitz-js/blitz/issues/3190

### What are the changes and their implications?

Updated the version of `prisma-ast` used in `blitz` to align it with `@blitzjs/generator` in the hopes it'll stop the following error from happening:

```sh
Error generating get__ModelName__.ts
MismatchedTokenException: Expecting --> ')' <-- but found --> '0' <--
```

This version is severely outdated and the library should be bumped to the [latest (v0.12.0)](https://github.com/MrLeebo/prisma-ast/releases/tag/v0.12.0) at some point.

## Bug Checklist

- [x] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [ ] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
