### PR TITLE
Fix minimal app template

### DIFF
--- a/.changeset/blue-pumas-dress.md
+++ b/.changeset/blue-pumas-dress.md
@@ -1,0 +1,5 @@
+---
+"@blitzjs/generator": patch
+---
+
+Fixes Error: Cannot find module when running blitz new and selecting the minimal pages router option

--- a/packages/generator/templates/minimalapp/package.js.json
+++ b/packages/generator/templates/minimalapp/package.js.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@blitzjs/next": "latest",
     "blitz": "latest",
-    "next": "13.5.8",
+    "next": "15.0.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "ts-node": "10.9.1"

--- a/packages/generator/templates/minimalapp/package.js.json
+++ b/packages/generator/templates/minimalapp/package.js.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@blitzjs/next": "latest",
     "blitz": "latest",
-    "next": "13.4.5",
+    "next": "13.5.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "ts-node": "10.9.1"

--- a/packages/generator/templates/minimalapp/package.js.json
+++ b/packages/generator/templates/minimalapp/package.js.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@blitzjs/next": "latest",
     "blitz": "latest",
-    "next": "13.5.4",
+    "next": "13.5.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "ts-node": "10.9.1"

--- a/packages/generator/templates/minimalapp/package.ts.json
+++ b/packages/generator/templates/minimalapp/package.ts.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@blitzjs/next": "latest",
     "blitz": "latest",
-    "next": "13.5.8",
+    "next": "15.0.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "ts-node": "10.9.1"

--- a/packages/generator/templates/minimalapp/package.ts.json
+++ b/packages/generator/templates/minimalapp/package.ts.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@blitzjs/next": "latest",
     "blitz": "latest",
-    "next": "13.4.5",
+    "next": "13.5.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "ts-node": "10.9.1"

--- a/packages/generator/templates/minimalapp/package.ts.json
+++ b/packages/generator/templates/minimalapp/package.ts.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@blitzjs/next": "latest",
     "blitz": "latest",
-    "next": "13.5.4",
+    "next": "13.5.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "ts-node": "10.9.1"


### PR DESCRIPTION
Closes: #4236

### What are the changes and their implications?

Fixes https://github.com/blitz-js/blitz/issues/4236 for the minimal setup. The setup for the minimal app still depended on next 13.4.5 where 13.5 is the minimum. Although changes were made in https://github.com/blitz-js/blitz/pull/4237, these didn't get applied to the template for the minimum template, which causes that to actually still be broken.

## Bug Checklist

- [X] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)

## Feature Checklist

- [X] Changeset added (run `pnpm changeset` in the root directory)
- [ ] Integration test added (see [test docs](https://blitzjs.com/docs/contributing#running-tests) if needed)
- [ ] Documentation added/updated (submit PR to [blitzjs.com repo `main` branch](https://github.com/blitz-js/blitzjs.com))
