### PR TITLE
Fix incorrect terminal message after installation

### DIFF
--- a/.changeset/few-kiwis-breathe.md
+++ b/.changeset/few-kiwis-breathe.md
@@ -1,0 +1,5 @@
+---
+"blitz": patch
+---
+
+Fixed incorrect terminal message after creating a new Blitz project to use the correct command (`npm run dev` or `yarn dev`).

--- a/packages/blitz/src/cli/commands/new.ts
+++ b/packages/blitz/src/cli/commands/new.ts
@@ -274,7 +274,7 @@ const newApp: CliCommand = async () => {
       )
     }
 
-    postInstallSteps.push(`${projectPkgManger} blitz dev`)
+    postInstallSteps.push(`${projectPkgManger} ${projectPkgManger === "npm" ? "run " : ""}dev`);
 
     console.log("\n Your new Blitz app is ready! Next steps:")
     postInstallSteps.forEach((step, index) => {


### PR DESCRIPTION
**Description**:
This PR resolves an issue in the terminal output after creating a new Blitz app. The post-installation steps currently suggest running:
`npm blitz dev`
This command does not work as expected.

**Fix**:
Updated the source code to ensure the correct command is displayed, based on the package manager used. For npm, the correct command is:
`npm run dev`
The updated logic now dynamically sets the command as follows:
`postInstallSteps.push(`${projectPkgManager} ${projectPkgManager === "npm" ? "run " : ""}dev`);`

**Impact**:
This fix improves the developer experience by providing accurate and actionable post-installation instructions.

Closes: #4401